### PR TITLE
feat(llm-adapter): LLMProvider interface + local-CLI subprocess + AST lint

### DIFF
--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -3,7 +3,18 @@ import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import globals from 'globals';
 import reactPlugin from 'eslint-plugin-react';
-import willbuy from './eslint-rules/no-sandbox-flag.js';
+import noSandboxFlag from './eslint-rules/no-sandbox-flag.js';
+import noReservedLlmIdentifiers from './packages/llm-adapter/eslint-rule.js';
+
+// Single namespaced plugin: ESLint v9 wants one plugin object with all
+// rules merged in. Two separate plugin entries with the same key would
+// collide.
+const willbuy = {
+  rules: {
+    ...noSandboxFlag.rules,
+    ...noReservedLlmIdentifiers.rules,
+  },
+};
 
 export default tseslint.config(
   {
@@ -20,6 +31,10 @@ export default tseslint.config(
       // issue #7 acceptance #4). They are linted explicitly by
       // apps/web/test/lint-scoping.test.ts via `eslint --no-ignore`.
       'apps/web/_lint-fixtures/**',
+      // Negative-test inputs for the AST identifier ban. Linted
+      // explicitly by packages/llm-adapter/test/lint-rule.test.ts via
+      // the fixtures-only config (which does NOT ignore them).
+      'packages/llm-adapter/lint-fixtures/**',
     ],
   },
   js.configs.recommended,
@@ -35,6 +50,7 @@ export default tseslint.config(
     },
     rules: {
       'willbuy/no-sandbox-flag': 'error',
+      'willbuy/no-reserved-llm-identifiers': 'error',
     },
   },
   {
@@ -55,12 +71,19 @@ export default tseslint.config(
     },
   },
   {
-    // The rule definition and the test that exercises it both legitimately
-    // mention the banned literal as a pattern/diagnostic string. They are the
-    // single allow-listed exception to `willbuy/no-sandbox-flag`.
-    files: ['eslint-rules/**/*.js', 'tests/lint-rules.test.ts'],
+    // The rule definitions and tests that exercise them both legitimately
+    // mention the banned literal/identifiers as patterns/diagnostic
+    // strings. This is the SINGLE allow-list scope for both willbuy
+    // custom rules; new files added here require a reviewer eyebrow.
+    files: [
+      'eslint-rules/**/*.js',
+      'packages/llm-adapter/eslint-rule.js',
+      'tests/lint-rules.test.ts',
+      'packages/llm-adapter/test/lint-rule.test.ts',
+    ],
     rules: {
       'willbuy/no-sandbox-flag': 'off',
+      'willbuy/no-reserved-llm-identifiers': 'off',
     },
   },
 );

--- a/eslint.fixtures.config.mjs
+++ b/eslint.fixtures.config.mjs
@@ -9,7 +9,15 @@ import js from '@eslint/js';
 import tseslint from 'typescript-eslint';
 import globals from 'globals';
 import reactPlugin from 'eslint-plugin-react';
-import willbuy from './eslint-rules/no-sandbox-flag.js';
+import noSandboxFlag from './eslint-rules/no-sandbox-flag.js';
+import noReservedLlmIdentifiers from './packages/llm-adapter/eslint-rule.js';
+
+const willbuy = {
+  rules: {
+    ...noSandboxFlag.rules,
+    ...noReservedLlmIdentifiers.rules,
+  },
+};
 
 export default tseslint.config(
   {
@@ -28,6 +36,7 @@ export default tseslint.config(
     },
     rules: {
       'willbuy/no-sandbox-flag': 'error',
+      'willbuy/no-reserved-llm-identifiers': 'error',
     },
   },
   {
@@ -45,9 +54,19 @@ export default tseslint.config(
     },
   },
   {
-    files: ['eslint-rules/**/*.js', 'tests/lint-rules.test.ts'],
+    // The single allow-list line for the AST rule itself: the rule source
+    // file, the lint-rule-test file, and (on the fixtures-only config)
+    // the lint fixtures themselves all legitimately mention banned names
+    // as patterns/diagnostics.
+    files: [
+      'eslint-rules/**/*.js',
+      'packages/llm-adapter/eslint-rule.js',
+      'tests/lint-rules.test.ts',
+      'packages/llm-adapter/test/lint-rule.test.ts',
+    ],
     rules: {
       'willbuy/no-sandbox-flag': 'off',
+      'willbuy/no-reserved-llm-identifiers': 'off',
     },
   },
 );

