### PR TITLE
chore: add CLAUDE.md with engineering principles

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,87 @@
+# Engineering principles for willbuy.dev
+
+This file is read by every Claude Code agent working in this repo. Follow it.
+
+## The spec is authoritative
+
+The single source of truth is `.samo/spec/willbuy/SPEC.md`. Read the relevant section before you start. If reality forces a deviation from the spec, do **not** silently change behavior — record the deviation in `.samo/spec/willbuy/SPEC.willbuy.amendments.md` (create if missing, append-only, dated) and link it from the PR description.
+
+## Public repo discipline
+
+This repository is **public on github.com**. Treat every commit as published.
+
+- No secrets, tokens, API keys, hostnames-with-IPs, or VM-specific identifiers in any committed file. The `.gitignore` blocks `.env`, `*secrets*`, `*.key`, `*.pem` — explicit allow-list entries exist for the two safe template files. Do not add new bypasses.
+- Real values live in 1Password (vault `willbuy`); local materialization via `op inject -i .env.op -o .env`; server materialization via `op run --env-file=.env.op -- scripts/push-secrets.sh`.
+- IP addresses, server names with their public IPs, tunnel tokens, OAuth artifacts: never in git. If you need a host reference, look it up via `hcloud` API at runtime (see `scripts/push-secrets.sh` for the pattern).
+- Architectural notes about how local-CLI subprocesses provide LLM access can stay generic ("LLMProvider implementation X uses a subprocess to a local CLI"). Specifics about subscription auth, OAuth-on-VM, or anything that leaks a cost-side advantage stay out of the repo. If you need to document it, put it in 1Password as a Secure Note.
+
+## TDD: red → green → refactor
+
+For every code change that touches behavior:
+
+1. **Red:** write the failing test first. Commit it (or include in the PR with a clearly-failing-then-passing history). The test names what the change is supposed to do.
+2. **Green:** the simplest code that makes the test pass. Resist generalizing.
+3. **Refactor:** if the green code is ugly, refactor with the test as your safety net. Tests must stay green.
+
+PRs that introduce behavior without a test will be sent back. PRs that add a test that was always passing (no red commit, or no diff that makes the test pass) will also be sent back.
+
+## Coding rules
+
+- **TypeScript everywhere** except the aggregator (Python for the pinned scientific stack per spec §17). Strict mode on; `noUncheckedIndexedAccess` on; `exactOptionalPropertyTypes` on.
+- **zod schemas** for every external input (HTTP requests, LLM outputs, env vars). Parse at the boundary; pass typed data inward.
+- **No premature abstraction.** Three similar lines is fine. Don't introduce a generic helper for two callers. Don't introduce a plugin system for one impl.
+- **No comments unless WHY is non-obvious.** Don't write `// fetches the user`. Do write `// CF query-strip means we deliberately accept token in path here; see spec §5.12`.
+- **Don't add error handling for impossible cases.** If a caller is internal and a value is guaranteed non-null by upstream code, don't add `if (x == null) throw` defensively.
+- **Don't add features the issue didn't ask for.** Bug fixes don't need surrounding cleanup. One-shot operations don't need helpers. No backwards-compat shims when you can just change the caller.
+- **No `--no-sandbox` for Chromium.** Ever. There's a CI grep-lint enforcing this.
+- **No reserved identifiers at LLM adapter call sites or in adapter type definitions.** Spec §2 #15 lists them; an AST lint enforces. If your code grep-matches `conversation_id|session_id|thread_id|previous_response_id|cached_prompt_id|parent_message_id|run_id` near an LLM call, you'll fail CI — by design, to preserve the fresh-context guarantee.
+- **All LLM calls go through `LLMProvider` (chat) — only.** No direct subprocess to a CLI from worker code; no direct HTTP to a provider. The adapter is the seam where capability flags, idempotency keys, prompt-caching prefix isolation, and spend ledger writes happen. Bypassing the adapter breaks every guarantee in the spec at once.
+- **Embeddings are local in-process** via `fastembed` (`BAAI/bge-small-en-v1.5`). No external embedding provider, no API key, no adapter. Spec §17.
+
+## The PR contract
+
+Every PR you open must include:
+
+1. **Linked issue** in the body (`Closes #N`).
+2. **Test evidence**:
+   - Unit/integration test commits that demonstrate red → green.
+   - For UI/integration changes: a paste of the actual command + output that exercised the feature, with the relevant log lines or a screenshot description (alt text is fine).
+3. **Spec link**: which spec section your work satisfies (e.g. "Implements spec §2 #16 + §5.5").
+4. **Public-repo audit**: confirm no secrets, IPs, or secret-sauce leaks in the diff. Re-grep your commits before opening the PR.
+5. **CI green** before requesting review.
+
+## Review will be applied
+
+Every PR gets reviewed by the REV tool (`/review-mr <PR-URL>`) before merge — both blocking and non-blocking findings are surfaced. SOC2-flavored findings can be ignored on this repo (we are not SOC2-scoped at v0.1; this is an explicit exception). All other blocking findings must be addressed before merge.
+
+## Commit message convention
+
+```
+<area>: <imperative summary under 60 chars>
+
+<optional body explaining WHY, wrapping at 72 chars>
+<optional footer with refs>
+
+Closes #<issue-number>
+```
+
+Areas seen so far: `infra`, `spec`, `chore`. New areas appear naturally (`api`, `web`, `capture`, `visitor`, `aggregator`, `shared`, `llm-adapter`, `ci`).
+
+Co-Authored-By footer is welcome but not required.
+
+## Commands you'll use a lot
+
+```sh
+# load all secrets into local env once (saves fingerprint per run)
+OP_ACCOUNT=my.1password.com op inject -i .env.op -o .env
+
+# push refreshed secrets to the server
+op run --env-file=.env.op -- scripts/push-secrets.sh
+
+# look up the VM IP without hardcoding
+HCLOUD_TOKEN=$(grep ^HCLOUD_TOKEN .env | cut -d= -f2-) hcloud server describe willbuy-v01 -o json | jq -r .public_net.ipv4.ip
+```
+
+## When in doubt
+
+Read the spec. Then ask in the issue thread before you write code.


### PR DESCRIPTION
## Summary

Adds `CLAUDE.md` at the repo root. Read by every Claude Code agent (engineer or reviewer) that works in this repo.

Codifies the principles the manager (me) will hold every spawned engineer agent to:
- Spec at `.samo/spec/willbuy/SPEC.md` is authoritative; deviations land in `SPEC.willbuy.amendments.md`.
- Repo is public — no secrets / IPs / secret-sauce ever.
- TDD red → green → refactor for every behavior change.
- TS strict + zod at boundaries; no premature abstraction; no comments unless WHY.
- All LLM calls go through `LLMProvider` (chat) only. Embeddings local via `fastembed`.
- No `--no-sandbox` for Chromium; no reserved identifiers at LLM adapter call sites.
- Every PR has linked issue + TDD evidence + spec link + public-repo audit + CI green before review.
- REV reviews every PR; SOC2 findings ignored on this repo.

## Test plan

- [ ] CLAUDE.md exists at repo root and is readable
- [ ] Spawned engineer agents can pick it up (verified implicitly the first time an agent runs in the repo)