### PR TITLE
feat(shared): visitor schema + scoring weights + backstory types

### DIFF
--- a/.samo/spec/willbuy/SPEC.willbuy.amendments.md
+++ b/.samo/spec/willbuy/SPEC.willbuy.amendments.md
@@ -1,0 +1,49 @@
+# SPEC amendments — willbuy
+
+Append-only. Each entry is dated and links the PR + issue that drove it.
+
+---
+
+## 2026-04-24 — A1: `next_action` enum + conversion-weighted score align with growth scoring rubric
+
+**Affects:** §2 #15 (visitor output schema — `next_action` enum), §2 #18 (conversion-weighted aggregation weights), §2 #19 (paired statistics — McNemar binarization rule).
+
+**Driver:** Issue #4 (PR `feat/4-shared`). The growth team's `ab/pricing-page-2026apr/scoring.md` (postgres-ai/growth) is the authoritative pricing-page rubric for the willbuy.dev launch dogfood study (§3 user story #4) and the postgres.ai pricing experiment that funds it. The pricing page optimizes for **paid conversion**, not free-tier signups. The rubric in §2 #18 (`purchase`, `contact_sales`, `signup_free`, `bookmark`, `browse_more`, `leave`) was drafted ahead of that growth work and undercounts paid intent (it has no slot for `book_demo`, `start_paid_trial`, `ask_teammate`, or paid-tier-anchored bookmarking) and treats `signup_free` as inherently a partial win. The growth rubric splits paid vs free-with-paid-consideration and adds a tier-aware bump.
+
+**Amendment.** The `next_action` enum and conversion-weighted score adopt the growth rubric verbatim:
+
+`next_action` enum (8 values, replaces the 6-value list in §2 #15 and §2 #18):
+
+- `purchase_paid_today`
+- `contact_sales`
+- `book_demo`
+- `start_paid_trial`
+- `bookmark_compare_later`
+- `start_free_hobby`
+- `ask_teammate`
+- `leave`
+
+Conversion-weight base map (replaces §2 #18):
+
+| `next_action`              | Base weight |
+| -------------------------- | ----------- |
+| `purchase_paid_today`      | 1.0         |
+| `contact_sales`            | 0.8         |
+| `book_demo`                | 0.8         |
+| `start_paid_trial`         | 0.6         |
+| `bookmark_compare_later`   | 0.0 (bumped to 0.3 if `tier_picked_if_buying_today` ∈ paid) |
+| `start_free_hobby`         | 0.0 (bumped to 0.2 if `highest_tier_willing_to_consider` ∈ paid) |
+| `ask_teammate`             | 0.2         |
+| `leave`                    | 0.0         |
+
+`paid_tiers = {"express", "starter", "scale", "enterprise"}` (per growth rubric).
+
+`scoreVisit(parsed, tierToday?, considered?)` returns the bumped weight per the rules above; unknown actions return `0.0`.
+
+**McNemar binarization (§2 #19) follow-on.** Update the canonical v0.1 rule: `converted = 1 IFF next_action ∈ {purchase_paid_today, contact_sales, book_demo, start_paid_trial}`; otherwise `0`. (`bookmark_compare_later` and `start_free_hobby` remain `0` for the binary collapse even when their bump fires — the bump is an intent-strength gradient, not a conversion event.) The "paired score is a different quantity than the binary collapse" disclaimer in §2 #19 still applies.
+
+**What is NOT changed.** Per-field length caps (§2 #15: `first_impression` ≤ 400, list items ≤ 200, ≤ 10 items per list, `reasoning` ≤ 1200), `max_tokens=800`, schema-repair retry semantics (§2 #14), idempotency contract (§2 #15/#16), paired-stats disagreement rule (§2 #19) — all unchanged.
+
+**Backstory dimensions.** §2 #5 enumerates backstory fields generically (stage, team_size, stack, pain, entry point, budget authority); the growth repo's `personas/backstories.md` pins concrete value sets for the launch dogfood and the postgres.ai study. Issue #4 wires those concrete value sets into the zod schema. This is a refinement of §2 #5 within its existing shape, not a deviation; recorded here for traceability.
+
+**Tracking.** PR #N (set on merge). Future spec rev rolls this amendment back into §2 #15 / §2 #18 / §2 #19 inline.

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -3,16 +3,36 @@
   "version": "0.0.0",
   "private": true,
   "type": "module",
-  "description": "willbuy.dev shared types/utils — see SPEC §4.1",
+  "description": "Shared zod schemas + scoring weights for willbuy.dev (visitor output, backstory, scoreVisit).",
   "main": "./src/index.ts",
   "types": "./src/index.ts",
   "exports": {
-    ".": "./src/index.ts"
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    },
+    "./visitor": {
+      "types": "./src/visitor.ts",
+      "default": "./src/visitor.ts"
+    },
+    "./scoring": {
+      "types": "./src/scoring.ts",
+      "default": "./src/scoring.ts"
+    },
+    "./backstory": {
+      "types": "./src/backstory.ts",
+      "default": "./src/backstory.ts"
+    }
   },
   "scripts": {
+    "test": "vitest run",
     "typecheck": "tsc -p tsconfig.json --noEmit"
   },
+  "dependencies": {
+    "zod": "^3.23.0"
+  },
   "devDependencies": {
+    "vitest": "^2.1.8",
     "typescript": "^5.7.2"
   }
 }

--- a/packages/shared/src/backstory.ts
+++ b/packages/shared/src/backstory.ts
@@ -1,0 +1,26 @@
+import { z } from 'zod';
+
+// Spec §2 #5 + growth/ab/pricing-page-2026apr/personas/backstories.md.
+// First pass: minimum permissive shape so the valid-fixture test passes.
+// Enum tightening lands in the next red→green pair.
+
+export const Backstory = z
+  .object({
+    name: z.string().min(1).describe('Display name for the sampled persona.'),
+    role_archetype: z.unknown().describe('Spec §2 #5 (role archetype).'),
+    stage: z.unknown().describe('Spec §2 #5 (stage).'),
+    team_size: z.unknown().describe('Spec §2 #5 (team size).'),
+    managed_postgres: z.unknown().describe('Spec §2 #5 (stack).'),
+    current_pain: z.unknown().describe('Spec §2 #5 (pain).'),
+    entry_point: z.unknown().describe('Spec §2 #5 (entry point).'),
+    regulated: z
+      .unknown()
+      .describe('Refinement of spec §2 #5 from growth/personas/backstories.md.'),
+    postgres_depth: z
+      .unknown()
+      .describe('Refinement of spec §2 #5 from growth/personas/backstories.md.'),
+    budget_authority: z.unknown().describe('Spec §2 #5 (budget authority).'),
+  })
+  .passthrough();
+
+export type BackstoryT = z.infer<typeof Backstory>;

--- a/packages/shared/src/backstory.ts
+++ b/packages/shared/src/backstory.ts
@@ -1,26 +1,102 @@
 import { z } from 'zod';
 
-// Spec §2 #5 + growth/ab/pricing-page-2026apr/personas/backstories.md.
-// First pass: minimum permissive shape so the valid-fixture test passes.
-// Enum tightening lands in the next red→green pair.
+// Spec §2 #5 ("Custom-ICP authoring form (free-text description + structured
+// fields: stage, team size, stack, pain, entry point, budget authority)")
+// pinned to the concrete value sets from growth/ab/pricing-page-2026apr/
+// personas/backstories.md (the postgres.ai pricing rubric for the 2026-04
+// study). See SPEC.willbuy.amendments.md A1 for traceability.
+
+export const Stage = z.enum(['seed', 'seed+', 'series_a', 'series_b']);
+export type StageT = z.infer<typeof Stage>;
+
+export const TeamSize = z.union([
+  z.literal(2),
+  z.literal(6),
+  z.literal(12),
+  z.literal(20),
+]);
+export type TeamSizeT = z.infer<typeof TeamSize>;
+
+export const ManagedPostgres = z.enum([
+  'supabase',
+  'neon',
+  'rds',
+  'aurora',
+  'cloud_sql',
+]);
+export type ManagedPostgresT = z.infer<typeof ManagedPostgres>;
+
+export const CurrentPain = z.enum([
+  'recent_outage',
+  'slow_queries',
+  'bad_migration_fear',
+  'cost_creep',
+  'upcoming_scale_event',
+  'post_mortem_in_hand',
+]);
+export type CurrentPainT = z.infer<typeof CurrentPain>;
+
+export const EntryPoint = z.enum([
+  'hacker_news',
+  'newsletter',
+  'vc_referral',
+  'google_search',
+  'postgres_blog_footer',
+  'conference_booth_followup',
+]);
+export type EntryPointT = z.infer<typeof EntryPoint>;
+
+export const Regulated = z.enum(['no', 'lightly', 'yes']);
+export type RegulatedT = z.infer<typeof Regulated>;
+
+export const PostgresDepth = z.enum(['light', 'medium', 'deep']);
+export type PostgresDepthT = z.infer<typeof PostgresDepth>;
+
+export const BudgetAuthority = z.enum([
+  'self',
+  'needs_founder_signoff',
+  'needs_manager_signoff',
+  'needs_board_visibility',
+]);
+export type BudgetAuthorityT = z.infer<typeof BudgetAuthority>;
+
+export const RoleArchetype = z.enum(['founder_or_eng_lead', 'ic_engineer']);
+export type RoleArchetypeT = z.infer<typeof RoleArchetype>;
 
 export const Backstory = z
   .object({
-    name: z.string().min(1).describe('Display name for the sampled persona.'),
-    role_archetype: z.unknown().describe('Spec §2 #5 (role archetype).'),
-    stage: z.unknown().describe('Spec §2 #5 (stage).'),
-    team_size: z.unknown().describe('Spec §2 #5 (team size).'),
-    managed_postgres: z.unknown().describe('Spec §2 #5 (stack).'),
-    current_pain: z.unknown().describe('Spec §2 #5 (pain).'),
-    entry_point: z.unknown().describe('Spec §2 #5 (entry point).'),
-    regulated: z
-      .unknown()
-      .describe('Refinement of spec §2 #5 from growth/personas/backstories.md.'),
-    postgres_depth: z
-      .unknown()
-      .describe('Refinement of spec §2 #5 from growth/personas/backstories.md.'),
-    budget_authority: z.unknown().describe('Spec §2 #5 (budget authority).'),
+    name: z
+      .string()
+      .min(1)
+      .describe('Display name for the sampled persona (e.g. "Maya").'),
+    role_archetype: RoleArchetype.describe(
+      'Spec §2 #5 (custom-ICP role) — `founder_or_eng_lead` or `ic_engineer`.',
+    ),
+    stage: Stage.describe(
+      'Spec §2 #5 (stage); growth/personas/backstories.md value set.',
+    ),
+    team_size: TeamSize.describe(
+      'Spec §2 #5 (team size); growth/personas/backstories.md fixed quartiles.',
+    ),
+    managed_postgres: ManagedPostgres.describe(
+      'Spec §2 #5 (stack); growth/personas/backstories.md value set.',
+    ),
+    current_pain: CurrentPain.describe(
+      'Spec §2 #5 (pain); growth/personas/backstories.md value set.',
+    ),
+    entry_point: EntryPoint.describe(
+      'Spec §2 #5 (entry point); growth/personas/backstories.md value set.',
+    ),
+    regulated: Regulated.describe(
+      'Refinement of spec §2 #5 from growth/personas/backstories.md.',
+    ),
+    postgres_depth: PostgresDepth.describe(
+      'Refinement of spec §2 #5 from growth/personas/backstories.md.',
+    ),
+    budget_authority: BudgetAuthority.describe(
+      'Spec §2 #5 (budget authority); growth/personas/backstories.md value set.',
+    ),
   })
-  .passthrough();
+  .strict();
 
 export type BackstoryT = z.infer<typeof Backstory>;

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -1,4 +1,33 @@
-// Placeholder for shared types/utils across willbuy apps.
-// Real shape arrives with the schemas in subsequent issues; this stub
-// exists so apps/web can declare the workspace dep that SPEC §4.1 calls for.
-export const SHARED_PACKAGE_VERSION = '0.0.0' as const;
+export {
+  VisitorOutput,
+  type VisitorOutputT,
+} from './visitor.js';
+export {
+  NextAction,
+  type NextActionT,
+  NEXT_ACTION_WEIGHTS,
+  PAID_TIERS,
+  scoreVisit,
+} from './scoring.js';
+export {
+  Backstory,
+  type BackstoryT,
+  Stage,
+  type StageT,
+  TeamSize,
+  type TeamSizeT,
+  ManagedPostgres,
+  type ManagedPostgresT,
+  CurrentPain,
+  type CurrentPainT,
+  EntryPoint,
+  type EntryPointT,
+  Regulated,
+  type RegulatedT,
+  PostgresDepth,
+  type PostgresDepthT,
+  BudgetAuthority,
+  type BudgetAuthorityT,
+  RoleArchetype,
+  type RoleArchetypeT,
+} from './backstory.js';

--- a/packages/shared/src/scoring.ts
+++ b/packages/shared/src/scoring.ts
@@ -17,13 +17,31 @@ export const NextAction = z.enum([
 
 export type NextActionT = z.infer<typeof NextAction>;
 
-// Mirrors the weight map in
-// growth/ab/pricing-page-2026apr/scoring.md verbatim. Each red→green
-// pair below extends this map with one branch from the rubric.
-export function scoreVisit(parsed: VisitorOutputT): number {
+// Paid tiers per growth/ab/pricing-page-2026apr/scoring.md (the postgres.ai
+// pricing rubric for the 2026-04 study). bookmark_compare_later is bumped
+// to 0.3 when tier_picked_if_buying_today ∈ PAID_TIERS, and start_free_hobby
+// is bumped to 0.2 when highest_tier_willing_to_consider ∈ PAID_TIERS.
+export const PAID_TIERS: ReadonlySet<string> = new Set([
+  'express',
+  'starter',
+  'scale',
+  'enterprise',
+]);
+
+// Mirrors the weight map in growth/ab/pricing-page-2026apr/scoring.md
+// verbatim. Each red→green pair below extends this map with one branch
+// from the rubric.
+export function scoreVisit(
+  parsed: VisitorOutputT,
+  tierToday?: string,
+  _considered?: string,
+): number {
   if (parsed.next_action === 'purchase_paid_today') return 1.0;
   if (parsed.next_action === 'contact_sales') return 0.8;
   if (parsed.next_action === 'book_demo') return 0.8;
   if (parsed.next_action === 'start_paid_trial') return 0.6;
+  if (parsed.next_action === 'bookmark_compare_later') {
+    return tierToday !== undefined && PAID_TIERS.has(tierToday) ? 0.3 : 0.0;
+  }
   return 0.0;
 }

--- a/packages/shared/src/scoring.ts
+++ b/packages/shared/src/scoring.ts
@@ -28,24 +28,34 @@ export const PAID_TIERS: ReadonlySet<string> = new Set([
   'enterprise',
 ]);
 
-// Mirrors the weight map in growth/ab/pricing-page-2026apr/scoring.md
-// verbatim. Each red→green pair below extends this map with one branch
-// from the rubric.
+// Base weight map per growth/ab/pricing-page-2026apr/scoring.md. The
+// bookmark_compare_later and start_free_hobby rows are 0.0 here; their
+// bumps to 0.3 / 0.2 fire conditionally inside scoreVisit when the
+// corresponding paid-tier signal is present.
+export const NEXT_ACTION_WEIGHTS: Record<NextActionT, number> = {
+  purchase_paid_today: 1.0,
+  contact_sales: 0.8,
+  book_demo: 0.8,
+  start_paid_trial: 0.6,
+  bookmark_compare_later: 0.0,
+  start_free_hobby: 0.0,
+  ask_teammate: 0.2,
+  leave: 0.0,
+};
+
+// Mirrors the weight map + bump rules in
+// growth/ab/pricing-page-2026apr/scoring.md verbatim.
 export function scoreVisit(
   parsed: VisitorOutputT,
   tierToday?: string,
   considered?: string,
 ): number {
-  if (parsed.next_action === 'purchase_paid_today') return 1.0;
-  if (parsed.next_action === 'contact_sales') return 0.8;
-  if (parsed.next_action === 'book_demo') return 0.8;
-  if (parsed.next_action === 'start_paid_trial') return 0.6;
   if (parsed.next_action === 'bookmark_compare_later') {
     return tierToday !== undefined && PAID_TIERS.has(tierToday) ? 0.3 : 0.0;
   }
   if (parsed.next_action === 'start_free_hobby') {
     return considered !== undefined && PAID_TIERS.has(considered) ? 0.2 : 0.0;
   }
-  if (parsed.next_action === 'ask_teammate') return 0.2;
-  return 0.0;
+  const base = NEXT_ACTION_WEIGHTS[parsed.next_action as NextActionT];
+  return typeof base === 'number' ? base : 0.0;
 }

--- a/packages/shared/src/scoring.ts
+++ b/packages/shared/src/scoring.ts
@@ -46,5 +46,6 @@ export function scoreVisit(
   if (parsed.next_action === 'start_free_hobby') {
     return considered !== undefined && PAID_TIERS.has(considered) ? 0.2 : 0.0;
   }
+  if (parsed.next_action === 'ask_teammate') return 0.2;
   return 0.0;
 }

--- a/packages/shared/src/scoring.ts
+++ b/packages/shared/src/scoring.ts
@@ -34,7 +34,7 @@ export const PAID_TIERS: ReadonlySet<string> = new Set([
 export function scoreVisit(
   parsed: VisitorOutputT,
   tierToday?: string,
-  _considered?: string,
+  considered?: string,
 ): number {
   if (parsed.next_action === 'purchase_paid_today') return 1.0;
   if (parsed.next_action === 'contact_sales') return 0.8;
@@ -42,6 +42,9 @@ export function scoreVisit(
   if (parsed.next_action === 'start_paid_trial') return 0.6;
   if (parsed.next_action === 'bookmark_compare_later') {
     return tierToday !== undefined && PAID_TIERS.has(tierToday) ? 0.3 : 0.0;
+  }
+  if (parsed.next_action === 'start_free_hobby') {
+    return considered !== undefined && PAID_TIERS.has(considered) ? 0.2 : 0.0;
   }
   return 0.0;
 }

--- a/packages/shared/src/scoring.ts
+++ b/packages/shared/src/scoring.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+// Spec §2 #15 + amendment A1 (2026-04-24): next_action enum mirrors the
+// growth scoring rubric in ab/pricing-page-2026apr/scoring.md.
+export const NextAction = z.enum([
+  'purchase_paid_today',
+  'contact_sales',
+  'book_demo',
+  'start_paid_trial',
+  'bookmark_compare_later',
+  'start_free_hobby',
+  'ask_teammate',
+  'leave',
+]);
+
+export type NextActionT = z.infer<typeof NextAction>;

--- a/packages/shared/src/scoring.ts
+++ b/packages/shared/src/scoring.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import type { VisitorOutputT } from './visitor.js';
+
 // Spec §2 #15 + amendment A1 (2026-04-24): next_action enum mirrors the
 // growth scoring rubric in ab/pricing-page-2026apr/scoring.md.
 export const NextAction = z.enum([
@@ -14,3 +16,11 @@ export const NextAction = z.enum([
 ]);
 
 export type NextActionT = z.infer<typeof NextAction>;
+
+// Mirrors the weight map in
+// growth/ab/pricing-page-2026apr/scoring.md verbatim. Each red→green
+// pair below extends this map with one branch from the rubric.
+export function scoreVisit(parsed: VisitorOutputT): number {
+  if (parsed.next_action === 'purchase_paid_today') return 1.0;
+  return 0.0;
+}

--- a/packages/shared/src/scoring.ts
+++ b/packages/shared/src/scoring.ts
@@ -22,5 +22,7 @@ export type NextActionT = z.infer<typeof NextAction>;
 // pair below extends this map with one branch from the rubric.
 export function scoreVisit(parsed: VisitorOutputT): number {
   if (parsed.next_action === 'purchase_paid_today') return 1.0;
+  if (parsed.next_action === 'contact_sales') return 0.8;
+  if (parsed.next_action === 'book_demo') return 0.8;
   return 0.0;
 }

--- a/packages/shared/src/scoring.ts
+++ b/packages/shared/src/scoring.ts
@@ -24,5 +24,6 @@ export function scoreVisit(parsed: VisitorOutputT): number {
   if (parsed.next_action === 'purchase_paid_today') return 1.0;
   if (parsed.next_action === 'contact_sales') return 0.8;
   if (parsed.next_action === 'book_demo') return 0.8;
+  if (parsed.next_action === 'start_paid_trial') return 0.6;
   return 0.0;
 }

--- a/packages/shared/src/visitor.ts
+++ b/packages/shared/src/visitor.ts
@@ -2,14 +2,12 @@ import { z } from 'zod';
 
 import { NextAction } from './scoring.js';
 
-// Spec §2 #15 (visitor output schema). Length caps, integer ranges, enum
-// tightening, and array-shape enforcement land in subsequent red→green
-// pairs. This first pass requires every key to be present (per spec §2 #15
-// "all nine fields") with permissive value shapes.
-
-const anyValue = z.any().refine((v) => v !== undefined, {
-  message: 'field is required (spec §2 #15)',
-});
+// Spec §2 #15 (visitor output schema). All nine fields are required;
+// per-field caps are documented in zod messages and cross-referenced
+// to the spec section. The validator-side rejection of any over-cap
+// or out-of-range value drives the schema-repair retry contract in
+// spec §2 #14 — repairs are fresh-context calls, never amendments to
+// a prior assistant turn.
 
 // Spec §2 #15 caps first_impression at 400 chars; rejecting longer
 // strings is what triggers the schema-repair retry path (§2 #14).
@@ -53,8 +51,13 @@ export const VisitorOutput = z
     next_action: NextAction.describe(
       'Spec §2 #15 + amendment A1 (2026-04-24): next_action enum aligned with growth scoring rubric.',
     ),
-    confidence: anyValue.describe('Spec §2 #15: confidence.'),
-    reasoning: anyValue.describe('Spec §2 #15: reasoning.'),
+    confidence: score0to10.describe(
+      'Spec §2 #15: confidence integer 0–10.',
+    ),
+    reasoning: z
+      .string()
+      .max(1200, 'reasoning capped at 1200 chars (spec §2 #15)')
+      .describe('Spec §2 #15: reasoning, ≤ 1200 chars.'),
   })
   .passthrough();
 

--- a/packages/shared/src/visitor.ts
+++ b/packages/shared/src/visitor.ts
@@ -20,6 +20,16 @@ const firstImpression = z
 // Spec §2 #15: will_to_buy and confidence are integers 0–10.
 const score0to10 = z.number().int().min(0).max(10);
 
+// Spec §2 #15: questions/confusions/objections/unanswered_blockers are
+// each ≤ 10 strings × ≤ 200 chars per string.
+const shortStringList = z
+  .array(
+    z
+      .string()
+      .max(200, 'list items capped at 200 chars (spec §2 #15)'),
+  )
+  .max(10, 'list capped at 10 items (spec §2 #15)');
+
 export const VisitorOutput = z
   .object({
     first_impression: firstImpression.describe(
@@ -28,11 +38,17 @@ export const VisitorOutput = z
     will_to_buy: score0to10.describe(
       'Spec §2 #15: will_to_buy integer 0–10.',
     ),
-    questions: anyValue.describe('Spec §2 #15: questions[].'),
-    confusions: anyValue.describe('Spec §2 #15: confusions[].'),
-    objections: anyValue.describe('Spec §2 #15: objections[].'),
-    unanswered_blockers: anyValue.describe(
-      'Spec §2 #15: unanswered_blockers[].',
+    questions: shortStringList.describe(
+      'Spec §2 #15: questions[], ≤ 10 items × ≤ 200 chars each.',
+    ),
+    confusions: shortStringList.describe(
+      'Spec §2 #15: confusions[], ≤ 10 items × ≤ 200 chars each.',
+    ),
+    objections: shortStringList.describe(
+      'Spec §2 #15: objections[], ≤ 10 items × ≤ 200 chars each.',
+    ),
+    unanswered_blockers: shortStringList.describe(
+      'Spec §2 #15: unanswered_blockers[], ≤ 10 items × ≤ 200 chars each.',
     ),
     next_action: NextAction.describe(
       'Spec §2 #15 + amendment A1 (2026-04-24): next_action enum aligned with growth scoring rubric.',

--- a/packages/shared/src/visitor.ts
+++ b/packages/shared/src/visitor.ts
@@ -1,29 +1,30 @@
 import { z } from 'zod';
 
-// Spec §2 #15 (visitor output schema). Per-field length caps, integer
-// ranges, enum tightening, array-shape enforcement, and required-field
-// rules land in subsequent red→green pairs. This first commit is the
-// minimum permissive shape that makes the valid-fixture test pass.
+// Spec §2 #15 (visitor output schema). Length caps, integer ranges, enum
+// tightening, and array-shape enforcement land in subsequent red→green
+// pairs. This first pass requires every key to be present (per spec §2 #15
+// "all nine fields") with permissive value shapes.
+
+const anyValue = z.any().refine((v) => v !== undefined, {
+  message: 'field is required (spec §2 #15)',
+});
 
 export const VisitorOutput = z
   .object({
-    first_impression: z.unknown().describe('Spec §2 #15: first_impression.'),
-    will_to_buy: z.unknown().describe('Spec §2 #15: will_to_buy.'),
-    questions: z.unknown().describe('Spec §2 #15: questions[].'),
-    confusions: z.unknown().describe('Spec §2 #15: confusions[].'),
-    objections: z.unknown().describe('Spec §2 #15: objections[].'),
-    unanswered_blockers: z
-      .unknown()
-      .describe('Spec §2 #15: unanswered_blockers[].'),
-    next_action: z
-      .unknown()
-      .describe(
-        'Spec §2 #15 + amendment A1 (2026-04-24): next_action enum (tightened in a later commit).',
-      ),
-    confidence: z.unknown().describe('Spec §2 #15: confidence.'),
-    reasoning: z.unknown().describe('Spec §2 #15: reasoning.'),
+    first_impression: anyValue.describe('Spec §2 #15: first_impression.'),
+    will_to_buy: anyValue.describe('Spec §2 #15: will_to_buy.'),
+    questions: anyValue.describe('Spec §2 #15: questions[].'),
+    confusions: anyValue.describe('Spec §2 #15: confusions[].'),
+    objections: anyValue.describe('Spec §2 #15: objections[].'),
+    unanswered_blockers: anyValue.describe(
+      'Spec §2 #15: unanswered_blockers[].',
+    ),
+    next_action: anyValue.describe(
+      'Spec §2 #15 + amendment A1 (2026-04-24): next_action enum (tightened in a later commit).',
+    ),
+    confidence: anyValue.describe('Spec §2 #15: confidence.'),
+    reasoning: anyValue.describe('Spec §2 #15: reasoning.'),
   })
-  .partial()
   .passthrough();
 
 export type VisitorOutputT = z.infer<typeof VisitorOutput>;

--- a/packages/shared/src/visitor.ts
+++ b/packages/shared/src/visitor.ts
@@ -9,9 +9,17 @@ const anyValue = z.any().refine((v) => v !== undefined, {
   message: 'field is required (spec §2 #15)',
 });
 
+// Spec §2 #15 caps first_impression at 400 chars; rejecting longer
+// strings is what triggers the schema-repair retry path (§2 #14).
+const firstImpression = z
+  .string()
+  .max(400, 'first_impression capped at 400 chars (spec §2 #15)');
+
 export const VisitorOutput = z
   .object({
-    first_impression: anyValue.describe('Spec §2 #15: first_impression.'),
+    first_impression: firstImpression.describe(
+      'Spec §2 #15: first_impression, ≤ 400 chars.',
+    ),
     will_to_buy: anyValue.describe('Spec §2 #15: will_to_buy.'),
     questions: anyValue.describe('Spec §2 #15: questions[].'),
     confusions: anyValue.describe('Spec §2 #15: confusions[].'),

--- a/packages/shared/src/visitor.ts
+++ b/packages/shared/src/visitor.ts
@@ -1,0 +1,29 @@
+import { z } from 'zod';
+
+// Spec §2 #15 (visitor output schema). Per-field length caps, integer
+// ranges, enum tightening, array-shape enforcement, and required-field
+// rules land in subsequent red→green pairs. This first commit is the
+// minimum permissive shape that makes the valid-fixture test pass.
+
+export const VisitorOutput = z
+  .object({
+    first_impression: z.unknown().describe('Spec §2 #15: first_impression.'),
+    will_to_buy: z.unknown().describe('Spec §2 #15: will_to_buy.'),
+    questions: z.unknown().describe('Spec §2 #15: questions[].'),
+    confusions: z.unknown().describe('Spec §2 #15: confusions[].'),
+    objections: z.unknown().describe('Spec §2 #15: objections[].'),
+    unanswered_blockers: z
+      .unknown()
+      .describe('Spec §2 #15: unanswered_blockers[].'),
+    next_action: z
+      .unknown()
+      .describe(
+        'Spec §2 #15 + amendment A1 (2026-04-24): next_action enum (tightened in a later commit).',
+      ),
+    confidence: z.unknown().describe('Spec §2 #15: confidence.'),
+    reasoning: z.unknown().describe('Spec §2 #15: reasoning.'),
+  })
+  .partial()
+  .passthrough();
+
+export type VisitorOutputT = z.infer<typeof VisitorOutput>;

--- a/packages/shared/src/visitor.ts
+++ b/packages/shared/src/visitor.ts
@@ -1,5 +1,7 @@
 import { z } from 'zod';
 
+import { NextAction } from './scoring.js';
+
 // Spec §2 #15 (visitor output schema). Length caps, integer ranges, enum
 // tightening, and array-shape enforcement land in subsequent red→green
 // pairs. This first pass requires every key to be present (per spec §2 #15
@@ -32,8 +34,8 @@ export const VisitorOutput = z
     unanswered_blockers: anyValue.describe(
       'Spec §2 #15: unanswered_blockers[].',
     ),
-    next_action: anyValue.describe(
-      'Spec §2 #15 + amendment A1 (2026-04-24): next_action enum (tightened in a later commit).',
+    next_action: NextAction.describe(
+      'Spec §2 #15 + amendment A1 (2026-04-24): next_action enum aligned with growth scoring rubric.',
     ),
     confidence: anyValue.describe('Spec §2 #15: confidence.'),
     reasoning: anyValue.describe('Spec §2 #15: reasoning.'),

--- a/packages/shared/src/visitor.ts
+++ b/packages/shared/src/visitor.ts
@@ -15,12 +15,17 @@ const firstImpression = z
   .string()
   .max(400, 'first_impression capped at 400 chars (spec §2 #15)');
 
+// Spec §2 #15: will_to_buy and confidence are integers 0–10.
+const score0to10 = z.number().int().min(0).max(10);
+
 export const VisitorOutput = z
   .object({
     first_impression: firstImpression.describe(
       'Spec §2 #15: first_impression, ≤ 400 chars.',
     ),
-    will_to_buy: anyValue.describe('Spec §2 #15: will_to_buy.'),
+    will_to_buy: score0to10.describe(
+      'Spec §2 #15: will_to_buy integer 0–10.',
+    ),
     questions: anyValue.describe('Spec §2 #15: questions[].'),
     confusions: anyValue.describe('Spec §2 #15: confusions[].'),
     objections: anyValue.describe('Spec §2 #15: objections[].'),

--- a/packages/shared/test/backstory.test.ts
+++ b/packages/shared/test/backstory.test.ts
@@ -14,4 +14,9 @@ describe('Backstory (spec §2 #5 + personas/backstories.md)', () => {
     const parsed = Backstory.parse(validFixture);
     expect(parsed.name).toBe('Maya');
   });
+
+  it('rejects a backstory with a bad enum value', () => {
+    const bad = { ...validFixture, managed_postgres: 'mongodb' };
+    expect(() => Backstory.parse(bad)).toThrow();
+  });
 });

--- a/packages/shared/test/backstory.test.ts
+++ b/packages/shared/test/backstory.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { Backstory } from '../src/backstory.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const validFixture = JSON.parse(
+  readFileSync(resolve(here, 'fixtures/valid-backstory.json'), 'utf8'),
+);
+
+describe('Backstory (spec §2 #5 + personas/backstories.md)', () => {
+  it('parses a known-valid fixture', () => {
+    const parsed = Backstory.parse(validFixture);
+    expect(parsed.name).toBe('Maya');
+  });
+});

--- a/packages/shared/test/fixtures/valid-backstory.json
+++ b/packages/shared/test/fixtures/valid-backstory.json
@@ -1,0 +1,12 @@
+{
+  "name": "Maya",
+  "role_archetype": "founder_or_eng_lead",
+  "stage": "series_a",
+  "team_size": 12,
+  "managed_postgres": "supabase",
+  "current_pain": "upcoming_scale_event",
+  "entry_point": "newsletter",
+  "regulated": "no",
+  "postgres_depth": "light",
+  "budget_authority": "self"
+}

--- a/packages/shared/test/fixtures/valid-visitor.json
+++ b/packages/shared/test/fixtures/valid-visitor.json
@@ -1,0 +1,20 @@
+{
+  "first_impression": "The pricing page leads with a managed Postgres pitch. Tiers are clear; the difference between Starter and Scale is mostly storage and connection limits.",
+  "will_to_buy": 7,
+  "questions": [
+    "Is there a self-hosted option, or only managed?",
+    "How is data residency handled in EU?"
+  ],
+  "confusions": [
+    "I cannot tell from the page whether 'connections' means client connections or pooled connections."
+  ],
+  "objections": [
+    "$99/mo feels steep for a 2-engineer team that already runs RDS."
+  ],
+  "unanswered_blockers": [
+    "No mention of SOC2 or HIPAA — blocker for our fintech use case."
+  ],
+  "next_action": "contact_sales",
+  "confidence": 8,
+  "reasoning": "Strong pricing-page clarity but missing compliance signals; for a regulated fintech buyer the next step is a sales conversation to confirm SOC2 status and EU data residency before a paid trial."
+}

--- a/packages/shared/test/index.test.ts
+++ b/packages/shared/test/index.test.ts
@@ -1,0 +1,13 @@
+import { describe, expect, it } from 'vitest';
+import * as shared from '../src/index.js';
+
+describe('@willbuy/shared barrel export', () => {
+  it('exports VisitorOutput, Backstory, NextAction, NEXT_ACTION_WEIGHTS, PAID_TIERS, scoreVisit', () => {
+    expect(shared.VisitorOutput).toBeDefined();
+    expect(shared.Backstory).toBeDefined();
+    expect(shared.NextAction).toBeDefined();
+    expect(shared.NEXT_ACTION_WEIGHTS).toBeDefined();
+    expect(shared.PAID_TIERS).toBeDefined();
+    expect(shared.scoreVisit).toBeDefined();
+  });
+});

--- a/packages/shared/test/scoring.test.ts
+++ b/packages/shared/test/scoring.test.ts
@@ -34,4 +34,15 @@ describe('scoreVisit (growth/ab/pricing-page-2026apr/scoring.md mirror)', () => 
   it('returns 0.6 for start_paid_trial', () => {
     expect(scoreVisit(visitWith('start_paid_trial'))).toBe(0.6);
   });
+
+  it('returns 0.3 for bookmark_compare_later when tier_picked is paid', () => {
+    expect(scoreVisit(visitWith('bookmark_compare_later'), 'starter')).toBe(
+      0.3,
+    );
+  });
+
+  it('returns 0.0 for bookmark_compare_later when tier_picked is not paid', () => {
+    expect(scoreVisit(visitWith('bookmark_compare_later'), 'hobby')).toBe(0.0);
+    expect(scoreVisit(visitWith('bookmark_compare_later'))).toBe(0.0);
+  });
 });

--- a/packages/shared/test/scoring.test.ts
+++ b/packages/shared/test/scoring.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest';
+import { scoreVisit } from '../src/scoring.js';
+import type { VisitorOutputT } from '../src/visitor.js';
+
+const baseVisit: VisitorOutputT = {
+  first_impression: 'fine',
+  will_to_buy: 5,
+  questions: [],
+  confusions: [],
+  objections: [],
+  unanswered_blockers: [],
+  next_action: 'leave',
+  confidence: 5,
+  reasoning: 'placeholder',
+};
+
+const visitWith = (
+  next_action: VisitorOutputT['next_action'],
+): VisitorOutputT => ({ ...baseVisit, next_action });
+
+describe('scoreVisit (growth/ab/pricing-page-2026apr/scoring.md mirror)', () => {
+  it('returns 1.0 for purchase_paid_today regardless of tier args', () => {
+    expect(scoreVisit(visitWith('purchase_paid_today'))).toBe(1.0);
+  });
+});

--- a/packages/shared/test/scoring.test.ts
+++ b/packages/shared/test/scoring.test.ts
@@ -58,4 +58,8 @@ describe('scoreVisit (growth/ab/pricing-page-2026apr/scoring.md mirror)', () => 
     ).toBe(0.0);
     expect(scoreVisit(visitWith('start_free_hobby'))).toBe(0.0);
   });
+
+  it('returns 0.2 for ask_teammate', () => {
+    expect(scoreVisit(visitWith('ask_teammate'))).toBe(0.2);
+  });
 });

--- a/packages/shared/test/scoring.test.ts
+++ b/packages/shared/test/scoring.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { scoreVisit } from '../src/scoring.js';
+import { NEXT_ACTION_WEIGHTS, scoreVisit } from '../src/scoring.js';
 import type { VisitorOutputT } from '../src/visitor.js';
 
 const baseVisit: VisitorOutputT = {
@@ -61,5 +61,30 @@ describe('scoreVisit (growth/ab/pricing-page-2026apr/scoring.md mirror)', () => 
 
   it('returns 0.2 for ask_teammate', () => {
     expect(scoreVisit(visitWith('ask_teammate'))).toBe(0.2);
+  });
+
+  it('returns 0.0 for leave', () => {
+    expect(scoreVisit(visitWith('leave'))).toBe(0.0);
+  });
+
+  it('exposes NEXT_ACTION_WEIGHTS mirroring the growth scoring rubric', () => {
+    expect(NEXT_ACTION_WEIGHTS.purchase_paid_today).toBe(1.0);
+    expect(NEXT_ACTION_WEIGHTS.contact_sales).toBe(0.8);
+    expect(NEXT_ACTION_WEIGHTS.book_demo).toBe(0.8);
+    expect(NEXT_ACTION_WEIGHTS.start_paid_trial).toBe(0.6);
+    // bookmark_compare_later and start_free_hobby base = 0.0; bumps live in
+    // scoreVisit per growth/scoring.md.
+    expect(NEXT_ACTION_WEIGHTS.bookmark_compare_later).toBe(0.0);
+    expect(NEXT_ACTION_WEIGHTS.start_free_hobby).toBe(0.0);
+    expect(NEXT_ACTION_WEIGHTS.ask_teammate).toBe(0.2);
+    expect(NEXT_ACTION_WEIGHTS.leave).toBe(0.0);
+  });
+
+  it('returns 0.0 defensively for an unknown next_action', () => {
+    const malformed = {
+      ...baseVisit,
+      next_action: 'not_in_enum',
+    } as unknown as VisitorOutputT;
+    expect(scoreVisit(malformed)).toBe(0.0);
   });
 });

--- a/packages/shared/test/scoring.test.ts
+++ b/packages/shared/test/scoring.test.ts
@@ -45,4 +45,17 @@ describe('scoreVisit (growth/ab/pricing-page-2026apr/scoring.md mirror)', () => 
     expect(scoreVisit(visitWith('bookmark_compare_later'), 'hobby')).toBe(0.0);
     expect(scoreVisit(visitWith('bookmark_compare_later'))).toBe(0.0);
   });
+
+  it('returns 0.2 for start_free_hobby when considered tier is paid', () => {
+    expect(
+      scoreVisit(visitWith('start_free_hobby'), undefined, 'express'),
+    ).toBe(0.2);
+  });
+
+  it('returns 0.0 for start_free_hobby when considered tier is not paid', () => {
+    expect(
+      scoreVisit(visitWith('start_free_hobby'), undefined, 'hobby'),
+    ).toBe(0.0);
+    expect(scoreVisit(visitWith('start_free_hobby'))).toBe(0.0);
+  });
 });

--- a/packages/shared/test/scoring.test.ts
+++ b/packages/shared/test/scoring.test.ts
@@ -30,4 +30,8 @@ describe('scoreVisit (growth/ab/pricing-page-2026apr/scoring.md mirror)', () => 
   it('returns 0.8 for book_demo', () => {
     expect(scoreVisit(visitWith('book_demo'))).toBe(0.8);
   });
+
+  it('returns 0.6 for start_paid_trial', () => {
+    expect(scoreVisit(visitWith('start_paid_trial'))).toBe(0.6);
+  });
 });

--- a/packages/shared/test/scoring.test.ts
+++ b/packages/shared/test/scoring.test.ts
@@ -22,4 +22,12 @@ describe('scoreVisit (growth/ab/pricing-page-2026apr/scoring.md mirror)', () => 
   it('returns 1.0 for purchase_paid_today regardless of tier args', () => {
     expect(scoreVisit(visitWith('purchase_paid_today'))).toBe(1.0);
   });
+
+  it('returns 0.8 for contact_sales', () => {
+    expect(scoreVisit(visitWith('contact_sales'))).toBe(0.8);
+  });
+
+  it('returns 0.8 for book_demo', () => {
+    expect(scoreVisit(visitWith('book_demo'))).toBe(0.8);
+  });
 });

--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -14,4 +14,9 @@ describe('VisitorOutput (spec §2 #15)', () => {
     const parsed = VisitorOutput.parse(validFixture);
     expect(parsed.next_action).toBe('contact_sales');
   });
+
+  it('rejects when a required field is missing', () => {
+    const { reasoning: _omit, ...withoutReasoning } = validFixture;
+    expect(() => VisitorOutput.parse(withoutReasoning)).toThrow();
+  });
 });

--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -37,4 +37,12 @@ describe('VisitorOutput (spec §2 #15)', () => {
     const wrongEnum = { ...validFixture, next_action: 'signup_free' };
     expect(() => VisitorOutput.parse(wrongEnum)).toThrow();
   });
+
+  it('rejects a non-array array (questions must be string[])', () => {
+    const notAnArray = {
+      ...validFixture,
+      questions: 'one big string instead of array',
+    };
+    expect(() => VisitorOutput.parse(notAnArray)).toThrow();
+  });
 });

--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -16,7 +16,8 @@ describe('VisitorOutput (spec §2 #15)', () => {
   });
 
   it('rejects when a required field is missing', () => {
-    const { reasoning: _omit, ...withoutReasoning } = validFixture;
+    const withoutReasoning: Record<string, unknown> = { ...validFixture };
+    delete withoutReasoning['reasoning'];
     expect(() => VisitorOutput.parse(withoutReasoning)).toThrow();
   });
 

--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -27,4 +27,9 @@ describe('VisitorOutput (spec §2 #15)', () => {
     };
     expect(() => VisitorOutput.parse(oversized)).toThrow();
   });
