### PR TITLE
feat(visitor-worker): orchestrate backstory + page + LLMProvider with retries

### DIFF
--- a/apps/visitor-worker/package.json
+++ b/apps/visitor-worker/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "@willbuy/visitor-worker",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "description": "runVisit orchestrator: backstory + captured page → LLMProvider chat → VisitorOutput zod, with up to 2 fresh-context schema-repair retries (spec §2 #14, §2 #15, §5.15).",
+  "main": "./src/index.ts",
+  "types": "./src/index.ts",
+  "exports": {
+    ".": {
+      "types": "./src/index.ts",
+      "default": "./src/index.ts"
+    }
+  },
+  "scripts": {
+    "test": "vitest run",
+    "typecheck": "tsc -p tsconfig.json --noEmit"
+  },
+  "dependencies": {
+    "@willbuy/llm-adapter": "workspace:*",
+    "@willbuy/shared": "workspace:*",
+    "zod": "^3.23.8"
+  },
+  "devDependencies": {
+    "@types/node": "^22.10.2",
+    "typescript": "^5.7.2",
+    "vitest": "^2.1.8"
+  }
+}

--- a/apps/visitor-worker/src/index.ts
+++ b/apps/visitor-worker/src/index.ts
@@ -8,7 +8,7 @@
 //
 // Heavy lifting lives in ./visitor.js so the package barrel stays stable.
 
-export { runVisit } from './visitor.js';
+export { runVisit, computeLogicalRequestKey } from './visitor.js';
 export type {
   VisitResult,
   RunVisitOptions,

--- a/apps/visitor-worker/src/index.ts
+++ b/apps/visitor-worker/src/index.ts
@@ -1,0 +1,17 @@
+// Spec §2 #14, §2 #15, §5.15 — visitor-worker package entrypoint.
+//
+// `runVisit(opts)` orchestrates: build prompt → LLMProvider.chat → validate
+// against VisitorOutput zod → on validation failure, build a fresh-context
+// repair prompt (new logical_request_key by incrementing repair_generation,
+// prior bad output passed back as user-role content only — NEVER as an
+// assistant turn) and retry up to 2 times.
+//
+// Heavy lifting lives in ./visitor.js so the package barrel stays stable.
+
+export { runVisit } from './visitor.js';
+export type {
+  VisitResult,
+  RunVisitOptions,
+  VisitFailureReason,
+  VisitStatus,
+} from './visitor.js';

--- a/apps/visitor-worker/src/prompt.ts
+++ b/apps/visitor-worker/src/prompt.ts
@@ -1,0 +1,73 @@
+// Spec §2 #14, §2 #15. Prompt builders for the visitor-worker.
+//
+// The static prefix is byte-identical across all visits — it is the
+// system instructions + structured-output spec, and is the only part
+// the LLMProvider should mark cacheable per spec §1 prompt-caching
+// carve-out (the actual cache marker wiring is Sprint-2; here we just
+// guarantee determinism).
+//
+// The dynamic tail (per-visit) carries the persona-specific payload.
+// At this step the orchestrator only ever issues a single chat() call
+// per visit; the repair-tail builder lands with acceptance #2.
+
+import type { BackstoryT } from '@willbuy/shared';
+
+// Spec §2 #14 carve-out: production prompt copy is tuned in the Sprint-3
+// 5-page benchmark. v0.1 ships a placeholder that is deterministic and
+// names the structured-output expectation in plain English. The exact
+// wording is not load-bearing for any acceptance — only that the prefix
+// is byte-identical across every visit (so the cacheability invariant
+// holds) and the tail carries the per-visit content.
+const STATIC_PREFIX = [
+  'You are a synthetic visitor evaluating a landing or pricing page.',
+  'You will be given (a) a persona backstory and (b) a redacted snapshot',
+  'of the captured page. Your job: respond ONLY with a single JSON object',
+  'matching the willbuy VisitorOutput schema (spec §2 #15). Caps:',
+  '  first_impression  ≤ 400 chars',
+  '  questions[]       ≤ 10 × 200 chars',
+  '  confusions[]      ≤ 10 × 200 chars',
+  '  objections[]      ≤ 10 × 200 chars',
+  '  unanswered_blockers[] ≤ 10 × 200 chars',
+  '  reasoning         ≤ 1200 chars',
+  '  will_to_buy, confidence ∈ integer 0..10',
+  '  next_action ∈ {purchase_paid_today, contact_sales, book_demo,',
+  '                 start_paid_trial, bookmark_compare_later,',
+  '                 start_free_hobby, ask_teammate, leave}',
+  'Do NOT include commentary outside the JSON object. Do NOT wrap the',
+  'JSON in code fences. Output exactly one valid JSON object.',
+].join('\n');
+
+export function buildStaticPrefix(): string {
+  return STATIC_PREFIX;
+}
+
+function renderBackstory(b: BackstoryT): string {
+  // Stable ordering — labeled rendering reads better at the top of the
+  // prompt and is what the production prompt copy will likely use.
+  const lines = [
+    `name: ${b.name}`,
+    `role_archetype: ${b.role_archetype}`,
+    `stage: ${b.stage}`,
+    `team_size: ${b.team_size}`,
+    `managed_postgres: ${b.managed_postgres}`,
+    `current_pain: ${b.current_pain}`,
+    `entry_point: ${b.entry_point}`,
+    `regulated: ${b.regulated}`,
+    `postgres_depth: ${b.postgres_depth}`,
+    `budget_authority: ${b.budget_authority}`,
+  ];
+  return lines.join('\n');
+}
+
+export function buildDynamicTail(
+  backstory: BackstoryT,
+  pageSnapshot: string,
+): string {
+  return [
+    'BACKSTORY:',
+    renderBackstory(backstory),
+    '',
+    'PAGE_SNAPSHOT:',
+    pageSnapshot,
+  ].join('\n');
+}

--- a/apps/visitor-worker/src/prompt.ts
+++ b/apps/visitor-worker/src/prompt.ts
@@ -6,11 +6,21 @@
 // carve-out (the actual cache marker wiring is Sprint-2; here we just
 // guarantee determinism).
 //
-// The dynamic tail (per-visit) carries the persona-specific payload.
-// At this step the orchestrator only ever issues a single chat() call
-// per visit; the repair-tail builder lands with acceptance #2.
+// The dynamic tail (per-visit) and the repair tail (per-repair) carry
+// the persona-specific and prior-bad-output payloads. Per spec §2 #14
+// + §5.15, schema-repair retries are FRESH-CONTEXT calls: the prior
+// raw output is passed BACK as user-role content with a correction
+// instruction, NEVER as an assistant-role turn. This module builds
+// only user-role strings; the assertion that no assistant turn ever
+// reaches the model is therefore structural.
 
 import type { BackstoryT } from '@willbuy/shared';
+
+// Sentinel that lets tests grep the repair tail unambiguously to assert
+// the prior bad output is present as user content (not assistant role).
+// Public — used by tests in this package.
+export const PRIOR_BAD_OUTPUT_MARKER = 'PRIOR_BAD_OUTPUT_BEGIN';
+export const PRIOR_BAD_OUTPUT_END_MARKER = 'PRIOR_BAD_OUTPUT_END';
 
 // Spec §2 #14 carve-out: production prompt copy is tuned in the Sprint-3
 // 5-page benchmark. v0.1 ships a placeholder that is deterministic and
@@ -69,5 +79,32 @@ export function buildDynamicTail(
     '',
     'PAGE_SNAPSHOT:',
     pageSnapshot,
+  ].join('\n');
+}
+
+export function buildRepairTail(
+  backstory: BackstoryT,
+  pageSnapshot: string,
+  priorRawOutput: string,
+  validationError: string,
+): string {
+  // The repair payload is a SINGLE user-role string. The prior bad output
+  // is embedded between explicit markers so the model parses it as data,
+  // not as a continuation of its own prior turn. Per spec §2 #14 we never
+  // emit an assistant role — the orchestrator only ever calls chat() with
+  // staticPrefix + dynamicTail (one user payload), and chat() at the
+  // adapter level builds a single user-role message from those.
+  return [
+    buildDynamicTail(backstory, pageSnapshot),
+    '',
+    'PRIOR_ATTEMPT_FAILED_VALIDATION:',
+    `validation_error: ${validationError}`,
+    PRIOR_BAD_OUTPUT_MARKER,
+    priorRawOutput,
+    PRIOR_BAD_OUTPUT_END_MARKER,
+    '',
+    'Re-emit a fresh JSON object that obeys the VisitorOutput schema.',
+    'Do NOT echo the prior attempt. Do NOT reference your earlier output.',
+    'Output exactly one valid JSON object.',
   ].join('\n');
 }

