### PR TITLE
fix(visitor-worker): include model in logical_request_key per spec §5.15

### DIFF
--- a/apps/visitor-worker/src/visitor.ts
+++ b/apps/visitor-worker/src/visitor.ts
@@ -1,10 +1,11 @@
 // Spec §2 #14, §2 #15, §5.15 — visitor orchestrator.
 //
-// At this step (acceptance #2): up to 1 schema-repair retry. On
-// validation failure we build a FRESH-CONTEXT repair call — prior bad
-// raw output passed back as user-role content only, NEVER as an
-// assistant turn — and retry once. The 2-repair upper bound and the
-// transport-error branch arrive in subsequent acceptance pairs.
+// On schema-validation failure we build a FRESH-CONTEXT repair call —
+// prior bad raw output passed back as user-role content only, NEVER as
+// an assistant turn — and retry up to MAX_REPAIR_GENERATION times. Each
+// repair generation gets a NEW logical_request_key (§5.15 line 253 form
+// `sha256(visit_id || provider || model || 'visit' || repair_generation)`);
+// transport retries inside the adapter share the key.
 
 import { createHash } from 'node:crypto';
 
@@ -43,20 +44,27 @@ const MAX_OUTPUT_TOKENS = 800;
 // that's 3 chat() calls maximum per visit (repair_generation = 0, 1, 2).
 const MAX_REPAIR_GENERATION = 2;
 
-// Spec §5.15 + issue #9: logical_request_key for the visit-kind call is
-// sha256(visitId || provider.name() || 'visit' || repair_generation).
+// Spec §5.15 line 253 + §5.1 step 7 line 131 + §2 #15:
+//   logical_request_key = sha256(
+//     visit_id || provider || model || request_kind || repair_generation
+//   )
 // Repair_generation increments on each schema-repair retry, yielding a
 // distinct logical key per generation; transport retries inside the