+
+  it('rejects an out-of-range integer (will_to_buy must be 0–10 per §2 #15)', () => {
+    const outOfRange = { ...validFixture, will_to_buy: 11 };
+    expect(() => VisitorOutput.parse(outOfRange)).toThrow();
+  });
 });

--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -1,0 +1,17 @@
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+import { describe, expect, it } from 'vitest';
+import { VisitorOutput } from '../src/visitor.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const validFixture = JSON.parse(
+  readFileSync(resolve(here, 'fixtures/valid-visitor.json'), 'utf8'),
+);
+
+describe('VisitorOutput (spec §2 #15)', () => {
+  it('parses a known-valid fixture', () => {
+    const parsed = VisitorOutput.parse(validFixture);
+    expect(parsed.next_action).toBe('contact_sales');
+  });
+});

--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -32,4 +32,9 @@ describe('VisitorOutput (spec §2 #15)', () => {
     const outOfRange = { ...validFixture, will_to_buy: 11 };
     expect(() => VisitorOutput.parse(outOfRange)).toThrow();
   });
+
+  it('rejects a wrong enum value for next_action', () => {
+    const wrongEnum = { ...validFixture, next_action: 'signup_free' };
+    expect(() => VisitorOutput.parse(wrongEnum)).toThrow();
+  });
 });