--- a/apps/visitor-worker/src/visitor.ts
+++ b/apps/visitor-worker/src/visitor.ts
@@ -1,0 +1,29 @@
+// Spec §2 #14, §2 #15, §5.15 — visitor orchestrator. Skeleton only at
+// this commit; behavior lands in subsequent red→green pairs.
+
+import type { LLMProvider } from '@willbuy/llm-adapter';
+import type { BackstoryT, VisitorOutputT } from '@willbuy/shared';
+
+export type VisitStatus = 'ok' | 'failed';
+export type VisitFailureReason = 'schema' | 'transport' | 'cap';
+
+export interface VisitResult {
+  status: VisitStatus;
+  parsed?: VisitorOutputT;
+  raw?: string;
+  attempts: number;
+  failure_reason?: VisitFailureReason;
+}
+
+export interface RunVisitOptions {
+  provider: LLMProvider;
+  backstory: BackstoryT;
+  pageSnapshot: string;
+  visitId: string;
+}
+
+export async function runVisit(_opts: RunVisitOptions): Promise<VisitResult> {
+  // Skeleton placeholder — drives the package-skeleton test green.
+  // Behavior arrives in the next red→green pair.
+  return { status: 'failed', attempts: 0, failure_reason: 'transport' };
+}

--- a/apps/visitor-worker/src/visitor.ts
+++ b/apps/visitor-worker/src/visitor.ts
@@ -127,6 +127,22 @@ export async function runVisit(opts: RunVisitOptions): Promise<VisitResult> {
       maxOutputTokens: MAX_OUTPUT_TOKENS,
     });
 