--- a/packages/llm-adapter/eslint-rule.js
+++ b/packages/llm-adapter/eslint-rule.js
@@ -1,0 +1,171 @@
+/**
+ * Custom ESLint rule: bans the reserved continuation identifiers from
+ * spec §2 #15 (`conversation_id`, `session_id`, `thread_id`,
+ * `previous_response_id`, `cached_prompt_id`, `parent_message_id`,
+ * `run_id`) ANYWHERE in the repo, with a single allow-list line for the
+ * rule definition itself.
+ *
+ * The rule walks the AST (typescript-eslint extends ESLint's AST so we
+ * can intercept TS-only nodes the same way we intercept regular ones),
+ * which catches matches inside:
+ *
+ *   - variable / const / let declarations
+ *   - object-literal properties (including shorthand)
+ *   - function parameters (incl. destructured)
+ *   - object destructure patterns at binding sites
+ *   - TypeScript interface / type-literal property signatures
+ *   - import + export specifiers
+ *
+ * A regex over file bytes would catch the literal substrings but ALSO
+ * flag every comment that talks about the rule, every fixture, every
+ * spec excerpt — which is why we walk the AST.
+ *
+ * Issue #5 acceptance #6.
+ */
+
+// Spec §2 #15. Keep the list narrow — it is the authoritative set the rule
+// blocks. The amendments file may add provider-specific aliases later;
+// when that happens, add them here, NOT in a separate config knob (the
+// rule is the single source of truth and reviewers grep for this list).
+const FORBIDDEN = new Set([
+  'conversation_id',
+  'session_id',
+  'thread_id',
+  'previous_response_id',
+  'cached_prompt_id',
+  'parent_message_id',
+  'run_id',
+]);
+
+function isForbidden(name) {
+  return typeof name === 'string' && FORBIDDEN.has(name);
+}
+
+function reportIfForbidden(context, node, name) {
+  if (isForbidden(name)) {
+    context.report({
+      node,
+      messageId: 'banned',
+      data: { name },
+    });
+  }
+}
+
+function nameFromKey(keyNode) {
+  if (!keyNode) return null;
+  if (keyNode.type === 'Identifier') return keyNode.name;
+  if (keyNode.type === 'Literal' && typeof keyNode.value === 'string') return keyNode.value;
+  return null;
+}
+
+/** @type {import('eslint').Rule.RuleModule} */
+const rule = {
+  meta: {
+    type: 'problem',
+    docs: {
+      description:
+        'Disallow reserved LLM continuation identifiers (spec §2 #15) anywhere in source — fresh-context guarantee.',
+    },
+    schema: [],
+    messages: {
+      banned:
+        "Reserved LLM continuation identifier '{{name}}' is forbidden anywhere in the repo (spec §2 #15 fresh-context guarantee). Use logical_request_key + transport_attempts instead.",
+    },
+  },
+  create(context) {
+    return {
+      // Plain bindings: `const session_id = …`, `let thread_id`, function
+      // parameters declared as identifiers, etc. typescript-eslint resolves
+      // parameter and destructure patterns to Identifier leaves so this
+      // single visitor catches them all.
+      Identifier(node) {
+        // Skip plain references and member-expression property lookups —
+        // re-using a forbidden NAME at a read site is still a leak (e.g.
+        // `obj.session_id`). We DO want to flag every binding/property
+        // appearance; not flagging member access would let stateful code
+        // sneak through. Members are caught by MemberExpression below.
+        if (!isForbidden(node.name)) return;
+
+        // De-dup: skip Identifier visits that we will already report from
+        // a more specific visitor (Property, ImportSpecifier, etc) so
+        // each binding flags exactly once.
+        const parent = node.parent;
+        if (!parent) {
+          reportIfForbidden(context, node, node.name);
+          return;
+        }
+        // The Property / TSPropertySignature visitors below report the key.
+        if (
+          (parent.type === 'Property' || parent.type === 'PropertyDefinition') &&
+          parent.key === node
+        ) {
+          return;
+        }
+        if (parent.type === 'TSPropertySignature' && parent.key === node) return;
+        if (parent.type === 'TSMethodSignature' && parent.key === node) return;
+        // Import/export specifier visitors below.
+        if (
+          (parent.type === 'ImportSpecifier' && (parent.imported === node || parent.local === node)) ||
+          (parent.type === 'ExportSpecifier' && (parent.exported === node || parent.local === node)) ||
+          (parent.type === 'ImportDefaultSpecifier' && parent.local === node) ||
+          (parent.type === 'ImportNamespaceSpecifier' && parent.local === node)
+        ) {
+          return;
+        }
+        // MemberExpression .property reads are reported here directly —
+        // no specific visitor below.
+        if (parent.type === 'MemberExpression' && parent.property === node && !parent.computed) {
+          context.report({ node, messageId: 'banned', data: { name: node.name } });
+          return;
+        }
+        // Anything else: the binding/parameter/reference itself.
+        context.report({ node, messageId: 'banned', data: { name: node.name } });
+      },
+      // Object literal properties: `{ thread_id: '…' }`. Catches both
+      // shorthand (`{ thread_id }`) — which Identifier already covers —
+      // and explicit-key form.
+      Property(node) {
+        const name = nameFromKey(node.key);
+        reportIfForbidden(context, node.key, name);
+      },
+      // Class properties: `class X { run_id = '…' }`.
+      PropertyDefinition(node) {
+        const name = nameFromKey(node.key);
+        reportIfForbidden(context, node.key, name);
+      },
+      // TS interface / type-literal property signatures:
+      // `interface X { conversation_id: string }`.
+      TSPropertySignature(node) {
+        const name = nameFromKey(node.key);
+        reportIfForbidden(context, node.key, name);
+      },
+      TSMethodSignature(node) {
+        const name = nameFromKey(node.key);
+        reportIfForbidden(context, node.key, name);
+      },
+      // Import/export specifiers: `import { run_id } from 'x'`.
+      ImportSpecifier(node) {
+        if (node.imported && node.imported.type === 'Identifier') {
+          reportIfForbidden(context, node.imported, node.imported.name);
+        }
+        if (node.local && node.local.type === 'Identifier' && node.local !== node.imported) {
+          reportIfForbidden(context, node.local, node.local.name);
+        }
+      },
+      ExportSpecifier(node) {
+        if (node.exported && node.exported.type === 'Identifier') {
+          reportIfForbidden(context, node.exported, node.exported.name);
+        }
+        if (node.local && node.local.type === 'Identifier' && node.local !== node.exported) {
+          reportIfForbidden(context, node.local, node.local.name);
+        }
+      },
+    };
+  },
+};
+
+export default {
+  rules: {
+    'no-reserved-llm-identifiers': rule,
+  },
+};

--- a/packages/llm-adapter/eslint-rule.js
+++ b/packages/llm-adapter/eslint-rule.js
@@ -95,9 +95,12 @@ const rule = {
           return;
         }
         // The Property / TSPropertySignature visitors below report the key.
+        // For shorthand `{ x }` (object literal) and `{ x }` (destructure),
+        // key === value (same node), and the Property visitor fires once;
+        // skip the Identifier visit either way to avoid double-reporting.
         if (
           (parent.type === 'Property' || parent.type === 'PropertyDefinition') &&
-          parent.key === node
+          (parent.key === node || (parent.shorthand && parent.value === node))
         ) {
           return;
         }

--- a/packages/llm-adapter/lint-fixtures/clean.ts
+++ b/packages/llm-adapter/lint-fixtures/clean.ts
@@ -1,0 +1,20 @@
+// Lint fixture: clean module — no reserved continuation identifiers,
+// no forbidden patterns, no banned literals. The willbuy/no-reserved-llm-
+// identifiers rule MUST accept this file. (issue #5 acceptance #6)
+
+export interface CleanShape {
+  visit_id: string;
+  logical_request_key: string;
+  transport_attempts: number;
+}
+
+export const cleanPayload: CleanShape = {
+  visit_id: 'v1',
+  logical_request_key: 'lk-1',
+  transport_attempts: 1,
+};
+
+export function score(input: CleanShape): number {
+  const { transport_attempts } = input;
+  return transport_attempts;
+}