--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -19,4 +19,12 @@ describe('VisitorOutput (spec §2 #15)', () => {
     const { reasoning: _omit, ...withoutReasoning } = validFixture;
     expect(() => VisitorOutput.parse(withoutReasoning)).toThrow();
   });
+
+  it('rejects an oversized field (first_impression > 400 chars per §2 #15)', () => {
+    const oversized = {
+      ...validFixture,
+      first_impression: 'x'.repeat(401),
+    };
+    expect(() => VisitorOutput.parse(oversized)).toThrow();
+  });
 });

--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -45,4 +45,14 @@ describe('VisitorOutput (spec §2 #15)', () => {
     };
     expect(() => VisitorOutput.parse(notAnArray)).toThrow();
   });
+
+  it('rejects out-of-range confidence (must be 0–10 per §2 #15)', () => {
+    const bad = { ...validFixture, confidence: -1 };
+    expect(() => VisitorOutput.parse(bad)).toThrow();
+  });
+
+  it('rejects oversized reasoning (> 1200 chars per §2 #15)', () => {
+    const bad = { ...validFixture, reasoning: 'r'.repeat(1201) };
+    expect(() => VisitorOutput.parse(bad)).toThrow();
+  });
 });

--- a/packages/shared/tsconfig.json
+++ b/packages/shared/tsconfig.json
@@ -1,10 +1,10 @@
 {
   "extends": "../../tsconfig.base.json",
   "compilerOptions": {
-    "rootDir": "src",
+    "composite": true,
     "outDir": "dist",
-    "noEmit": false,
-    "composite": false
+    "rootDir": ".",
+    "types": ["node"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "test/**/*", "vitest.config.ts"]
 }

--- a/packages/shared/vitest.config.ts
+++ b/packages/shared/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 10_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -105,10 +105,17 @@ importers:
         version: 2.1.9(@types/node@22.19.17)
 
   packages/shared:
+    dependencies:
+      zod:
+        specifier: ^3.23.0
+        version: 3.25.76
     devDependencies:
       typescript:
         specifier: ^5.7.2
         version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.17)
 
 packages:
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,5 @@
   },
   "include": ["tests/**/*", "scripts/**/*", "*.config.ts", "*.config.mjs"],
   "exclude": ["node_modules", "dist", "build", ".next", "coverage", "tests/lint-fixtures"],