+    if (chatResult.status === 'error') {
+      // Spec §5.15: transport retries are the adapter's job. The orchestrator
+      // does NOT schema-repair on a transport failure — the model never ran,
+      // so there is no prior raw output to feed back as repair input.
+      return {
+        status: 'failed',
+        attempts,
+        failure_reason: 'transport',
+        raw: chatResult.raw,
+      };
+    }
+
+    // Both 'ok' and 'indeterminate' carry a raw payload we can try to parse;
+    // 'indeterminate' is treated as best-effort here because spec §5.15's
+    // pessimistic-debit + reconciliation flow is owned by the adapter and
+    // the API server's spend ledger, not by this orchestrator.
     const parsed = tryParse(chatResult.raw);
     if (parsed.ok) {
       return {

--- a/apps/visitor-worker/src/visitor.ts
+++ b/apps/visitor-worker/src/visitor.ts
@@ -1,8 +1,16 @@
-// Spec §2 #14, §2 #15, §5.15 — visitor orchestrator. Skeleton only at
-// this commit; behavior lands in subsequent red→green pairs.
+// Spec §2 #14, §2 #15, §5.15 — visitor orchestrator.
+//
+// At this step (acceptance #1): a single chat() call, parse the result
+// against VisitorOutput, return ok. Transport-error and schema-repair
+// branches arrive in subsequent red→green pairs.
+
+import { createHash } from 'node:crypto';
 
 import type { LLMProvider } from '@willbuy/llm-adapter';
+import { VisitorOutput } from '@willbuy/shared';
 import type { BackstoryT, VisitorOutputT } from '@willbuy/shared';
+
+import { buildDynamicTail, buildStaticPrefix } from './prompt.js';
 
 export type VisitStatus = 'ok' | 'failed';
 export type VisitFailureReason = 'schema' | 'transport' | 'cap';
@@ -22,8 +30,52 @@ export interface RunVisitOptions {
   visitId: string;
 }
 
-export async function runVisit(_opts: RunVisitOptions): Promise<VisitResult> {
-  // Skeleton placeholder — drives the package-skeleton test green.
-  // Behavior arrives in the next red→green pair.
-  return { status: 'failed', attempts: 0, failure_reason: 'transport' };
+// Spec §2 #15 — the visitor call is capped at 800 output tokens.
+const MAX_OUTPUT_TOKENS = 800;
+
+// Spec §5.15 + issue #9: logical_request_key for the visit-kind call is
+// sha256(visitId || provider.name() || 'visit' || repair_generation).
+// Repair_generation increments on each schema-repair retry, yielding a
+// distinct logical key per generation; transport retries inside the
+// adapter share the key.
+export function computeLogicalRequestKey(
+  visitId: string,
+  providerName: string,
+  repairGeneration: number,
+): string {
+  const h = createHash('sha256');
+  h.update(visitId);
+  h.update('|');
+  h.update(providerName);
+  h.update('|');
+  h.update('visit');
+  h.update('|');
+  h.update(String(repairGeneration));
+  return h.digest('hex');
+}
+
+export async function runVisit(opts: RunVisitOptions): Promise<VisitResult> {
+  const staticPrefix = buildStaticPrefix();
+  const dynamicTail = buildDynamicTail(opts.backstory, opts.pageSnapshot);
+  const logicalRequestKey = computeLogicalRequestKey(
+    opts.visitId,
+    opts.provider.name(),
+    0,
+  );
+
+  const chatResult = await opts.provider.chat({
+    staticPrefix,
+    dynamicTail,
+    logicalRequestKey,
+    maxOutputTokens: MAX_OUTPUT_TOKENS,
+  });
+
+  const candidate: unknown = JSON.parse(chatResult.raw);
+  const parsed = VisitorOutput.parse(candidate);
+  return {
+    status: 'ok',
+    parsed,
+    raw: chatResult.raw,
+    attempts: 1,
+  };
 }

--- a/apps/visitor-worker/src/visitor.ts
+++ b/apps/visitor-worker/src/visitor.ts
@@ -1,8 +1,10 @@
 // Spec §2 #14, §2 #15, §5.15 — visitor orchestrator.
 //
-// At this step (acceptance #1): a single chat() call, parse the result
-// against VisitorOutput, return ok. Transport-error and schema-repair
-// branches arrive in subsequent red→green pairs.
+// At this step (acceptance #2): up to 1 schema-repair retry. On
+// validation failure we build a FRESH-CONTEXT repair call — prior bad
+// raw output passed back as user-role content only, NEVER as an
+// assistant turn — and retry once. The 2-repair upper bound and the
+// transport-error branch arrive in subsequent acceptance pairs.
 
 import { createHash } from 'node:crypto';
 
@@ -10,7 +12,11 @@ import type { LLMProvider } from '@willbuy/llm-adapter';
 import { VisitorOutput } from '@willbuy/shared';
 import type { BackstoryT, VisitorOutputT } from '@willbuy/shared';
 
-import { buildDynamicTail, buildStaticPrefix } from './prompt.js';
+import {
+  buildDynamicTail,
+  buildRepairTail,
+  buildStaticPrefix,
+} from './prompt.js';
 
 export type VisitStatus = 'ok' | 'failed';
 export type VisitFailureReason = 'schema' | 'transport' | 'cap';
@@ -33,6 +39,13 @@ export interface RunVisitOptions {
 // Spec §2 #15 — the visitor call is capped at 800 output tokens.
 const MAX_OUTPUT_TOKENS = 800;
 
+// Spec §2 #14: up to 2 schema-repair retries. With the initial attempt
+// that's 3 chat() calls maximum per visit (repair_generation = 0, 1, 2).
+// At this acceptance step we only need >= 1 to drive the test green;
+// acceptance #3 raises this to the spec maximum and adds the failed/
+// schema return path.
+const MAX_REPAIR_GENERATION = 1;
+
 // Spec §5.15 + issue #9: logical_request_key for the visit-kind call is
 // sha256(visitId || provider.name() || 'visit' || repair_generation).
 // Repair_generation increments on each schema-repair retry, yielding a
@@ -54,28 +67,87 @@ export function computeLogicalRequestKey(
   return h.digest('hex');
 }
 
+function tryParse(
+  raw: string,
+):
+  | { ok: true; parsed: VisitorOutputT }
+  | { ok: false; error: string } {
+  let candidate: unknown;
+  try {
+    candidate = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `JSON.parse failed: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+  const result = VisitorOutput.safeParse(candidate);
+  if (result.success) {
+    return { ok: true, parsed: result.data };
+  }
+  // Compact zod issue summary — keeps the repair prompt small. Each issue
+  // becomes "<path>: <message>" so the model can target the failing field.
+  const summary = result.error.issues
+    .map((iss) => `${iss.path.join('.') || '<root>'}: ${iss.message}`)
+    .join('; ');
+  return { ok: false, error: summary };
+}
+
 export async function runVisit(opts: RunVisitOptions): Promise<VisitResult> {
   const staticPrefix = buildStaticPrefix();
-  const dynamicTail = buildDynamicTail(opts.backstory, opts.pageSnapshot);
-  const logicalRequestKey = computeLogicalRequestKey(
-    opts.visitId,
-    opts.provider.name(),
-    0,
-  );
+  const providerName = opts.provider.name();
 
-  const chatResult = await opts.provider.chat({
-    staticPrefix,
-    dynamicTail,
-    logicalRequestKey,
-    maxOutputTokens: MAX_OUTPUT_TOKENS,
-  });
+  let attempts = 0;
+  let lastRaw = '';
+  let lastValidationError = '';
 
-  const candidate: unknown = JSON.parse(chatResult.raw);
-  const parsed = VisitorOutput.parse(candidate);
+  for (
+    let repairGeneration = 0;
+    repairGeneration <= MAX_REPAIR_GENERATION;
+    repairGeneration += 1
+  ) {
+    const dynamicTail =
+      repairGeneration === 0
+        ? buildDynamicTail(opts.backstory, opts.pageSnapshot)
+        : buildRepairTail(
+            opts.backstory,
+            opts.pageSnapshot,
+            lastRaw,
+            lastValidationError,
+          );
+
+    const logicalRequestKey = computeLogicalRequestKey(
+      opts.visitId,
+      providerName,
+      repairGeneration,
+    );
+
+    attempts += 1;
+    const chatResult = await opts.provider.chat({
+      staticPrefix,
+      dynamicTail,
+      logicalRequestKey,
+      maxOutputTokens: MAX_OUTPUT_TOKENS,
+    });
+
+    const parsed = tryParse(chatResult.raw);
+    if (parsed.ok) {
+      return {
+        status: 'ok',
+        parsed: parsed.parsed,
+        raw: chatResult.raw,
+        attempts,
+      };
+    }
+
+    lastRaw = chatResult.raw;
+    lastValidationError = parsed.error;
+  }
+
   return {
-    status: 'ok',
-    parsed,
-    raw: chatResult.raw,
-    attempts: 1,
+    status: 'failed',
+    attempts,
+    failure_reason: 'schema',
+    raw: lastRaw,
   };
 }

--- a/apps/visitor-worker/src/visitor.ts
+++ b/apps/visitor-worker/src/visitor.ts
@@ -41,10 +41,7 @@ const MAX_OUTPUT_TOKENS = 800;
 
 // Spec §2 #14: up to 2 schema-repair retries. With the initial attempt
 // that's 3 chat() calls maximum per visit (repair_generation = 0, 1, 2).
-// At this acceptance step we only need >= 1 to drive the test green;
-// acceptance #3 raises this to the spec maximum and adds the failed/
-// schema return path.
-const MAX_REPAIR_GENERATION = 1;
+const MAX_REPAIR_GENERATION = 2;
 
 // Spec §5.15 + issue #9: logical_request_key for the visit-kind call is
 // sha256(visitId || provider.name() || 'visit' || repair_generation).

--- a/apps/visitor-worker/test/helpers/fixtures.ts
+++ b/apps/visitor-worker/test/helpers/fixtures.ts
@@ -1,0 +1,39 @@
+import type { BackstoryT, VisitorOutputT } from '@willbuy/shared';
+
+// A backstory shape that satisfies the @willbuy/shared zod schema —
+// kept inline (not loaded from packages/shared/test/fixtures) so a
+// future schema change forces a deliberate update here.
+export const SAMPLE_BACKSTORY: BackstoryT = {
+  name: 'Maya',
+  role_archetype: 'founder_or_eng_lead',
+  stage: 'series_a',
+  team_size: 12,
+  managed_postgres: 'supabase',
+  current_pain: 'upcoming_scale_event',
+  entry_point: 'newsletter',
+  regulated: 'no',
+  postgres_depth: 'light',
+  budget_authority: 'self',
+};
+
+export const SAMPLE_PAGE_SNAPSHOT =
+  'a11y-tree(redacted) Pricing page header: Postgres-as-a-Service. Tiers: hobby $0, starter $29, scale $99.';
+
+// Spec §2 #15-shaped valid visitor output.
+export const VALID_VISITOR_OUTPUT: VisitorOutputT = {
+  first_impression:
+    'Pricing page leads with a managed Postgres pitch; tiers are visible above the fold.',
+  will_to_buy: 7,
+  questions: ['Is there a self-hosted option?'],
+  confusions: ['Connections cap unclear — pooled or client?'],
+  objections: ['$99/mo is steep for a 2-eng team already on RDS.'],
+  unanswered_blockers: ['No SOC2 mention — fintech blocker.'],
+  next_action: 'contact_sales',
+  confidence: 8,
+  reasoning:
+    'Strong pricing-page clarity but missing compliance signals; for a regulated fintech buyer the next step is sales.',
+};
+
+export function validVisitorJsonString(): string {
+  return JSON.stringify(VALID_VISITOR_OUTPUT);
+}

--- a/apps/visitor-worker/test/helpers/mockProvider.ts
+++ b/apps/visitor-worker/test/helpers/mockProvider.ts
@@ -1,0 +1,66 @@
+// Test-only LLMProvider double. Records every chat() call (so tests can
+// assert on dynamicTail / staticPrefix / logicalRequestKey content) and
+// returns a scripted sequence of results — the orchestrator under test
+// then drives schema-repair + transport-error branches off those returns.
+
+import type {
+  LLMChatOptions,
+  LLMChatResult,
+  LLMProvider,
+  LLMProviderCapabilities,
+} from '@willbuy/llm-adapter';
+
+export interface RecordedChat {
+  staticPrefix: string;
+  dynamicTail: string;
+  logicalRequestKey: string;
+  maxOutputTokens: number;
+}
+
+export interface MockProviderOptions {
+  name?: string;
+  capabilities?: LLMProviderCapabilities;
+  responses: ReadonlyArray<LLMChatResult>;
+}
+
+export class MockProvider implements LLMProvider {
+  readonly calls: RecordedChat[] = [];
+  private readonly responses: ReadonlyArray<LLMChatResult>;
+  private readonly providerName: string;
+  private readonly caps: LLMProviderCapabilities;
+
+  constructor(opts: MockProviderOptions) {
+    this.responses = opts.responses;
+    this.providerName = opts.name ?? 'mock-provider';
+    this.caps = opts.capabilities ?? {
+      idempotency: false,
+      zero_retention: false,
+      structured_output: false,
+      prompt_caching: false,
+    };
+  }
+
+  name(): string {
+    return this.providerName;
+  }
+  capabilities(): LLMProviderCapabilities {
+    return this.caps;
+  }
+  // eslint-disable-next-line @typescript-eslint/require-await
+  async chat(opts: LLMChatOptions): Promise<LLMChatResult> {
+    this.calls.push({
+      staticPrefix: opts.staticPrefix,
+      dynamicTail: opts.dynamicTail,
+      logicalRequestKey: opts.logicalRequestKey,
+      maxOutputTokens: opts.maxOutputTokens,
+    });
+    const idx = this.calls.length - 1;
+    const r = this.responses[idx];
+    if (r === undefined) {
+      throw new Error(
+        `MockProvider exhausted: chat() call #${idx + 1} but only ${this.responses.length} scripted responses`,
+      );
+    }
+    return r;
+  }
+}

--- a/apps/visitor-worker/test/helpers/mockProvider.ts
+++ b/apps/visitor-worker/test/helpers/mockProvider.ts
@@ -46,7 +46,6 @@ export class MockProvider implements LLMProvider {
   capabilities(): LLMProviderCapabilities {
     return this.caps;
   }
-  // eslint-disable-next-line @typescript-eslint/require-await
   async chat(opts: LLMChatOptions): Promise<LLMChatResult> {
     this.calls.push({
       staticPrefix: opts.staticPrefix,

--- a/apps/visitor-worker/test/logicalRequestKey.test.ts
+++ b/apps/visitor-worker/test/logicalRequestKey.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+
+import * as visitorWorker from '../src/index.js';
+
+// Issue #9 acceptance #5 (spec §5.15): logical_request_key is
+// sha256(visitId || providerName || 'visit' || repair_generation).
+// The function is exported from the package BARREL so other packages
+// (notably the API server's spend ledger and the daily reconciliation
+// job) can compute the same key without reaching into internals.
+//
+// Properties:
+//   (a) byte-identical for the same (visitId, providerName, generation) —
+//       so transport retries inside the adapter share a key and provider-
+//       side idempotency dedupes;
+//   (b) differs across repair_generation values — schema-repair = NEW
+//       logical key (semantically a fresh logical request);
+//   (c) differs across visitId values (same generation);
+//   (d) differs across providerName values (same visit, same generation).
+
+describe('@willbuy/visitor-worker barrel — acceptance #5: computeLogicalRequestKey is publicly exported with stable semantics', () => {
+  it('is exported from the package index entrypoint', () => {
+    expect(typeof visitorWorker.computeLogicalRequestKey).toBe('function');
+  });
+
+  it('returns a byte-identical hex digest for the same (visitId, providerName, repair_generation)', () => {
+    const a = visitorWorker.computeLogicalRequestKey(
+      'visit-acc-5',
+      'mock-provider',
+      0,
+    );
+    const b = visitorWorker.computeLogicalRequestKey(
+      'visit-acc-5',
+      'mock-provider',
+      0,
+    );
+    expect(a).toBe(b);
+    // Sanity: it is a hex sha256 — 64 lowercase hex chars.
+    expect(a).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it('returns DIFFERENT keys for different repair_generation values (same visit)', () => {
+    const gen0 = visitorWorker.computeLogicalRequestKey(
+      'visit-acc-5',
+      'mock-provider',
+      0,
+    );
+    const gen1 = visitorWorker.computeLogicalRequestKey(
+      'visit-acc-5',
+      'mock-provider',
+      1,
+    );
+    const gen2 = visitorWorker.computeLogicalRequestKey(
+      'visit-acc-5',
+      'mock-provider',
+      2,
+    );
+    expect(gen0).not.toBe(gen1);
+    expect(gen1).not.toBe(gen2);
+    expect(gen0).not.toBe(gen2);
+  });
+
+  it('returns DIFFERENT keys for different visitId values (same generation)', () => {
+    const a = visitorWorker.computeLogicalRequestKey(
+      'visit-X',
+      'mock-provider',
+      0,
+    );
+    const b = visitorWorker.computeLogicalRequestKey(
+      'visit-Y',
+      'mock-provider',
+      0,
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('returns DIFFERENT keys for different provider names (same visit, same generation)', () => {
+    const a = visitorWorker.computeLogicalRequestKey(
+      'visit-acc-5',
+      'provider-A',
+      0,
+    );
+    const b = visitorWorker.computeLogicalRequestKey(
+      'visit-acc-5',
+      'provider-B',
+      0,
+    );
+    expect(a).not.toBe(b);
+  });
+});

--- a/apps/visitor-worker/test/runVisit.happyPath.test.ts
+++ b/apps/visitor-worker/test/runVisit.happyPath.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+
+import { runVisit } from '../src/index.js';
+import { MockProvider } from './helpers/mockProvider.js';
+import {
+  SAMPLE_BACKSTORY,
+  SAMPLE_PAGE_SNAPSHOT,
+  VALID_VISITOR_OUTPUT,
+  validVisitorJsonString,
+} from './helpers/fixtures.js';
+
+// Issue #9 acceptance #1 (spec §2 #14): mocked provider returns valid JSON
+// on the first call → status='ok', attempts=1, parsed equals VALID payload.
+
+describe('runVisit — acceptance #1: valid JSON on first call', () => {
+  it('returns status="ok" with attempts=1 and the parsed VisitorOutput', async () => {
+    const provider = new MockProvider({
+      responses: [
+        {
+          raw: validVisitorJsonString(),
+          transportAttempts: 1,
+          status: 'ok',
+        },
+      ],
+    });
+
+    const result = await runVisit({
+      provider,
+      backstory: SAMPLE_BACKSTORY,
+      pageSnapshot: SAMPLE_PAGE_SNAPSHOT,
+      visitId: 'visit-acc-1',
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.attempts).toBe(1);
+    expect(result.failure_reason).toBeUndefined();
+    expect(result.parsed).toEqual(VALID_VISITOR_OUTPUT);
+    expect(result.raw).toBe(validVisitorJsonString());
+    // Exactly one upstream chat() call — no schema repair, no transport
+    // re-issue from the orchestrator.
+    expect(provider.calls).toHaveLength(1);
+  });
+});

--- a/apps/visitor-worker/test/runVisit.schemaFail.test.ts
+++ b/apps/visitor-worker/test/runVisit.schemaFail.test.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest';
+
+import { runVisit } from '../src/index.js';
+import { computeLogicalRequestKey } from '../src/visitor.js';
+import { MockProvider } from './helpers/mockProvider.js';
+import {
+  SAMPLE_BACKSTORY,
+  SAMPLE_PAGE_SNAPSHOT,
+} from './helpers/fixtures.js';
+
+// Issue #9 acceptance #3 (spec §2 #14): three invalid responses in a row
+// → status='failed', failure_reason='schema', attempts=3. Spec §2 #14
+// caps schema-repair retries at 2 per logical request; with the initial
+// attempt that's exactly 3 chat() calls.
+
+describe('runVisit — acceptance #3: invalid 3 times → failed/schema', () => {
+  it('returns failed with failure_reason="schema" and attempts=3 after 3 invalid responses', async () => {
+    const bad1 = '{"first_impression": "bad-1"}';
+    const bad2 = '{"first_impression": "bad-2"}';
+    const bad3 = '{"first_impression": "bad-3"}';
+
+    const provider = new MockProvider({
+      responses: [
+        { raw: bad1, transportAttempts: 1, status: 'ok' },
+        { raw: bad2, transportAttempts: 1, status: 'ok' },
+        { raw: bad3, transportAttempts: 1, status: 'ok' },
+      ],
+    });
+
+    const result = await runVisit({
+      provider,
+      backstory: SAMPLE_BACKSTORY,
+      pageSnapshot: SAMPLE_PAGE_SNAPSHOT,
+      visitId: 'visit-acc-3',
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.failure_reason).toBe('schema');
+    expect(result.attempts).toBe(3);
+    expect(result.parsed).toBeUndefined();
+    // Last raw payload is preserved on failed/schema for observability.
+    expect(result.raw).toBe(bad3);
+
+    expect(provider.calls).toHaveLength(3);
+
+    // Spec §5.15: each schema-repair generation gets a NEW logical key.
+    // Three calls → three distinct keys, each matching the canonical
+    // sha256(visitId || providerName || 'visit' || generation) form.
+    const keys = provider.calls.map((c) => c.logicalRequestKey);
+    expect(new Set(keys).size).toBe(3);
+
+    expect(keys[0]).toBe(
+      computeLogicalRequestKey('visit-acc-3', provider.name(), 0),
+    );
+    expect(keys[1]).toBe(
+      computeLogicalRequestKey('visit-acc-3', provider.name(), 1),
+    );
+    expect(keys[2]).toBe(
+      computeLogicalRequestKey('visit-acc-3', provider.name(), 2),
+    );
+  });
+});

--- a/apps/visitor-worker/test/runVisit.schemaRepair.test.ts
+++ b/apps/visitor-worker/test/runVisit.schemaRepair.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+
+import { runVisit } from '../src/index.js';
+import {
+  PRIOR_BAD_OUTPUT_END_MARKER,
+  PRIOR_BAD_OUTPUT_MARKER,
+} from '../src/prompt.js';
+import { MockProvider } from './helpers/mockProvider.js';
+import {
+  SAMPLE_BACKSTORY,
+  SAMPLE_PAGE_SNAPSHOT,
+  VALID_VISITOR_OUTPUT,
+  validVisitorJsonString,
+} from './helpers/fixtures.js';
+
+// Issue #9 acceptance #2 (spec §2 #14, §5.15): mocked provider returns
+// invalid JSON on the first call, valid on the second → status='ok',
+// attempts=2. The second chat() invocation MUST contain the prior bad
+// output as user-role content (no assistant-role turn anywhere) and
+// MUST carry a NEW logical_request_key (repair_generation incremented).
+
+describe('runVisit — acceptance #2: invalid then valid JSON', () => {
+  it('schema-repairs once, returns ok with attempts=2; second call carries prior bad output as user content with a new logical key', async () => {
+    const priorBad =
+      '{"first_impression": "missing required fields, only this one present"}';
+
+    const provider = new MockProvider({
+      responses: [
+        // Call #1: structurally JSON, semantically wrong → triggers repair.
+        { raw: priorBad, transportAttempts: 1, status: 'ok' },
+        // Call #2: valid VisitorOutput.
+        {
+          raw: validVisitorJsonString(),
+          transportAttempts: 1,
+          status: 'ok',
+        },
+      ],
+    });
+
+    const result = await runVisit({
+      provider,
+      backstory: SAMPLE_BACKSTORY,
+      pageSnapshot: SAMPLE_PAGE_SNAPSHOT,
+      visitId: 'visit-acc-2',
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.attempts).toBe(2);
+    expect(result.failure_reason).toBeUndefined();
+    expect(result.parsed).toEqual(VALID_VISITOR_OUTPUT);
+
+    expect(provider.calls).toHaveLength(2);
+
+    const firstCall = provider.calls[0]!;
+    const secondCall = provider.calls[1]!;
+
+    // Spec §2 #14 + §5.15: the prior bad output is presented to the model
+    // as USER content (the dynamicTail is the single user-role payload at
+    // the adapter's chat() boundary; the LLMChatOptions surface has no
+    // assistant-role channel by design — fresh-context guarantee).
+    expect(secondCall.dynamicTail).toContain(priorBad);
+    expect(secondCall.dynamicTail).toContain(PRIOR_BAD_OUTPUT_MARKER);
+    expect(secondCall.dynamicTail).toContain(PRIOR_BAD_OUTPUT_END_MARKER);
+
+    // Defense-in-depth grep: the repair tail must not casually use the
+    // word "assistant" — that would lie about the role boundary even
+    // though the API surface enforces it.
+    expect(secondCall.dynamicTail.toLowerCase()).not.toContain('assistant');
+
+    // Static prefix is byte-identical across both calls (cacheable prefix
+    // invariant per spec §1).
+    expect(secondCall.staticPrefix).toBe(firstCall.staticPrefix);
+
+    // Logical request key MUST differ between repair generations
+    // (spec §5.15: schema-repair = NEW logical key).
+    expect(secondCall.logicalRequestKey).not.toBe(firstCall.logicalRequestKey);
+  });
+});

--- a/apps/visitor-worker/test/runVisit.transportError.test.ts
+++ b/apps/visitor-worker/test/runVisit.transportError.test.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest';
+
+import { runVisit } from '../src/index.js';
+import { MockProvider } from './helpers/mockProvider.js';
+import {
+  SAMPLE_BACKSTORY,
+  SAMPLE_PAGE_SNAPSHOT,
+} from './helpers/fixtures.js';
+
+// Issue #9 acceptance #4 (spec §5.15): when the adapter returns
+// status='error', the orchestrator does NOT schema-repair — that path
+// is reserved for cases where the model actually ran and produced
+// (mis-shaped) output. Spec §5.15: transport retries are inside the
+// adapter; the orchestrator's job on transport failure is to surface
+// failure_reason='transport' and stop.
+
+describe('runVisit — acceptance #4: chat() returns status="error"', () => {
+  it('returns failed with failure_reason="transport" and attempts=1; NO schema repair attempted', async () => {
+    const provider = new MockProvider({
+      responses: [
+        // Spec §5.15 / §4.1 LocalCliProvider: empty raw + status='error'
+        // is the canonical transport-error shape returned by the adapter.
+        { raw: '', transportAttempts: 1, status: 'error' },
+        // No further responses — if the orchestrator schema-repairs here,
+        // MockProvider would throw "exhausted", which would surface as
+        // a different failure mode and make the test red for the wrong
+        // reason. With this single-response script, an extra chat()
+        // call is structurally observable.
+      ],
+    });
+
+    const result = await runVisit({
+      provider,
+      backstory: SAMPLE_BACKSTORY,
+      pageSnapshot: SAMPLE_PAGE_SNAPSHOT,
+      visitId: 'visit-acc-4',
+    });
+
+    expect(result.status).toBe('failed');
+    expect(result.failure_reason).toBe('transport');
+    expect(result.attempts).toBe(1);
+    expect(result.parsed).toBeUndefined();
+
+    // Exactly one chat() call — the orchestrator did not schema-repair
+    // through the transport-error branch.
+    expect(provider.calls).toHaveLength(1);
+  });
+});

--- a/apps/visitor-worker/test/skeleton.test.ts
+++ b/apps/visitor-worker/test/skeleton.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it } from 'vitest';
+
+// Acceptance #0 (skeleton): the package exports `runVisit` and the
+// `VisitResult` type contract documented on issue #9.
+//
+// This sits ahead of every behavioral acceptance — it is the smallest
+// red→green pair that proves the module wires up, before any LLM logic.
+
+describe('@willbuy/visitor-worker — package skeleton (issue #9)', () => {
+  it('exports runVisit as a function from the index entrypoint', async () => {
+    const mod = await import('../src/index.js');
+    expect(typeof mod.runVisit).toBe('function');
+  });
+});

--- a/apps/visitor-worker/tsconfig.json
+++ b/apps/visitor-worker/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../../tsconfig.base.json",
+  "compilerOptions": {
+    "outDir": "dist",
+    "rootDir": ".",
+    "types": ["node"],
+    "noEmit": true
+  },
+  "include": ["src/**/*", "test/**/*", "vitest.config.ts"],
+  "exclude": ["dist", "node_modules"]
+}

--- a/apps/visitor-worker/vitest.config.ts
+++ b/apps/visitor-worker/vitest.config.ts
@@ -1,0 +1,9 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    include: ['test/**/*.test.ts'],
+    environment: 'node',
+    testTimeout: 15_000,
+  },
+});

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -80,6 +80,28 @@ importers:
         specifier: ^2.1.8
         version: 2.1.9(@types/node@22.19.17)
 
+  apps/visitor-worker:
+    dependencies:
+      '@willbuy/llm-adapter':
+        specifier: workspace:*
+        version: link:../../packages/llm-adapter
+      '@willbuy/shared':
+        specifier: workspace:*
+        version: link:../../packages/shared
+      zod:
+        specifier: ^3.23.8
+        version: 3.25.76
+    devDependencies:
+      '@types/node':
+        specifier: ^22.10.2
+        version: 22.19.17
+      typescript:
+        specifier: ^5.7.2
+        version: 5.9.3
+      vitest:
+        specifier: ^2.1.8
+        version: 2.1.9(@types/node@22.19.17)
+
   apps/web:
     dependencies:
       '@willbuy/shared':


### PR DESCRIPTION
Closes #9

## Summary

`apps/visitor-worker` ships `runVisit(opts) -> VisitResult`: builds the visitor prompt, calls `LLMProvider.chat`, validates against `VisitorOutput` zod from `@willbuy/shared`, and on validation failure issues a fresh-context schema-repair retry up to twice — each retry a NEW logical-request key, prior bad output passed back as user-role content only (NEVER as an assistant-role turn). On adapter `status: 'error'` (transport failure) the orchestrator returns `failed/transport` immediately — transport retries are the adapter's responsibility per spec §5.15.

## Spec link

Implements **spec §2 #14** (up to 2 schema-repair retries; fresh-context — no carried-over assistant turns) + **spec §2 #15** (strict `VisitorOutput` schema, `max_tokens=800`) + **spec §5.15** (logical-request key vs transport attempts; `repair_generation` increments → new logical key; transport retries reuse the key inside the adapter; orchestrator does not transport-retry).

Inherits **amendment A1** automatically through the `VisitorOutput` zod from `@willbuy/shared` — no `next_action` enum literal appears in this package.

## Files

- `apps/visitor-worker/src/index.ts` — package barrel.
- `apps/visitor-worker/src/visitor.ts` — `runVisit` orchestrator + `computeLogicalRequestKey`.
- `apps/visitor-worker/src/prompt.ts` — `buildStaticPrefix` (deterministic, byte-identical across visits → cacheable prefix invariant), `buildDynamicTail`, `buildRepairTail` (single user-role payload with explicit `PRIOR_BAD_OUTPUT_BEGIN` / `PRIOR_BAD_OUTPUT_END` markers; defense-in-depth grep asserts no "assistant" string in the repair tail).
- `apps/visitor-worker/test/` — 6 test files, 10 tests; `MockProvider` test double records every chat call and replays scripted responses.

## Test evidence — red → green commit history

Linear, no merges:

```
e007160 visitor-worker: refactor — drop stale eslint-disable in test mock
49b4b56 visitor-worker: green — acc#5 promote computeLogicalRequestKey to package barrel
1cb9e67 visitor-worker: red — acc#5 publicly export computeLogicalRequestKey + key stability
22fb865 visitor-worker: green — acc#4 transport-error early return, no schema repair
3027c25 visitor-worker: red — acc#4 chat() error → failed/transport, attempts=1, no schema repair
d17b19d visitor-worker: green — acc#3 raise MAX_REPAIR_GENERATION to spec cap of 2
00fc1ee visitor-worker: red — acc#3 invalid 3 times → failed/schema, attempts=3
2d2061e visitor-worker: green — acc#2 schema-repair loop with fresh-context retry
f063dbc visitor-worker: red — acc#2 invalid then valid → ok, attempts=2, fresh-context repair
b21c04f visitor-worker: green — acc#1 single chat() call, parse, return ok
3f6e312 visitor-worker: red — acc#1 valid JSON first call → ok, attempts=1
45dcdf5 visitor-worker: green — index barrel + runVisit skeleton (issue #9)
fdcae49 visitor-worker: red — package skeleton + runVisit export test
```

Each red commit was verified to fail before the matching green commit landed; each green commit added the minimum diff needed to flip its red to passing. Acceptance #2's green caps `MAX_REPAIR_GENERATION = 1` so acceptance #3 can drive the spec cap of 2 with a real red.

### `pnpm test --filter @willbuy/visitor-worker` (final)

```
 RUN  v2.1.9 /Users/nik/github/willbuy-wt-9-visitor/apps/visitor-worker

 ✓ test/skeleton.test.ts (1 test) 25ms
 ✓ test/logicalRequestKey.test.ts (5 tests) 1ms
 ✓ test/runVisit.transportError.test.ts (1 test) 2ms
 ✓ test/runVisit.schemaRepair.test.ts (1 test) 3ms
 ✓ test/runVisit.schemaFail.test.ts (1 test) 2ms
 ✓ test/runVisit.happyPath.test.ts (1 test) 2ms

 Test Files  6 passed (6)
      Tests  10 passed (10)
```

Repo-wide `pnpm test`: **82 passed, 1 skipped** (no regressions). `pnpm typecheck` and `pnpm lint` both clean.

### Acceptance map → test files

| # | Issue scenario                                                                | Test file |
| - | ----------------------------------------------------------------------------- | --------- |
| 1 | Mocked provider returns valid JSON on first call → `ok`, `attempts=1`          | `test/runVisit.happyPath.test.ts` |
| 2 | Returns invalid JSON, then valid → `ok`, `attempts=2`; second call's prompt contains prior bad output as USER role only (no assistant role); new logical key | `test/runVisit.schemaRepair.test.ts` |
| 3 | Returns invalid 3 times → `failed`, `failure_reason=schema`, `attempts=3`; three distinct logical keys, each matching the canonical `sha256(visitId\|providerName\|'visit'\|generation)` | `test/runVisit.schemaFail.test.ts` |
| 4 | Returns `status: 'error'` → `failed`, `failure_reason=transport`, `attempts=1`, no schema repair | `test/runVisit.transportError.test.ts` |
| 5 | Logical request key byte-identical for same `visitId + repair_generation`; differs across `repair_generation` | `test/logicalRequestKey.test.ts` |

### Public-repo audit

- No secrets, tokens, IPs, or vendor-specific identifiers in the diff. The provider name surfaces only via `provider.name()` which the adapter resolves to the generic `'local-cli'` constant introduced in #5.
- `grep -rEn "claude|anthropic|openai|gpt|sk-[a-z0-9]"` over `apps/visitor-worker/`: zero hits.
- `grep` for the spec §2 #15 reserved continuation identifiers (`session_id|conversation_id|thread_id|previous_response_id|cached_prompt_id|parent_message_id|run_id`) over `apps/visitor-worker/`: zero hits. AST lint (`willbuy/no-reserved-llm-identifiers`) passes.