-// adapter share the key.
+// adapter share the key. The `model` component (added per issue #23 / B1)
+// guards the §5.15 collision case where a model bump on the same provider
+// would otherwise reuse a provider-side Idempotency-Key.
 export function computeLogicalRequestKey(
   visitId: string,
   providerName: string,
+  modelName: string,
   repairGeneration: number,
 ): string {
   const h = createHash('sha256');
   h.update(visitId);
   h.update('|');
   h.update(providerName);
+  h.update('|');
+  h.update(modelName);
   h.update('|');
   h.update('visit');
   h.update('|');
@@ -93,6 +101,11 @@ function tryParse(
 export async function runVisit(opts: RunVisitOptions): Promise<VisitResult> {
   const staticPrefix = buildStaticPrefix();
   const providerName = opts.provider.name();
+  // Spec §5.15: pin the model identity once per visit so all repair
+  // generations of one visit hash against the same model. A mid-visit
+  // env-var bump would otherwise produce non-comparable keys across
+  // generation 0 / 1 / 2 of the SAME logical visit.
+  const modelName = opts.provider.model();
 
   let attempts = 0;
   let lastRaw = '';
@@ -116,6 +129,7 @@ export async function runVisit(opts: RunVisitOptions): Promise<VisitResult> {
     const logicalRequestKey = computeLogicalRequestKey(
       opts.visitId,
       providerName,
+      modelName,
       repairGeneration,
     );
 

--- a/apps/visitor-worker/test/helpers/mockProvider.ts
+++ b/apps/visitor-worker/test/helpers/mockProvider.ts
@@ -19,6 +19,7 @@ export interface RecordedChat {
 
 export interface MockProviderOptions {
   name?: string;
+  model?: string;
   capabilities?: LLMProviderCapabilities;
   responses: ReadonlyArray<LLMChatResult>;
 }
@@ -27,11 +28,13 @@ export class MockProvider implements LLMProvider {
   readonly calls: RecordedChat[] = [];
   private readonly responses: ReadonlyArray<LLMChatResult>;
   private readonly providerName: string;
+  private readonly modelName: string;
   private readonly caps: LLMProviderCapabilities;
 
   constructor(opts: MockProviderOptions) {
     this.responses = opts.responses;
     this.providerName = opts.name ?? 'mock-provider';
+    this.modelName = opts.model ?? 'mock-model';
     this.caps = opts.capabilities ?? {
       idempotency: false,
       zero_retention: false,
@@ -42,6 +45,9 @@ export class MockProvider implements LLMProvider {
 
   name(): string {
     return this.providerName;
+  }
+  model(): string {
+    return this.modelName;
   }
   capabilities(): LLMProviderCapabilities {
     return this.caps;

--- a/apps/visitor-worker/test/logicalRequestKey.test.ts
+++ b/apps/visitor-worker/test/logicalRequestKey.test.ts
@@ -2,35 +2,45 @@ import { describe, expect, it } from 'vitest';
 
 import * as visitorWorker from '../src/index.js';
 
-// Issue #9 acceptance #5 (spec §5.15): logical_request_key is
-// sha256(visitId || providerName || 'visit' || repair_generation).
+// Issue #23 / B1 (spec §5.15 line 253, §5.1 step 7 line 131, §2 #15):
+//   logical_request_key = sha256(
+//     visit_id || provider || model || request_kind || repair_generation
+//   )
+//
 // The function is exported from the package BARREL so other packages
 // (notably the API server's spend ledger and the daily reconciliation
-// job) can compute the same key without reaching into internals.
+// job — see §2 #16 `provider_attempts.logical_request_key UNIQUE` +
+// `model`) can compute the same key without reaching into internals.
 //
 // Properties:
-//   (a) byte-identical for the same (visitId, providerName, generation) —
-//       so transport retries inside the adapter share a key and provider-
-//       side idempotency dedupes;
+//   (a) byte-identical for the same (visitId, providerName, modelName,
+//       generation) — so transport retries inside the adapter share a
+//       key and provider-side idempotency dedupes;
 //   (b) differs across repair_generation values — schema-repair = NEW
 //       logical key (semantically a fresh logical request);
 //   (c) differs across visitId values (same generation);
-//   (d) differs across providerName values (same visit, same generation).
+//   (d) differs across providerName values (same visit, same generation);
+//   (e) differs across modelName values (same visit, same provider, same
+//       generation) — guards the §5.15 collision case where two visits
+//       run against the same provider but a bumped model would otherwise
+//       reuse a provider-side Idempotency-Key.
 
-describe('@willbuy/visitor-worker barrel — acceptance #5: computeLogicalRequestKey is publicly exported with stable semantics', () => {
+describe('@willbuy/visitor-worker barrel — computeLogicalRequestKey is publicly exported with stable semantics (incl. model component per spec §5.15)', () => {
   it('is exported from the package index entrypoint', () => {
     expect(typeof visitorWorker.computeLogicalRequestKey).toBe('function');
   });
 
-  it('returns a byte-identical hex digest for the same (visitId, providerName, repair_generation)', () => {
+  it('returns a byte-identical hex digest for the same (visitId, providerName, modelName, repair_generation)', () => {
     const a = visitorWorker.computeLogicalRequestKey(
       'visit-acc-5',
       'mock-provider',
+      'mock-model',
       0,
     );
     const b = visitorWorker.computeLogicalRequestKey(
       'visit-acc-5',
       'mock-provider',
+      'mock-model',
       0,
     );
     expect(a).toBe(b);
@@ -38,20 +48,23 @@ describe('@willbuy/visitor-worker barrel — acceptance #5: computeLogicalReques
     expect(a).toMatch(/^[0-9a-f]{64}$/);
   });
 
-  it('returns DIFFERENT keys for different repair_generation values (same visit)', () => {
+  it('returns DIFFERENT keys for different repair_generation values (same visit, same model)', () => {
     const gen0 = visitorWorker.computeLogicalRequestKey(
       'visit-acc-5',
       'mock-provider',
+      'mock-model',
       0,
     );
     const gen1 = visitorWorker.computeLogicalRequestKey(
       'visit-acc-5',
       'mock-provider',
+      'mock-model',
       1,
     );
     const gen2 = visitorWorker.computeLogicalRequestKey(
       'visit-acc-5',
       'mock-provider',
+      'mock-model',
       2,
     );
     expect(gen0).not.toBe(gen1);
@@ -59,29 +72,49 @@ describe('@willbuy/visitor-worker barrel — acceptance #5: computeLogicalReques
     expect(gen0).not.toBe(gen2);
   });
 
-  it('returns DIFFERENT keys for different visitId values (same generation)', () => {
+  it('returns DIFFERENT keys for different visitId values (same generation, same model)', () => {
     const a = visitorWorker.computeLogicalRequestKey(
       'visit-X',
       'mock-provider',
+      'mock-model',
       0,
     );
     const b = visitorWorker.computeLogicalRequestKey(
       'visit-Y',
       'mock-provider',
+      'mock-model',
       0,
     );
     expect(a).not.toBe(b);
   });
 
-  it('returns DIFFERENT keys for different provider names (same visit, same generation)', () => {
+  it('returns DIFFERENT keys for different provider names (same visit, same generation, same model)', () => {
     const a = visitorWorker.computeLogicalRequestKey(
       'visit-acc-5',
       'provider-A',
+      'mock-model',
       0,
     );
     const b = visitorWorker.computeLogicalRequestKey(
       'visit-acc-5',
       'provider-B',
+      'mock-model',
+      0,
+    );
+    expect(a).not.toBe(b);
+  });
+
+  it('returns DIFFERENT keys for different model names (same visit, same provider, same generation) — spec §5.15 model component', () => {
+    const a = visitorWorker.computeLogicalRequestKey(
+      'visit-acc-5',
+      'mock-provider',
+      'model-v1',
+      0,
+    );
+    const b = visitorWorker.computeLogicalRequestKey(
+      'visit-acc-5',
+      'mock-provider',
+      'model-v2',
       0,
     );
     expect(a).not.toBe(b);

--- a/apps/visitor-worker/test/runVisit.schemaFail.test.ts
+++ b/apps/visitor-worker/test/runVisit.schemaFail.test.ts
@@ -45,18 +45,34 @@ describe('runVisit — acceptance #3: invalid 3 times → failed/schema', () => 
 
     // Spec §5.15: each schema-repair generation gets a NEW logical key.
     // Three calls → three distinct keys, each matching the canonical
-    // sha256(visitId || providerName || 'visit' || generation) form.
+    // sha256(visit_id || provider || model || 'visit' || generation) form
+    // — model component added per issue #23 / B1.
     const keys = provider.calls.map((c) => c.logicalRequestKey);
     expect(new Set(keys).size).toBe(3);
 
     expect(keys[0]).toBe(
-      computeLogicalRequestKey('visit-acc-3', provider.name(), 0),
+      computeLogicalRequestKey(
+        'visit-acc-3',
+        provider.name(),
+        provider.model(),
+        0,
+      ),
     );
     expect(keys[1]).toBe(
-      computeLogicalRequestKey('visit-acc-3', provider.name(), 1),
+      computeLogicalRequestKey(
+        'visit-acc-3',
+        provider.name(),
+        provider.model(),
+        1,
+      ),
     );
     expect(keys[2]).toBe(
-      computeLogicalRequestKey('visit-acc-3', provider.name(), 2),
+      computeLogicalRequestKey(
+        'visit-acc-3',
+        provider.name(),
+        provider.model(),
+        2,
+      ),
     );
   });
 });

--- a/packages/llm-adapter/src/index.ts
+++ b/packages/llm-adapter/src/index.ts
@@ -9,6 +9,13 @@
 // future provider can use it as Idempotency-Key (the v0.1 local CLI may
 // ignore it; spec §5.15 says transport retries reuse the key, schema-repair
 // generates a new one).
+//
+// Per spec §5.15 / §2 #15 the logical_request_key embeds a model component;
+// LLMProvider exposes model() so callers (visitor-worker, the API server's
+// spend ledger, the daily reconciliation job) can compute a key that
+// matches the on-wire request. LocalCliProvider's model() honors
+// WILLBUY_LLM_MODEL (default `local-cli/v1`) and forwards it to the
+// subprocess as WILLBUY_LLM_MODEL.
 
 import { spawn } from 'node:child_process';
 
@@ -38,6 +45,13 @@ export interface LLMChatResult {
 
 export interface LLMProvider {
   name(): string;
+  // Spec §5.15 / §2 #15: logical_request_key embeds the `model` component.
+  // The provider — not the caller — owns model identity (mirrors name()
+  // and capabilities()), so callers can compute a key that matches the
+  // on-wire request without coupling to provider config. Stable for the
+  // lifetime of the process; bumped only via deploy-time env (e.g.
+  // WILLBUY_LLM_MODEL) — never per-call.
+  model(): string;
   capabilities(): LLMProviderCapabilities;
   chat(opts: LLMChatOptions): Promise<LLMChatResult>;
 }
@@ -54,6 +68,12 @@ export const LOCAL_CLI_CAPABILITIES: LLMProviderCapabilities = {
 // identifiers, filenames, or logged messages. The CLI binary itself is
 // configurable via WILLBUY_LLM_BIN; "local-cli" is the abstraction name.
 export const LOCAL_CLI_PROVIDER_NAME = 'local-cli';
+
+// Spec §5.15 / §2 #15 model component for logical_request_key. Generic
+// per CLAUDE.md "no vendor name leaks"; deploy-time override via the
+// WILLBUY_LLM_MODEL env var lets ops bump the identity (e.g. canary)
+// without a code change while keeping the key stable per-process.
+export const LOCAL_CLI_DEFAULT_MODEL = 'local-cli/v1';
 
 // Spec §4.1 mentions a 120 s default subprocess timeout for the local CLI.
 export const LOCAL_CLI_DEFAULT_TIMEOUT_MS = 120_000;
@@ -78,6 +98,17 @@ export class LocalCliProvider implements LLMProvider {
   name(): string {
     return LOCAL_CLI_PROVIDER_NAME;
   }
+  // Spec §5.15 / §2 #15: model identity contributes to logical_request_key.
+  // Resolved fresh on every call (no cache) so a deploy-time env-var bump
+  // takes effect without restarting the process — at the cost of a per-call
+  // env lookup, which is negligible vs. the subprocess spawn cost.
+  model(): string {
+    const envModel = process.env.WILLBUY_LLM_MODEL;
+    if (envModel && envModel.trim().length > 0) {
+      return envModel.trim();
+    }
+    return LOCAL_CLI_DEFAULT_MODEL;
+  }
   capabilities(): LLMProviderCapabilities {
     return LOCAL_CLI_CAPABILITIES;
   }
@@ -98,6 +129,10 @@ export class LocalCliProvider implements LLMProvider {
         ...process.env,
         ...(this.options.env ?? {}),
         WILLBUY_REQ_KEY: opts.logicalRequestKey,
+        // Spec §5.15: the on-wire request and the logical_request_key share
+        // the same model identity. Forwarded so a future provider impl can
+        // pin the model on the subprocess side too.
+        WILLBUY_LLM_MODEL: this.model(),
       },
       stdin: stdinPayload,
       timeoutMs,

--- a/packages/llm-adapter/test/capabilities.test.ts
+++ b/packages/llm-adapter/test/capabilities.test.ts
@@ -28,4 +28,30 @@ describe('LocalCliProvider — capabilities()', () => {
     // CLAUDE.md "No vendor name leaks" + issue #5 generic-naming requirement.
     expect(name).not.toMatch(/anthropic|claude|openai|gpt|gemini/i);
   });
+
+  // Issue #23 / B1 (spec §5.15 line 253, §5.1 step 7 line 131, §2 #15):
+  // logical_request_key embeds the model component. The provider — not the
+  // caller — owns the model identity (mirrors how it owns name() and
+  // capabilities()), so callers (visitor-worker, future spend ledger,
+  // reconciliation job) can compute a key that matches the on-wire request.
+  it('reports a stable, generic model() identifier that does not leak vendor identifiers', () => {
+    const model = new LocalCliProvider().model();
+    expect(typeof model).toBe('string');
+    expect(model.length).toBeGreaterThan(0);
+    expect(model).not.toMatch(/anthropic|claude|openai|gpt|gemini/i);
+  });
+
+  it('honors WILLBUY_LLM_MODEL env var for model() identifier', () => {
+    const prev = process.env.WILLBUY_LLM_MODEL;
+    process.env.WILLBUY_LLM_MODEL = 'local-cli/v2-canary';
+    try {
+      expect(new LocalCliProvider().model()).toBe('local-cli/v2-canary');
+    } finally {
+      if (prev === undefined) {
+        delete process.env.WILLBUY_LLM_MODEL;
+      } else {
+        process.env.WILLBUY_LLM_MODEL = prev;
+      }
+    }
+  });
 });

--- a/packages/llm-adapter/test/chat.test.ts
+++ b/packages/llm-adapter/test/chat.test.ts
@@ -124,6 +124,42 @@ describe('LocalCliProvider — chat() acceptance #3: logical_request_key passthr
   });
 });
 
+describe('LocalCliProvider — chat() acceptance #3b: model passthrough (issue #23 / B1, spec §5.15)', () => {
+  it('passes provider.model() through to the subprocess as WILLBUY_LLM_MODEL env var', async () => {
+    const recorderPath = join(workDir, 'recorder.jsonl');
+    const counterPath = join(workDir, 'counter.txt');
+
+    const prev = process.env.WILLBUY_LLM_MODEL;
+    process.env.WILLBUY_LLM_MODEL = 'local-cli/test-model';
+    try {
+      const provider = new LocalCliProvider({
+        argv: RECORD_BIN,
+        env: {
+          WILLBUY_TEST_COUNTER: counterPath,
+          WILLBUY_TEST_RECORDER: recorderPath,
+        },
+      });
+
+      await provider.chat({
+        staticPrefix: 'P',
+        dynamicTail: 'T',
+        logicalRequestKey: 'lk-model-test',
+        maxOutputTokens: 800,
+      });
+
+      const lines = readFileSync(recorderPath, 'utf8').trim().split('\n');
+      const first = JSON.parse(lines[0]!);
+      expect(first.model).toBe('local-cli/test-model');
+    } finally {
+      if (prev === undefined) {
+        delete process.env.WILLBUY_LLM_MODEL;
+      } else {
+        process.env.WILLBUY_LLM_MODEL = prev;
+      }
+    }
+  });
+});
+
 describe('LocalCliProvider — chat() acceptance #4: error paths', () => {
   it('subprocess exit non-zero → status="error", raw is empty', async () => {
     const provider = new LocalCliProvider({

--- a/packages/llm-adapter/test/fixtures/record-bin.mjs
+++ b/packages/llm-adapter/test/fixtures/record-bin.mjs
@@ -6,8 +6,9 @@
 // per call) uses this to assert two consecutive calls produce two distinct
 // PIDs and two separate counter increments.
 //
-// Also echoes WILLBUY_REQ_KEY into the recorded line so acceptance #3
-// (logical_request_key reaches the subprocess) can assert pass-through.
+// Also echoes WILLBUY_REQ_KEY and WILLBUY_LLM_MODEL into the recorded line
+// so acceptance #3 / #3b (logical_request_key + model reach the subprocess)
+// can assert pass-through.
 
 import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
 import { stdin, stdout, env, pid, exit } from 'node:process';
@@ -33,6 +34,7 @@ stdin.on('end', () => {
     pid,
     counter,
     req_key: env.WILLBUY_REQ_KEY ?? null,
+    model: env.WILLBUY_LLM_MODEL ?? null,
     stdin_len: stdinStr.length,
     stdin_sha_prefix: stdinStr.slice(0, 64),
   });


### PR DESCRIPTION
Closes #23

Fixes **B1** (silent drift) identified in the Sprint 1 retrospective audit.

## Spec sections cited

- §5.15 line 253: `logical_request_key = sha256(visit_id || provider || model || request_kind || repair_generation)`
- §5.1 step 7 line 131: same formula
- §2 #15: same formula + commentary on why model must be in the key
- §2 #16: `provider_attempts.logical_request_key UNIQUE` + `model` column

## The drift

`apps/visitor-worker/src/visitor.ts` lines 51–65 were hashing only

```
sha256(visit_id || provider || 'visit' || repair_generation)
```

— the `model` component was missing. Two visits with the same `(visit_id, repair_generation)` against different model versions on the same provider would have collided on the provider-side `Idempotency-Key`, and the §2 #16 spend-ledger row (`UNIQUE(logical_request_key)` + `model` column) would have been ambiguous on a model bump. No amendment was on file in `SPEC.willbuy.amendments.md`, so this was a **silent drift**, not an authorized deviation.

## Decision: Option A (fix the code), with `model()` on `LLMProvider`

The spec is unambiguous (§5.15 + §5.1 + §2 #15 all agree); the amendment route would have weakened a contract that v0.3 (second wired chat backend with automatic fallback) and reconciliation directly depend on. Even with one wired backend in v0.1, ops can bump the model identity at deploy time (canary, A/B of model versions on the same CLI) and the key must reflect that.

Between the two Option A sub-choices:

- **(a) `LLMChatOptions.model`** would put model identity on the per-call surface — but the visitor doesn't pick the model, deploy config does. It would also expand the reserved-identifier-lint AST surface (`LLMChatOptions` is exactly what §2 #12 guards).
- **(b) `LLMProvider.model()`** mirrors the existing `name()` / `capabilities()` shape; callers that need to recompute the key (visitor-worker today, spend ledger + reconciliation in Sprint 2) call `provider.model()` without coupling to `LocalCliProviderOptions`. Picked.

## Diff summary

- `packages/llm-adapter/src/index.ts` — `LLMProvider` interface gains `model()`. `LocalCliProvider` returns `LOCAL_CLI_DEFAULT_MODEL = 'local-cli/v1'` unless `WILLBUY_LLM_MODEL` overrides at deploy time. The model is also forwarded to the subprocess as `WILLBUY_LLM_MODEL`.
- `apps/visitor-worker/src/visitor.ts` — `computeLogicalRequestKey(visitId, providerName, modelName, repairGeneration)` hashes per spec order. `runVisit()` pins `provider.model()` once at the top of the visit (so all repair generations of one logical visit share a model identity).
- Tests: red commit `adc93ab` (fails on current main), green commit (this PR) makes them pass. New assertions: model collision differentiates keys, `LLMProvider.model()` honors `WILLBUY_LLM_MODEL`, subprocess receives `WILLBUY_LLM_MODEL`, generic-name discipline.
- `apps/visitor-worker/test/helpers/mockProvider.ts` — `MockProvider` gets `model()` returning `'mock-model'` (overridable).
- `packages/llm-adapter/test/fixtures/record-bin.mjs` — records `WILLBUY_LLM_MODEL` so chat passthrough is asserted end-to-end.

## Test evidence (red → green)

```
adc93ab test: red — logical_request_key must include model component (B1)
37ae345 fix(visitor-worker): include model in logical_request_key per spec §5.15
```

Local CI:

```
pnpm typecheck   → 6 workspaces, all Done
pnpm lint        → clean
pnpm -r test     → 24 files, 86 passed (was 82; +4 B1 assertions: model collision, model()/env, subprocess WILLBUY_LLM_MODEL, generic-name discipline)
```

## Public-repo audit

- `LOCAL_CLI_DEFAULT_MODEL = 'local-cli/v1'` — generic, no vendor identifier.
- Capabilities test asserts the `model()` return doesn't match `/anthropic|claude|openai|gpt|gemini/i`.
- No secrets, IPs, or tokens in the diff. `git diff origin/main..HEAD | grep -iE 'sk-[a-zA-Z0-9]{20,}|api[_-]?key|secret|password'` is clean.

## Spec-amendment file

No new entry needed — this PR reverts to the spec form. A1 in `SPEC.willbuy.amendments.md` is unrelated (next_action enum + scoring rubric).

🤖 Generated with [Claude Code](https://claude.com/claude-code)