-  "references": [{ "path": "./apps/api" }]
+  "references": [{ "path": "./apps/api" }, { "path": "./packages/shared" }]
 }


### PR DESCRIPTION
Closes #4

## Summary

- `packages/shared` (`@willbuy/shared`) now exposes `VisitorOutput`, `Backstory`, `NextAction`, `NEXT_ACTION_WEIGHTS`, `PAID_TIERS`, and `scoreVisit` as the single zod-validated source of truth — every other package can import them per the issue's stated outcome.
- `scoreVisit` and `NEXT_ACTION_WEIGHTS` mirror the growth team's `ab/pricing-page-2026apr/scoring.md` rubric verbatim (1.0 / 0.8 / 0.6 / 0.3 / 0.2 / 0.0 with the bookmark-and-paid-tier and start_free_hobby-and-paid-tier bumps); `Backstory` mirrors `personas/backstories.md` dimension by dimension. Every zod field carries a `.describe()` cross-referencing the spec section.
- The growth rubric uses 8 next_action values (paid-conversion-aligned), which extends the 6-value list in spec §2 #15/#18/#19. SPEC amendment **A1 (2026-04-24)** records the deviation per CLAUDE.md "spec is authoritative" rule. McNemar binarization (§2 #19) is updated accordingly: `converted = 1 IFF next_action ∈ {purchase_paid_today, contact_sales, book_demo, start_paid_trial}`.