--- a/packages/llm-adapter/lint-fixtures/forbidden-identifier.ts
+++ b/packages/llm-adapter/lint-fixtures/forbidden-identifier.ts
@@ -1,0 +1,5 @@
+// Lint fixture: contains a forbidden continuation identifier per spec §2 #15.
+// The custom willbuy/no-reserved-llm-identifiers rule MUST flag this file.
+// Direct variable declaration is the simplest possible match site.
+
+export const session_id = 'should-be-flagged';

--- a/packages/llm-adapter/lint-fixtures/forbidden-in-destructure.ts
+++ b/packages/llm-adapter/lint-fixtures/forbidden-in-destructure.ts
@@ -1,0 +1,12 @@
+// Lint fixture: forbidden identifier appearing inside an object destructure.
+// Issue #5 explicitly enumerates "deconstructions" as in scope for the rule.
+
+interface Source {
+  run_id: string;
+  rest: number;
+}
+
+export function pull(s: Source): string {
+  const { run_id } = s;
+  return run_id;
+}

--- a/packages/llm-adapter/lint-fixtures/forbidden-in-object.ts
+++ b/packages/llm-adapter/lint-fixtures/forbidden-in-object.ts
@@ -1,0 +1,7 @@
+// Lint fixture: forbidden identifier as a property of an object literal —
+// the canonical "LLM call site argument" shape. Spec §2 #15 forbids carrying
+// state across calls; this would do exactly that.
+
+export const payload = {
+  thread_id: 'leak',
+};

--- a/packages/llm-adapter/lint-fixtures/forbidden-in-param.ts
+++ b/packages/llm-adapter/lint-fixtures/forbidden-in-param.ts
@@ -1,0 +1,8 @@
+// Lint fixture: forbidden identifier as a function parameter name.
+// Issue #5 acceptance #6 requires the AST rule to catch this even though
+// no LLM call site is visible — type-defs and helper signatures are equally
+// in scope.
+
+export function bad(previous_response_id: string): string {
+  return previous_response_id;
+}

--- a/packages/llm-adapter/lint-fixtures/forbidden-in-type.ts
+++ b/packages/llm-adapter/lint-fixtures/forbidden-in-type.ts
@@ -1,0 +1,9 @@
+// Lint fixture: forbidden identifier as a type-definition property name.
+// Issue #5 explicitly requires the AST rule to walk type definitions, not
+// just call sites. A regex would also catch this but the test asserts the
+// AST path covers it.
+
+export interface BadShape {
+  conversation_id: string;
+  ok: number;
+}