## Spec link

Implements spec **§2 #15** (visitor output schema) + **§2 #5** (backstory dimensions) + **§5.6 / §2 #18** (conversion-weighted next-action score), as amended by `.samo/spec/willbuy/SPEC.willbuy.amendments.md` **A1 (2026-04-24)**.

## Test evidence — red→green for every acceptance branch

\`pnpm --filter @willbuy/shared test --reporter=verbose\` output (current HEAD):

\`\`\`
 ✓ test/visitor.test.ts > VisitorOutput (spec §2 #15) > parses a known-valid fixture
 ✓ test/visitor.test.ts > VisitorOutput (spec §2 #15) > rejects when a required field is missing
 ✓ test/visitor.test.ts > VisitorOutput (spec §2 #15) > rejects an oversized field (first_impression > 400 chars per §2 #15)
 ✓ test/visitor.test.ts > VisitorOutput (spec §2 #15) > rejects an out-of-range integer (will_to_buy must be 0–10 per §2 #15)
 ✓ test/visitor.test.ts > VisitorOutput (spec §2 #15) > rejects a wrong enum value for next_action
 ✓ test/visitor.test.ts > VisitorOutput (spec §2 #15) > rejects a non-array array (questions must be string[])
 ✓ test/visitor.test.ts > VisitorOutput (spec §2 #15) > rejects out-of-range confidence (must be 0–10 per §2 #15)
 ✓ test/visitor.test.ts > VisitorOutput (spec §2 #15) > rejects oversized reasoning (> 1200 chars per §2 #15)
 ✓ test/backstory.test.ts > Backstory (spec §2 #5 + personas/backstories.md) > parses a known-valid fixture
 ✓ test/backstory.test.ts > Backstory (spec §2 #5 + personas/backstories.md) > rejects a backstory with a bad enum value
 ✓ test/scoring.test.ts > scoreVisit … > returns 1.0 for purchase_paid_today regardless of tier args
 ✓ test/scoring.test.ts > scoreVisit … > returns 0.8 for contact_sales
 ✓ test/scoring.test.ts > scoreVisit … > returns 0.8 for book_demo
 ✓ test/scoring.test.ts > scoreVisit … > returns 0.6 for start_paid_trial
 ✓ test/scoring.test.ts > scoreVisit … > returns 0.3 for bookmark_compare_later when tier_picked is paid
 ✓ test/scoring.test.ts > scoreVisit … > returns 0.0 for bookmark_compare_later when tier_picked is not paid
 ✓ test/scoring.test.ts > scoreVisit … > returns 0.2 for start_free_hobby when considered tier is paid
 ✓ test/scoring.test.ts > scoreVisit … > returns 0.0 for start_free_hobby when considered tier is not paid
 ✓ test/scoring.test.ts > scoreVisit … > returns 0.2 for ask_teammate
 ✓ test/scoring.test.ts > scoreVisit … > returns 0.0 for leave
 ✓ test/scoring.test.ts > scoreVisit … > exposes NEXT_ACTION_WEIGHTS mirroring the growth scoring rubric
 ✓ test/scoring.test.ts > scoreVisit … > returns 0.0 defensively for an unknown next_action
 ✓ test/index.test.ts > @willbuy/shared barrel export > exports VisitorOutput, Backstory, NextAction, NEXT_ACTION_WEIGHTS, PAID_TIERS, scoreVisit

 Test Files  4 passed (4)
      Tests  23 passed (23)
\`\`\`

Each acceptance branch from the issue is its own red→green commit pair. Reviewer can verify chronologically:

| # | Branch | Red | Green |
|---|---|---|---|
| 1 | VisitorOutput parses valid fixture | \`4bd207c\` | \`c69631e\` |
| 2 | rejects missing field | \`37e34c0\` | \`26f9ade\` |
| 3 | rejects oversized first_impression | \`7a0350d\` | \`e3cf7d0\` |
| 4 | rejects out-of-range will_to_buy | \`86aab7a\` | \`b2bc825\` |
| 5 | rejects wrong next_action enum | \`fe9a523\` | \`0d68caa\` |
| 6 | rejects non-array questions | \`c963435\` | \`efbf1a8\` |
| 7 | confidence range + reasoning cap | \`8b2fa0d\` | \`9efdf67\` |
| 8 | Backstory parses valid fixture | \`663723b\` | \`5d40e90\` |
| 9 | Backstory rejects bad enum | \`abee66c\` | \`560c76b\` |
| 10 | scoreVisit purchase_paid_today=1.0 | \`8abbf1d\` | \`36730e4\` |
| 11 | scoreVisit contact_sales / book_demo=0.8 | \`2f7ed9a\` | \`1cedc34\` |
| 12 | scoreVisit start_paid_trial=0.6 | \`ac406c2\` | \`540be6c\` |
| 13 | scoreVisit bookmark_compare_later bump | \`f40bcd3\` | \`6df1328\` |
| 14 | scoreVisit start_free_hobby bump | \`f50b020\` | \`291df0b\` |
| 15 | scoreVisit ask_teammate=0.2 | \`88f4472\` | \`9acfc98\` |
| 16 | NEXT_ACTION_WEIGHTS map + leave/unknown defensive | \`cd522ab\` | \`932598e\` |

## Public-repo audit

\`git diff origin/main..HEAD -- packages tsconfig.json .samo\` greps clean for \`secret|password|api[_-]?key|sk_live|hcloud|cloudflare|tunnel|<IPv4>\`. Diff touches only \`packages/shared/**\`, the SPEC amendments file, root \`tsconfig.json\` (added \`./packages/shared\` reference), \`package.json\` (no behavior change after rebase — main already has the workspace-recurse \`test\` + \`typecheck\` scripts), and \`pnpm-lock.yaml\` (zod added).

## Test plan

- [x] \`pnpm typecheck\` clean (root + every workspace package)
- [x] \`pnpm lint\` clean
- [x] \`pnpm test\` clean (root tests + \`apps/api\` + \`apps/web\` + \`@willbuy/shared\`)
- [x] \`pnpm --filter @willbuy/shared test\` shows all 23 acceptance assertions green
- [ ] CI green on the opened PR (waiting on Actions)