--- a/packages/llm-adapter/package.json
+++ b/packages/llm-adapter/package.json
@@ -1,0 +1,25 @@
+{
+  "name": "@willbuy/llm-adapter",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "LLMProvider interface + local-CLI subprocess provider — see SPEC §2 #15, §2 #27, §4.1, §5.15.",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {},
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/packages/llm-adapter/src/index.ts
+++ b/packages/llm-adapter/src/index.ts
@@ -1,0 +1,54 @@
+// Spec §4.1: this package is the ONLY call site for chat. Workers depend on
+// `LLMProvider`; one wired backend ships in v0.1 (§2 #27).
+//
+// Stub skeleton — tests in test/ drive the real implementation in red→green
+// commit pairs per CLAUDE.md TDD discipline.
+
+export interface LLMProviderCapabilities {
+  // Per spec §2 #15 / §5.15 — does the provider honor Idempotency-Key?
+  idempotency: boolean;
+  // Spec §2 #33 — provider configured to not retain prompts.
+  zero_retention: boolean;
+  // Spec §2 #27 — supports JSON-mode / schema-constrained output.
+  structured_output: boolean;
+  // Spec §1 prompt-caching carve-out — can mark a static prefix cacheable.
+  prompt_caching: boolean;
+}
+
+export interface LLMChatOptions {
+  staticPrefix: string;
+  dynamicTail: string;
+  logicalRequestKey: string;
+  maxOutputTokens: number;
+}
+
+export interface LLMChatResult {
+  raw: string;
+  transportAttempts: number;
+  status: 'ok' | 'indeterminate' | 'error';
+}
+
+export interface LLMProvider {
+  name(): string;
+  capabilities(): LLMProviderCapabilities;
+  chat(opts: LLMChatOptions): Promise<LLMChatResult>;
+}
+
+export const LOCAL_CLI_CAPABILITIES: LLMProviderCapabilities = {
+  idempotency: false,
+  zero_retention: false,
+  structured_output: false,
+  prompt_caching: false,
+};
+
+export class LocalCliProvider implements LLMProvider {
+  name(): string {
+    throw new Error('not implemented');
+  }
+  capabilities(): LLMProviderCapabilities {
+    throw new Error('not implemented');
+  }
+  chat(_opts: LLMChatOptions): Promise<LLMChatResult> {
+    throw new Error('not implemented');
+  }
+}

--- a/packages/llm-adapter/src/index.ts
+++ b/packages/llm-adapter/src/index.ts
@@ -1,8 +1,16 @@
 // Spec §4.1: this package is the ONLY call site for chat. Workers depend on
 // `LLMProvider`; one wired backend ships in v0.1 (§2 #27).
 //
-// Stub skeleton — tests in test/ drive the real implementation in red→green
-// commit pairs per CLAUDE.md TDD discipline.
+// LocalCliProvider subprocess-shells out to a CLI binary configured via the
+// WILLBUY_LLM_BIN env var (default 'claude' per issue #5). Each chat() call
+// is a fresh execFile/spawn — no shared state, no session reuse — preserving
+// the spec §2 #15 fresh-context guarantee at the lowest level. The logical
+// request key is forwarded as WILLBUY_REQ_KEY in the subprocess env so a
+// future provider can use it as Idempotency-Key (the v0.1 local CLI may
+// ignore it; spec §5.15 says transport retries reuse the key, schema-repair
+// generates a new one).
+
+import { spawn } from 'node:child_process';
 
 export interface LLMProviderCapabilities {
   // Per spec §2 #15 / §5.15 — does the provider honor Idempotency-Key?
@@ -62,11 +70,10 @@ export interface LocalCliProviderOptions {
 }
 
 export class LocalCliProvider implements LLMProvider {
-  // Stored but unused until green commit lands.
-  private readonly _options: LocalCliProviderOptions;
+  private readonly options: LocalCliProviderOptions;
 
   constructor(options: LocalCliProviderOptions = {}) {
-    this._options = options;
+    this.options = options;
   }
   name(): string {
     return LOCAL_CLI_PROVIDER_NAME;
@@ -74,8 +81,110 @@ export class LocalCliProvider implements LLMProvider {
   capabilities(): LLMProviderCapabilities {
     return LOCAL_CLI_CAPABILITIES;
   }
-  chat(_opts: LLMChatOptions): Promise<LLMChatResult> {
-    void this._options;
-    throw new Error('not implemented');
+  async chat(opts: LLMChatOptions): Promise<LLMChatResult> {
+    const argv = this.resolveArgv();
+    if (argv.length === 0) {
+      return { raw: '', transportAttempts: 1, status: 'error' };
+    }
+
+    const [cmd, ...args] = argv;
+    const timeoutMs = this.options.timeoutMs ?? LOCAL_CLI_DEFAULT_TIMEOUT_MS;
+    const stdinPayload = `${opts.staticPrefix}\n${opts.dynamicTail}`;
+
+    return await runOnce({
+      cmd: cmd!,
+      args,
+      env: {
+        ...process.env,
+        ...(this.options.env ?? {}),
+        WILLBUY_REQ_KEY: opts.logicalRequestKey,
+      },
+      stdin: stdinPayload,
+      timeoutMs,
+    });
   }
+
+  private resolveArgv(): string[] {
+    if (this.options.argv && this.options.argv.length > 0) {
+      return [...this.options.argv];
+    }
+    const envBin = process.env.WILLBUY_LLM_BIN;
+    if (envBin && envBin.trim().length > 0) {
+      // Naive split is fine for v0.1: WILLBUY_LLM_BIN is set by ops, not
+      // by user input, and we explicitly do NOT support shell metachars.
+      return envBin.trim().split(/\s+/);
+    }
+    return ['claude'];
+  }
+}
+
+interface RunOnceOpts {
+  cmd: string;
+  args: string[];
+  env: NodeJS.ProcessEnv;
+  stdin: string;
+  timeoutMs: number;
+}
+
+function runOnce(opts: RunOnceOpts): Promise<LLMChatResult> {
+  return new Promise((resolveP) => {
+    const child = spawn(opts.cmd, opts.args, {
+      env: opts.env,
+      stdio: ['pipe', 'pipe', 'pipe'],
+    });
+
+    const stdoutChunks: Buffer[] = [];
+    let settled = false;
+    const settle = (result: LLMChatResult) => {
+      if (settled) return;
+      settled = true;
+      clearTimeout(timer);
+      resolveP(result);
+    };
+
+    const timer: NodeJS.Timeout = setTimeout(() => {
+      // SIGKILL — the spec wants pessimistic-on-timeout behavior; a polite
+      // SIGTERM the child can ignore would defeat the wall-clock guarantee.
+      try {
+        child.kill('SIGKILL');
+      } catch {
+        // already exited
+      }
+      settle({ raw: '', transportAttempts: 1, status: 'error' });
+    }, opts.timeoutMs);
+
+    child.on('error', () => {
+      // ENOENT (binary not found) and similar spawn failures.
+      settle({ raw: '', transportAttempts: 1, status: 'error' });
+    });
+
+    child.stdout.on('data', (c: Buffer) => stdoutChunks.push(c));
+    child.stdout.on('error', () => {
+      // Stream errors fold into the same error path; the close handler will
+      // observe the non-zero exit / signal.
+    });
+    child.stderr.on('data', () => {
+      // Captured but intentionally not surfaced — keep logged messages
+      // generic per CLAUDE.md "no vendor name leaks". Future: stream into
+      // structured-log middleware behind an injected sink.
+    });
+    child.stderr.on('error', () => {});
+
+    child.on('close', (code, signal) => {
+      const raw = Buffer.concat(stdoutChunks).toString('utf8');
+      if (code === 0) {
+        settle({ raw, transportAttempts: 1, status: 'ok' });
+      } else {
+        // Killed by timeout (SIGKILL) OR non-zero exit → error w/ empty raw.
+        void signal;
+        settle({ raw: '', transportAttempts: 1, status: 'error' });
+      }
+    });
+
+    child.stdin.on('error', () => {
+      // EPIPE on a fast-failing child (e.g. exits before reading stdin).
+      // Close handler will produce the final error result.
+    });
+    child.stdin.end(opts.stdin);
+  });
 }

--- a/packages/llm-adapter/src/index.ts
+++ b/packages/llm-adapter/src/index.ts
@@ -47,7 +47,27 @@ export const LOCAL_CLI_CAPABILITIES: LLMProviderCapabilities = {
 // configurable via WILLBUY_LLM_BIN; "local-cli" is the abstraction name.
 export const LOCAL_CLI_PROVIDER_NAME = 'local-cli';
 
+// Spec §4.1 mentions a 120 s default subprocess timeout for the local CLI.
+export const LOCAL_CLI_DEFAULT_TIMEOUT_MS = 120_000;
+
+export interface LocalCliProviderOptions {
+  // Test/override hook: pass argv directly. When undefined, the provider
+  // resolves the binary from the WILLBUY_LLM_BIN env var (default 'claude'
+  // per issue #5; the value MUST stay generic and configurable).
+  argv?: readonly string[];
+  // Extra env vars merged into the subprocess env; logicalRequestKey is
+  // injected as WILLBUY_REQ_KEY by chat() regardless of what's passed here.
+  env?: Readonly<Record<string, string>>;
+  timeoutMs?: number;
+}
+
 export class LocalCliProvider implements LLMProvider {
+  // Stored but unused until green commit lands.
+  private readonly _options: LocalCliProviderOptions;
+
+  constructor(options: LocalCliProviderOptions = {}) {
+    this._options = options;
+  }
   name(): string {
     return LOCAL_CLI_PROVIDER_NAME;
   }
@@ -55,6 +75,7 @@ export class LocalCliProvider implements LLMProvider {
     return LOCAL_CLI_CAPABILITIES;
   }
   chat(_opts: LLMChatOptions): Promise<LLMChatResult> {
+    void this._options;
     throw new Error('not implemented');
   }
 }

--- a/packages/llm-adapter/src/index.ts
+++ b/packages/llm-adapter/src/index.ts
@@ -41,12 +41,18 @@ export const LOCAL_CLI_CAPABILITIES: LLMProviderCapabilities = {
   prompt_caching: false,
 };
 
+// Generic identifier per issue #5 / CLAUDE.md "Public repo discipline":
+// the provider implementation MUST NOT name a specific vendor in src/
+// identifiers, filenames, or logged messages. The CLI binary itself is
+// configurable via WILLBUY_LLM_BIN; "local-cli" is the abstraction name.
+export const LOCAL_CLI_PROVIDER_NAME = 'local-cli';
+
 export class LocalCliProvider implements LLMProvider {
   name(): string {
-    throw new Error('not implemented');
+    return LOCAL_CLI_PROVIDER_NAME;
   }
   capabilities(): LLMProviderCapabilities {
-    throw new Error('not implemented');
+    return LOCAL_CLI_CAPABILITIES;
   }
   chat(_opts: LLMChatOptions): Promise<LLMChatResult> {
     throw new Error('not implemented');

--- a/packages/llm-adapter/test/capabilities.test.ts
+++ b/packages/llm-adapter/test/capabilities.test.ts
@@ -1,0 +1,31 @@
+import { describe, expect, it } from 'vitest';
+
+import { LocalCliProvider, LOCAL_CLI_CAPABILITIES } from '../src/index.js';
+
+// Spec §2 #27: pluggable LLM adapter declares capability flags
+// (idempotency, zero_retention, structured_output, prompt_caching).
+// Issue #5 acceptance #5: capability flags returned by
+// LocalCliProvider.capabilities() match a documented constant — no CLI
+// introspection in v0.1.
+describe('LocalCliProvider — capabilities()', () => {
+  it('returns the documented constant flag set', () => {
+    const provider = new LocalCliProvider();
+    expect(provider.capabilities()).toStrictEqual(LOCAL_CLI_CAPABILITIES);
+  });
+
+  it('declares all four spec-required capability flags as booleans', () => {
+    const caps = new LocalCliProvider().capabilities();
+    expect(typeof caps.idempotency).toBe('boolean');
+    expect(typeof caps.zero_retention).toBe('boolean');
+    expect(typeof caps.structured_output).toBe('boolean');
+    expect(typeof caps.prompt_caching).toBe('boolean');
+  });
+
+  it('reports a stable, generic provider name() that does not leak vendor identifiers', () => {
+    const name = new LocalCliProvider().name();
+    expect(typeof name).toBe('string');
+    expect(name.length).toBeGreaterThan(0);
+    // CLAUDE.md "No vendor name leaks" + issue #5 generic-naming requirement.
+    expect(name).not.toMatch(/anthropic|claude|openai|gpt|gemini/i);
+  });
+});

--- a/packages/llm-adapter/test/chat.test.ts
+++ b/packages/llm-adapter/test/chat.test.ts
@@ -1,0 +1,201 @@
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { LocalCliProvider } from '../src/index.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, 'fixtures');
+const ECHO_BIN = ['node', resolve(fixturesDir, 'echo-bin.mjs')];
+const RECORD_BIN = ['node', resolve(fixturesDir, 'record-bin.mjs')];
+const EXIT_NONZERO_BIN = ['node', resolve(fixturesDir, 'exit-nonzero-bin.mjs')];
+const SLEEP_BIN = ['node', resolve(fixturesDir, 'sleep-bin.mjs')];
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'willbuy-llm-adapter-'));
+});
+
+afterEach(() => {
+  if (workDir && existsSync(workDir)) {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+describe('LocalCliProvider — chat() acceptance #1: subprocess invocation', () => {
+  it('pipes (staticPrefix + "\\n" + dynamicTail) on stdin to the configured binary, returns stdout as raw', async () => {
+    const provider = new LocalCliProvider({
+      argv: ECHO_BIN,
+    });
+
+    const result = await provider.chat({
+      staticPrefix: 'STATIC_PREFIX',
+      dynamicTail: 'DYNAMIC_TAIL',
+      logicalRequestKey: 'lk-acc-1',
+      maxOutputTokens: 800,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.transportAttempts).toBe(1);
+    expect(result.raw).toBe('STATIC_PREFIX\nDYNAMIC_TAIL');
+  });
+});
+
+describe('LocalCliProvider — chat() acceptance #2: fresh process per call', () => {
+  it('two consecutive chat() calls spawn two distinct OS processes (no PID reuse, no shared state)', async () => {
+    const counterPath = join(workDir, 'counter.txt');
+    const recorderPath = join(workDir, 'recorder.jsonl');
+
+    const provider = new LocalCliProvider({
+      argv: RECORD_BIN,
+      env: {
+        WILLBUY_TEST_COUNTER: counterPath,
+        WILLBUY_TEST_RECORDER: recorderPath,
+      },
+    });
+
+    const r1 = await provider.chat({
+      staticPrefix: 'P1',
+      dynamicTail: 'T1',
+      logicalRequestKey: 'lk-call-1',
+      maxOutputTokens: 800,
+    });
+    const r2 = await provider.chat({
+      staticPrefix: 'P2',
+      dynamicTail: 'T2',
+      logicalRequestKey: 'lk-call-2',
+      maxOutputTokens: 800,
+    });
+
+    expect(r1.status).toBe('ok');
+    expect(r2.status).toBe('ok');
+
+    const lines = readFileSync(recorderPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(2);
+    const first = JSON.parse(lines[0]!);
+    const second = JSON.parse(lines[1]!);
+
+    // Acceptance #2: two distinct processes — counter increments AND PIDs
+    // differ. counter is the authoritative "this was a fresh execution"
+    // signal because it's written from inside the child, persisted on disk.
+    expect(first.counter).toBe(1);
+    expect(second.counter).toBe(2);
+    expect(first.pid).not.toBe(second.pid);
+  });
+});
+
+describe('LocalCliProvider — chat() acceptance #3: logical_request_key passthrough', () => {
+  it('passes logicalRequestKey through to the subprocess as WILLBUY_REQ_KEY env var', async () => {
+    const recorderPath = join(workDir, 'recorder.jsonl');
+    const counterPath = join(workDir, 'counter.txt');
+
+    const provider = new LocalCliProvider({
+      argv: RECORD_BIN,
+      env: {
+        WILLBUY_TEST_COUNTER: counterPath,
+        WILLBUY_TEST_RECORDER: recorderPath,
+      },
+    });
+
+    // Spec §5.15: schema-repair retry increments repair_generation, yielding
+    // a NEW logical_request_key. Two calls with distinct keys must each see
+    // their own key in the subprocess env (no leakage, no reuse).
+    await provider.chat({
+      staticPrefix: 'P',
+      dynamicTail: 'T',
+      logicalRequestKey: 'lk-original',
+      maxOutputTokens: 800,
+    });
+    await provider.chat({
+      staticPrefix: 'P',
+      dynamicTail: 'T',
+      logicalRequestKey: 'lk-after-schema-repair',
+      maxOutputTokens: 800,
+    });
+
+    const lines = readFileSync(recorderPath, 'utf8').trim().split('\n');
+    const first = JSON.parse(lines[0]!);
+    const second = JSON.parse(lines[1]!);
+    expect(first.req_key).toBe('lk-original');
+    expect(second.req_key).toBe('lk-after-schema-repair');
+  });
+});
+
+describe('LocalCliProvider — chat() acceptance #4: error paths', () => {
+  it('subprocess exit non-zero → status="error", raw is empty', async () => {
+    const provider = new LocalCliProvider({
+      argv: EXIT_NONZERO_BIN,
+    });
+
+    const result = await provider.chat({
+      staticPrefix: 'P',
+      dynamicTail: 'T',
+      logicalRequestKey: 'lk-exit-nonzero',
+      maxOutputTokens: 800,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.raw).toBe('');
+  });
+
+  it('subprocess timeout → status="error" and the process is killed', async () => {
+    const provider = new LocalCliProvider({
+      argv: SLEEP_BIN,
+      timeoutMs: 250,
+    });
+
+    const start = Date.now();
+    const result = await provider.chat({
+      staticPrefix: 'P',
+      dynamicTail: 'T',
+      logicalRequestKey: 'lk-timeout',
+      maxOutputTokens: 800,
+    });
+    const elapsed = Date.now() - start;
+
+    expect(result.status).toBe('error');
+    expect(result.raw).toBe('');
+    // Should resolve well before vitest's per-test timeout, proving the
+    // adapter actually killed the child rather than waiting on EOF.
+    expect(elapsed).toBeLessThan(5_000);
+  });
+});
+
+describe('LocalCliProvider — env-var configuration', () => {
+  it('falls back to WILLBUY_LLM_BIN env var when no argv passed', async () => {
+    const recorderPath = join(workDir, 'recorder.jsonl');
+    const counterPath = join(workDir, 'counter.txt');
+
+    // The env-var-resolved binary is the record fixture; argv stays undefined.
+    const prevBin = process.env.WILLBUY_LLM_BIN;
+    process.env.WILLBUY_LLM_BIN = `node ${RECORD_BIN[1]}`;
+    try {
+      const provider = new LocalCliProvider({
+        env: {
+          WILLBUY_TEST_COUNTER: counterPath,
+          WILLBUY_TEST_RECORDER: recorderPath,
+        },
+      });
+      const result = await provider.chat({
+        staticPrefix: 'envP',
+        dynamicTail: 'envT',
+        logicalRequestKey: 'lk-env',
+        maxOutputTokens: 800,
+      });
+      expect(result.status).toBe('ok');
+      const lines = readFileSync(recorderPath, 'utf8').trim().split('\n');
+      expect(lines).toHaveLength(1);
+      const recorded = JSON.parse(lines[0]!);
+      expect(recorded.req_key).toBe('lk-env');
+    } finally {
+      if (prevBin === undefined) {
+        delete process.env.WILLBUY_LLM_BIN;
+      } else {
+        process.env.WILLBUY_LLM_BIN = prevBin;
+      }
+    }
+  });
+});

--- a/packages/llm-adapter/test/fixtures/echo-bin.mjs
+++ b/packages/llm-adapter/test/fixtures/echo-bin.mjs
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+// Test fixture: reads stdin, echoes it to stdout. Used by acceptance #1
+// to assert LocalCliProvider.chat() pipes (staticPrefix + '\n' + dynamicTail)
+// via stdin to the configured binary.
+
+import { stdin, stdout, exit } from 'node:process';
+
+const chunks = [];
+stdin.on('data', (c) => chunks.push(c));
+stdin.on('end', () => {
+  stdout.write(Buffer.concat(chunks));
+  exit(0);
+});
+stdin.on('error', () => exit(2));

--- a/packages/llm-adapter/test/fixtures/exit-nonzero-bin.mjs
+++ b/packages/llm-adapter/test/fixtures/exit-nonzero-bin.mjs
@@ -1,0 +1,9 @@
+#!/usr/bin/env node
+// Test fixture: drains stdin then exits with code 7. Used by acceptance #4
+// to assert non-zero exit yields status='error' with empty raw output.
+
+import { stdin, exit } from 'node:process';
+
+stdin.on('data', () => {});
+stdin.on('end', () => exit(7));
+stdin.on('error', () => exit(2));

--- a/packages/llm-adapter/test/fixtures/record-bin.mjs
+++ b/packages/llm-adapter/test/fixtures/record-bin.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Test fixture: records its own PID + a per-invocation counter (read from
+// a counter file passed via WILLBUY_TEST_COUNTER) and writes a JSON line
+// to a recorder file passed via WILLBUY_TEST_RECORDER. Stdout returns the
+// JSON line so the caller can also parse it. Acceptance #2 (fresh process
+// per call) uses this to assert two consecutive calls produce two distinct
+// PIDs and two separate counter increments.
+//
+// Also echoes WILLBUY_REQ_KEY into the recorded line so acceptance #3
+// (logical_request_key reaches the subprocess) can assert pass-through.
+
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { stdin, stdout, env, pid, exit } from 'node:process';
+
+const counterPath = env.WILLBUY_TEST_COUNTER;
+const recorderPath = env.WILLBUY_TEST_RECORDER;
+
+let counter = 0;
+if (counterPath) {
+  try {
+    counter = Number(readFileSync(counterPath, 'utf8') || '0') + 1;
+  } catch {
+    counter = 1;
+  }
+  writeFileSync(counterPath, String(counter));
+}
+
+const chunks = [];
+stdin.on('data', (c) => chunks.push(c));
+stdin.on('end', () => {
+  const stdinStr = Buffer.concat(chunks).toString('utf8');
+  const line = JSON.stringify({
+    pid,
+    counter,
+    req_key: env.WILLBUY_REQ_KEY ?? null,
+    stdin_len: stdinStr.length,
+    stdin_sha_prefix: stdinStr.slice(0, 64),
+  });
+  if (recorderPath) {
+    appendFileSync(recorderPath, line + '\n');
+  }
+  stdout.write(line);
+  exit(0);
+});
+stdin.on('error', () => exit(2));

--- a/packages/llm-adapter/test/fixtures/sleep-bin.mjs
+++ b/packages/llm-adapter/test/fixtures/sleep-bin.mjs
@@ -1,0 +1,12 @@
+#!/usr/bin/env node
+// Test fixture: drains stdin, then sleeps far longer than any test would
+// reasonably wait. Used by acceptance #4 to assert the adapter timeout
+// kills the subprocess and yields status='error'.
+
+import { stdin } from 'node:process';
+
+stdin.on('data', () => {});
+stdin.on('end', () => {
+  // 60 s — well beyond the 250 ms timeout the timeout test passes in.
+  setTimeout(() => {}, 60_000);
+});

--- a/packages/llm-adapter/test/lint-rule.test.ts
+++ b/packages/llm-adapter/test/lint-rule.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { fileURLToPath } from 'node:url';
+import { dirname, resolve } from 'node:path';
+
+// Issue #5 acceptance #6: a custom ESLint rule shipped from this package
+// (and enabled in the root config) bans the reserved continuation
+// identifiers from spec §2 #15 ANYWHERE in the repo (one allow-list line
+// for the rule definition itself). The rule must walk the TS AST so it
+// catches matches in type definitions, object literals, function params,
+// and destructures — not just at LLM call sites.
+
+const here = dirname(fileURLToPath(import.meta.url));
+// Root of the repo: tests live at packages/llm-adapter/test, so up three.
+const repoRoot = resolve(here, '..', '..', '..');
+
+function lintFile(relPath: string): { code: number; stdout: string; stderr: string } {
+  const result = spawnSync(
+    'pnpm',
+    [
+      'exec',
+      'eslint',
+      '--config',
+      'eslint.fixtures.config.mjs',
+      '--no-error-on-unmatched-pattern',
+      relPath,
+    ],
+    {
+      cwd: repoRoot,
+      encoding: 'utf8',
+      env: { ...process.env, CI: '1' },
+    },
+  );
+  return {
+    code: result.status ?? -1,
+    stdout: result.stdout ?? '',
+    stderr: result.stderr ?? '',
+  };
+}
+
+describe('willbuy/no-reserved-llm-identifiers — forbidden fixtures', () => {
+  it('flags a top-level `const session_id = …` declaration', () => {
+    const out = lintFile('packages/llm-adapter/lint-fixtures/forbidden-identifier.ts');
+    expect(out.code, `expected non-zero; got ${out.code}\n${out.stdout}\n${out.stderr}`).not.toBe(0);
+    expect(out.stdout + out.stderr).toMatch(/no-reserved-llm-identifiers/);
+    expect(out.stdout + out.stderr).toMatch(/session_id/);
+  });
+
+  it('flags `conversation_id` in a TS interface property', () => {
+    const out = lintFile('packages/llm-adapter/lint-fixtures/forbidden-in-type.ts');
+    expect(out.code, `expected non-zero; got ${out.code}\n${out.stdout}\n${out.stderr}`).not.toBe(0);
+    expect(out.stdout + out.stderr).toMatch(/no-reserved-llm-identifiers/);
+    expect(out.stdout + out.stderr).toMatch(/conversation_id/);
+  });
+
+  it('flags `thread_id` as an object-literal property', () => {
+    const out = lintFile('packages/llm-adapter/lint-fixtures/forbidden-in-object.ts');
+    expect(out.code, `expected non-zero; got ${out.code}\n${out.stdout}\n${out.stderr}`).not.toBe(0);
+    expect(out.stdout + out.stderr).toMatch(/no-reserved-llm-identifiers/);
+    expect(out.stdout + out.stderr).toMatch(/thread_id/);
+  });
+
+  it('flags `previous_response_id` as a function parameter', () => {
+    const out = lintFile('packages/llm-adapter/lint-fixtures/forbidden-in-param.ts');
+    expect(out.code, `expected non-zero; got ${out.code}\n${out.stdout}\n${out.stderr}`).not.toBe(0);
+    expect(out.stdout + out.stderr).toMatch(/no-reserved-llm-identifiers/);
+    expect(out.stdout + out.stderr).toMatch(/previous_response_id/);
+  });
+
+  it('flags `run_id` inside an object destructure', () => {
+    const out = lintFile('packages/llm-adapter/lint-fixtures/forbidden-in-destructure.ts');
+    expect(out.code, `expected non-zero; got ${out.code}\n${out.stdout}\n${out.stderr}`).not.toBe(0);
+    expect(out.stdout + out.stderr).toMatch(/no-reserved-llm-identifiers/);
+    expect(out.stdout + out.stderr).toMatch(/run_id/);
+  });
+});
+
+describe('willbuy/no-reserved-llm-identifiers — clean fixture', () => {
+  it('accepts a module with visit_id / logical_request_key / transport_attempts', () => {
+    const out = lintFile('packages/llm-adapter/lint-fixtures/clean.ts');
+    expect(out.code, `expected zero; got ${out.code}\n${out.stdout}\n${out.stderr}`).toBe(0);
+  });
+});

--- a/packages/llm-adapter/tsconfig.json
+++ b/packages/llm-adapter/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "composite": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"]
+  },
+  "include": ["src/**/*", "test/**/*", "vitest.config.ts"],
+  "exclude": ["dist", "node_modules", "test/fixtures/**", "lint-fixtures/**"]
+}

--- a/packages/llm-adapter/vitest.config.ts
+++ b/packages/llm-adapter/vitest.config.ts
@@ -1,0 +1,12 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+    // Subprocess + timeout cases need headroom above the default 120 s adapter
+    // timeout (spec §4.1 mentions 120 s default). Tests use a tighter override.
+    testTimeout: 30_000,
+    hookTimeout: 15_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -120,6 +120,18 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.17)
 
+  packages/llm-adapter:
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.17)
+
   packages/shared:
     dependencies:
       zod:

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,5 +8,9 @@
   },
   "include": ["tests/**/*", "scripts/**/*", "*.config.ts", "*.config.mjs"],
   "exclude": ["node_modules", "dist", "build", ".next", "coverage", "tests/lint-fixtures"],
-  "references": [{ "path": "./apps/api" }, { "path": "./packages/shared" }]
+  "references": [
+    { "path": "./apps/api" },
+    { "path": "./packages/shared" },
+    { "path": "./packages/llm-adapter" }
+  ]
 }


### PR DESCRIPTION
Closes #5.

## Summary

Implements the v0.1 LLM adapter seam (spec §4.1). Workers depend on `LLMProvider`; one wired backend (`LocalCliProvider`) ships behind it; an AST lint forbids reserved continuation identifiers anywhere in the repo.

- **`packages/llm-adapter/src/index.ts`** — exports `LLMProvider` interface, `LLMProviderCapabilities`, `LLMChatOptions`, `LLMChatResult`, `LOCAL_CLI_CAPABILITIES`, `LocalCliProvider` class.
- **`LocalCliProvider`** — `chat()` spawns a fresh subprocess per call (`spawn`, no shared state), pipes `staticPrefix + '\n' + dynamicTail` on stdin, returns stdout as `raw` on exit-code-0, returns `status='error'` with empty raw on non-zero exit OR timeout (SIGKILL). Forwards `logicalRequestKey` as `WILLBUY_REQ_KEY` in the child env so a future provider can use it as Idempotency-Key (spec §5.15). Argv resolves from constructor opt → `WILLBUY_LLM_BIN` env var → default `claude`. Default subprocess timeout 120 s (spec §4.1).
- **`packages/llm-adapter/eslint-rule.js`** — custom ESLint rule `willbuy/no-reserved-llm-identifiers`. Walks the typescript-eslint AST so the seven reserved names from spec §2 #15 (`conversation_id`, `session_id`, `thread_id`, `previous_response_id`, `cached_prompt_id`, `parent_message_id`, `run_id`) are caught as: var bindings, object-literal property keys (incl. shorthand), function parameters (incl. destructured), TS interface / type-literal property + method signatures, import + export specifiers, and non-computed member-expression reads. Wired into both `eslint.config.mjs` and `eslint.fixtures.config.mjs`. The rule itself + its test file are the single allow-list scope.

## Spec sections

- §2 #15 (fresh-context guarantee + reserved-identifier list)
- §2 #27 (pluggable LLM with capability flags)
- §5.15 (logical-request idempotency vs transport attempts; new logical key per schema-repair generation)
- §4.1 (LLM adapter layer is the only call site for chat)

This PR does NOT import the `next_action` enum from `@willbuy/shared`, so amendment **A1** (8-value enum) does not apply to this diff.

## Out of scope (per issue #5 "don't widen scope")

- Multiple providers / fallback chain (spec v0.3).
- Streaming.
- Prompt-caching marker logic at the API layer (Sprint 2/3).

## TDD evidence

3 red → green commit pairs, chronologically ordered (reviewer can verify with `git log --oneline origin/main..HEAD`):

| # | Pair | Acceptance |
|---|------|------------|
| 1 | red 550ef73 → green 77b2768 | #5 capabilities() returns documented constant + name() generic |
| 2 | red 19f1edf → green 2ef1e9f | #1 stdin = staticPrefix\\ndynamicTail, #2 fresh process per call (PID + counter), #3 logicalRequestKey → WILLBUY_REQ_KEY, #4 non-zero exit + timeout → status='error' |
| 3 | red 09e98cc → green e504c41 | #6 AST lint forbidden + clean fixtures |

Test fixtures used by acceptance #2/#3/#4: small node scripts at `packages/llm-adapter/test/fixtures/{echo,record,exit-nonzero,sleep}-bin.mjs`. The `record-bin` fixture writes its PID + a per-invocation counter (read from a temp file passed through env) to a recorder file, so the test asserts two consecutive `chat()` calls produce two distinct PIDs and two separate counter increments — i.e. two genuinely fresh OS processes.

AST-lint fixture files at `packages/llm-adapter/lint-fixtures/`:
- `forbidden-identifier.ts` — top-level `const session_id`
- `forbidden-in-type.ts` — `conversation_id` in TS interface property
- `forbidden-in-object.ts` — `thread_id` in object literal
- `forbidden-in-param.ts` — `previous_response_id` as function param
- `forbidden-in-destructure.ts` — `run_id` in object destructure
- `clean.ts` — visit_id / logical_request_key / transport_attempts (must pass)

## Test plan

- [x] `pnpm test` — 15/15 in `@willbuy/llm-adapter`, all other packages still green
- [x] `pnpm lint` — clean (existing tree has no forbidden identifiers; new rule does not regress)
- [x] `pnpm typecheck` — all 5 projects clean
- [ ] CI green on this PR

## Public-repo audit

- No vendor name in `packages/llm-adapter/src/` filenames or identifiers (`grep -rni 'anthropic|haiku|gpt-|openai|gemini' packages/llm-adapter/src/` returns nothing).
- The single mention of `'claude'` is the default value of `WILLBUY_LLM_BIN` — explicitly mandated by issue #5 ("env var `WILLBUY_LLM_BIN`, default `claude`"). Comments around it point at the env var, not the vendor.
- No secrets, IPs, or provider tokens in the diff.
- The capability-flag test `expect(name).not.toMatch(/anthropic|claude|openai|gpt|gemini/i)` enforces the no-leak rule on the provider name itself.