### PR TITLE
feat(infra): self-hosted Supabase compose + migrations runner

### DIFF
--- a/infra/dev/.env.example
+++ b/infra/dev/.env.example
@@ -1,0 +1,46 @@
+# infra/dev/.env.example — placeholders ONLY. Do NOT commit a real .env.
+#
+# Spec ref: §4.1 (self-hosted Supabase).
+#
+# Local dev usage:
+#   cp infra/dev/.env.example infra/dev/.env
+#   # Generate dev-only secrets locally; see infra/dev/README.md.
+#   docker compose -f infra/dev/docker-compose.yml --env-file infra/dev/.env up -d
+#
+# Prod / shared envs use 1Password materialization (`op inject -i .env.op -o .env`)
+# per the root CLAUDE.md "Public repo discipline" section.
+
+# --- Postgres ---------------------------------------------------------------
+POSTGRES_DB=postgres
+POSTGRES_USER=postgres
+# 32-char random alphanumeric. NEVER reuse across envs. NEVER commit a real one.
+POSTGRES_PASSWORD=replace-me-with-local-dev-password
+POSTGRES_HOST_PORT=54322
+
+# --- Auth (GoTrue) ----------------------------------------------------------
+# Origin of the willbuy web app (used for redirect-allow-list). Local default:
+SITE_URL=http://localhost:3000
+# Public Kong URL clients should hit (anon/service-role API gateway):
+API_EXTERNAL_URL=http://localhost:8000
+
+# --- JWT --------------------------------------------------------------------
+# Generate locally with: `openssl rand -base64 48 | tr -d '\n'` (≥ 32 chars).
+JWT_SECRET=replace-me-with-local-dev-jwt-secret-min-32-chars
+JWT_EXP=3600
+# Realtime needs a 64-char base64 key for cookie signing:
+SECRET_KEY_BASE=replace-me-64-char-base64-secret-for-realtime-cookie-signing-aaaa
+
+# --- API keys signed with JWT_SECRET ----------------------------------------
+# Mint locally with the snippet in infra/dev/README.md (jwt.io or `node`).
+# These are dev-only — production keys are minted per-env and stored in 1Password.
+ANON_KEY=replace-me-with-locally-minted-anon-jwt
+SERVICE_ROLE_KEY=replace-me-with-locally-minted-service-role-jwt
+
+# --- Studio + Kong ports ----------------------------------------------------
+STUDIO_HOST_PORT=54323
+KONG_HTTP_PORT=8000
+KONG_HTTPS_PORT=8443
+
+# --- Migrations runner ------------------------------------------------------
+# `pnpm migrate` reads DATABASE_URL. With the defaults above:
+DATABASE_URL=postgres://postgres:replace-me-with-local-dev-password@127.0.0.1:54322/postgres

--- a/infra/dev/README.md
+++ b/infra/dev/README.md
@@ -1,0 +1,108 @@
+# infra/dev — local self-hosted Supabase
+
+Local-development bring-up for willbuy.dev. Spec ref §4.1.
+
+> Production deploy of Supabase is **out of scope here** (lands in Sprint 3). This compose file is for laptop-grade dev only — single host, no TLS, no backups.
+
+## Fastest path from clean clone to a working DB
+
+```sh
+# 1. Copy and fill the env template (placeholders only in the example).
+cp infra/dev/.env.example infra/dev/.env
+$EDITOR infra/dev/.env   # see "Generating local dev secrets" below
+
+# 2. Bring up Supabase.
+docker compose -f infra/dev/docker-compose.yml --env-file infra/dev/.env up -d
+
+# 3. Apply migrations (creates _migrations + the placeholder row).
+set -a; . infra/dev/.env; set +a
+pnpm migrate
+```
+
+Studio is now at <http://localhost:54323>. The Kong API gateway is at <http://localhost:8000>. Postgres is on `127.0.0.1:54322` with the credentials in your `.env`.
+
+## What's in the compose
+
+Every image is pinned by tag **and** sha256 digest — no floating tags. Healthchecks gate `depends_on`, so dependents do not start until the dependency answers healthy.
+
+| service          | image                       | role                                |
+|------------------|-----------------------------|-------------------------------------|
+| `db`             | `supabase/postgres`         | Postgres 15.6 with Supabase extensions |
+| `auth`           | `supabase/gotrue`           | Auth (magic-link, JWT)              |
+| `rest`           | `postgrest/postgrest`       | REST over Postgres                  |
+| `realtime`       | `supabase/realtime`         | Realtime change-feed                |
+| `storage`        | `supabase/storage-api`      | Object storage                      |
+| `imgproxy`       | `darthsim/imgproxy`         | On-the-fly image transforms         |
+| `meta`           | `supabase/postgres-meta`    | Schema introspection for Studio     |
+| `studio`         | `supabase/studio`           | Web UI                              |
+| `kong`           | `kong`                      | API gateway in front of the above   |
+| `edge-functions` | `supabase/edge-runtime`     | Deno-based edge functions runtime   |
+
+To bump an image: update **both** the tag and the `@sha256:…` digest in `docker-compose.yml`. Floating-tag updates are not allowed.
+
+## Generating local dev secrets
+
+`infra/dev/.env.example` ships with `replace-me-…` placeholders. To turn it into a working `.env`:
+
+```sh
+# 1. Random Postgres password.
+openssl rand -hex 16
+
+# 2. JWT signing secret (≥ 32 chars).
+openssl rand -base64 48 | tr -d '\n'
+
+# 3. Realtime SECRET_KEY_BASE (64 char base64).
+openssl rand -base64 48 | tr -d '\n'
+
+# 4. ANON_KEY + SERVICE_ROLE_KEY are JWTs signed with JWT_SECRET. Mint them
+#    with any local JWT tool. Quick Node one-liner (no deps required):
+node --input-type=module -e '
+  import { createHmac } from "node:crypto";
+  const secret = process.env.JWT_SECRET;
+  const b64u = (b) => Buffer.from(b).toString("base64url");
+  const sign = (role) => {
+    const header = b64u(JSON.stringify({ alg: "HS256", typ: "JWT" }));
+    const payload = b64u(JSON.stringify({
+      role,
+      iss: "supabase-dev",
+      iat: Math.floor(Date.now() / 1000),
+      exp: Math.floor(Date.now() / 1000) + 60 * 60 * 24 * 365 * 10,
+    }));
+    const sig = createHmac("sha256", secret).update(`${header}.${payload}`).digest("base64url");
+    return `${header}.${payload}.${sig}`;
+  };
+  console.log("ANON_KEY=" + sign("anon"));
+  console.log("SERVICE_ROLE_KEY=" + sign("service_role"));
+'
+```
+
+Paste the output into `infra/dev/.env`. None of these values are committed.
+
+## Migrations
+
+`scripts/migrate.sh` (wired as `pnpm migrate`):
+
+- reads `DATABASE_URL` from the environment
+- finds every `*.sql` in `infra/migrations/` (override with `MIGRATIONS_DIR`)
+- skips files already recorded in the `_migrations` tracking table
+- applies the rest in lexicographic order, **one transaction per file** (`--single-transaction` + `ON_ERROR_STOP=1`)
+- exits non-zero AND rolls back the transaction (no partial state, no tracking row) if any file errors mid-way
+
+Re-running `pnpm migrate` against the same DB is a no-op.
+
+The runner uses a locally-installed `psql` if present; otherwise it falls back to `docker run --rm postgres:16-alpine psql`, so contributors without postgres client tools still work.
+
+## Tearing it all down
+
+```sh
+docker compose -f infra/dev/docker-compose.yml --env-file infra/dev/.env down -v
+```
+
+`-v` drops the named volumes (`db-data`, `storage-data`) — your local DB is gone after this.
+
+## What's NOT here (deferred)
+
+- Real schema migrations — land in #26.
+- Production deploy of self-hosted Supabase — Sprint 3.
+- KMS envelope encryption + per-env root keys — Sprint 3 ship-gate (§2 #23).
+- Preview-env-per-PR provisioning — out of Sprint 2 scope; see §2 #25.

--- a/infra/dev/docker-compose.yml
+++ b/infra/dev/docker-compose.yml
@@ -1,0 +1,275 @@
+# infra/dev/docker-compose.yml — local self-hosted Supabase for willbuy.dev
+#
+# Spec ref: §4.1 (self-hosted Supabase = Postgres + storage + auth + Realtime + Studio + Kong).
+#
+# Bring-up:
+#   cp infra/dev/.env.example infra/dev/.env       # placeholders ONLY in .env.example
+#   # fill .env with local-dev values (see infra/dev/README.md)
+#   docker compose -f infra/dev/docker-compose.yml --env-file infra/dev/.env up -d
+#   pnpm migrate                                   # applies infra/migrations/
+#
+# Hard rules:
+# - Every image is pinned by tag AND sha256 digest. Image promotions go
+#   through a deliberate digest update; no floating tags in this file.
+# - Every service has a healthcheck. The compose `depends_on` ordering
+#   uses `service_healthy` so dependents do not start until the
+#   dependency answers "healthy".
+# - This file is for LOCAL development only. Production deploy of
+#   Supabase lands in Sprint 3 per §4.1 + spec roadmap.
+
+x-base-postgres-env: &base-postgres-env
+  POSTGRES_HOST: db
+  POSTGRES_PORT: ${POSTGRES_PORT:-5432}
+  POSTGRES_DB: ${POSTGRES_DB:-postgres}
+  POSTGRES_USER: ${POSTGRES_USER:-postgres}
+  POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+
+services:
+  db:
+    image: supabase/postgres:15.6.1.146@sha256:ee29d0aaff03d0e12c7aa63437cba25f24246872f0ed3f82a9fd13184d780777
+    restart: unless-stopped
+    environment:
+      POSTGRES_DB: ${POSTGRES_DB:-postgres}
+      POSTGRES_USER: ${POSTGRES_USER:-postgres}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?set POSTGRES_PASSWORD in .env}
+      JWT_SECRET: ${JWT_SECRET:?set JWT_SECRET in .env}
+      JWT_EXP: ${JWT_EXP:-3600}
+    ports:
+      # Fixed host port so application code + scripts/migrate.sh can
+      # rely on a stable DATABASE_URL across reboots.
+      - '${POSTGRES_HOST_PORT:-54322}:5432'
+    volumes:
+      - db-data:/var/lib/postgresql/data
+    healthcheck:
+      test: ['CMD-SHELL', 'pg_isready -U ${POSTGRES_USER:-postgres} -d ${POSTGRES_DB:-postgres}']
+      interval: 5s
+      timeout: 5s
+      retries: 20
+
+  auth:
+    image: supabase/gotrue:v2.158.1@sha256:202c16530f2f29c886de963ab18b369074c49655480a463ce881169019f2bda7
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      GOTRUE_API_HOST: 0.0.0.0
+      GOTRUE_API_PORT: 9999
+      API_EXTERNAL_URL: ${API_EXTERNAL_URL:-http://localhost:8000}
+      GOTRUE_DB_DRIVER: postgres
+      GOTRUE_DB_DATABASE_URL: postgres://supabase_auth_admin:${POSTGRES_PASSWORD:?}@db:5432/${POSTGRES_DB:-postgres}?search_path=auth
+      GOTRUE_SITE_URL: ${SITE_URL:?set SITE_URL in .env}
+      GOTRUE_JWT_SECRET: ${JWT_SECRET:?}
+      GOTRUE_JWT_EXP: ${JWT_EXP:-3600}
+      GOTRUE_JWT_DEFAULT_GROUP_NAME: authenticated
+      GOTRUE_DISABLE_SIGNUP: 'false'
+      GOTRUE_MAILER_AUTOCONFIRM: 'true'
+      GOTRUE_LOG_LEVEL: warn
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:9999/health']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  rest:
+    image: postgrest/postgrest:v12.2.0@sha256:2cf1efd2c9c2e7606610c113cc73e936d8ce9ba089271cb9cbf11aa564bc30c7
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PGRST_DB_URI: postgres://authenticator:${POSTGRES_PASSWORD:?}@db:5432/${POSTGRES_DB:-postgres}
+      PGRST_DB_SCHEMAS: public,storage,graphql_public
+      PGRST_DB_ANON_ROLE: anon
+      PGRST_JWT_SECRET: ${JWT_SECRET:?}
+      PGRST_DB_USE_LEGACY_GUCS: 'false'
+    healthcheck:
+      # PostgREST has no built-in /health; root path returns OpenAPI JSON.
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:3000/ >/dev/null || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  realtime:
+    image: supabase/realtime:v2.30.34@sha256:f43c080c74915340687727a34b21ae9cacc5ac21380d05b61efebeca6fd7ca4f
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      DB_HOST: db
+      DB_PORT: 5432
+      DB_NAME: ${POSTGRES_DB:-postgres}
+      DB_USER: supabase_admin
+      DB_PASSWORD: ${POSTGRES_PASSWORD:?}
+      DB_AFTER_CONNECT_QUERY: 'SET search_path TO _realtime'
+      DB_ENC_KEY: supabaserealtime
+      API_JWT_SECRET: ${JWT_SECRET:?}
+      FLY_ALLOC_ID: 'fly123'
+      FLY_APP_NAME: realtime
+      SECRET_KEY_BASE: ${SECRET_KEY_BASE:?set SECRET_KEY_BASE in .env}
+      ERL_AFLAGS: '-proto_dist inet_tcp'
+      ENABLE_TAILSCALE: 'false'
+      DNS_NODES: "''"
+      RLIMIT_NOFILE: 10000
+      APP_NAME: realtime
+      SEED_SELF_HOST: 'true'
+    healthcheck:
+      test: ['CMD-SHELL', 'curl -sSf http://localhost:4000/api/tenants/realtime-dev/health || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  storage:
+    image: supabase/storage-api:v1.11.13@sha256:1e85dad48e8b3e85890a555e5114dc7ee48c2e8be4cfd97dd4e3564b4f104fcd
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+      rest:
+        condition: service_started
+      imgproxy:
+        condition: service_started
+    environment:
+      ANON_KEY: ${ANON_KEY:?set ANON_KEY in .env}
+      SERVICE_KEY: ${SERVICE_ROLE_KEY:?set SERVICE_ROLE_KEY in .env}
+      POSTGREST_URL: http://rest:3000
+      PGRST_JWT_SECRET: ${JWT_SECRET:?}
+      DATABASE_URL: postgres://supabase_storage_admin:${POSTGRES_PASSWORD:?}@db:5432/${POSTGRES_DB:-postgres}
+      FILE_SIZE_LIMIT: 52428800
+      STORAGE_BACKEND: file
+      FILE_STORAGE_BACKEND_PATH: /var/lib/storage
+      TENANT_ID: stub
+      REGION: stub
+      GLOBAL_S3_BUCKET: stub
+      ENABLE_IMAGE_TRANSFORMATION: 'true'
+      IMGPROXY_URL: http://imgproxy:5001
+    volumes:
+      - storage-data:/var/lib/storage
+    healthcheck:
+      test: ['CMD', 'wget', '--no-verbose', '--tries=1', '--spider', 'http://localhost:5000/status']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  imgproxy:
+    image: darthsim/imgproxy:v3.8.0@sha256:0facd355d50f3be665ebe674486f2b2e9cdaebd3f74404acd9b7fece2f661435
+    restart: unless-stopped
+    environment:
+      IMGPROXY_BIND: ':5001'
+      IMGPROXY_LOCAL_FILESYSTEM_ROOT: /
+      IMGPROXY_USE_ETAG: 'true'
+      IMGPROXY_ENABLE_WEBP_DETECTION: 'true'
+    volumes:
+      - storage-data:/var/lib/storage
+    healthcheck:
+      test: ['CMD', 'imgproxy', 'health']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  meta:
+    image: supabase/postgres-meta:v0.83.2@sha256:0e8cf91a277aefb7f85e4ec01c3b0ae69882b351c7927e3e21ce59c151ae780c
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      PG_META_PORT: 8080
+      PG_META_DB_HOST: db
+      PG_META_DB_PORT: 5432
+      PG_META_DB_NAME: ${POSTGRES_DB:-postgres}
+      PG_META_DB_USER: supabase_admin
+      PG_META_DB_PASSWORD: ${POSTGRES_PASSWORD:?}
+    healthcheck:
+      test: ['CMD-SHELL', 'wget -qO- http://localhost:8080/health >/dev/null || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  studio:
+    image: supabase/studio:20240729-ce42139@sha256:374da591f7190427447b9865f63061f561ebc81306d7655d14dab7cb453f3907
+    restart: unless-stopped
+    depends_on:
+      meta:
+        condition: service_healthy
+    ports:
+      - '${STUDIO_HOST_PORT:-54323}:3000'
+    environment:
+      STUDIO_PG_META_URL: http://meta:8080
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:?}
+      DEFAULT_ORGANIZATION_NAME: willbuy-dev
+      DEFAULT_PROJECT_NAME: willbuy
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_PUBLIC_URL: ${API_EXTERNAL_URL:-http://localhost:8000}
+      SUPABASE_ANON_KEY: ${ANON_KEY:?}
+      SUPABASE_SERVICE_KEY: ${SERVICE_ROLE_KEY:?}
+      AUTH_JWT_SECRET: ${JWT_SECRET:?}
+    healthcheck:
+      test:
+        [
+          'CMD',
+          'node',
+          '-e',
+          "fetch('http://localhost:3000/api/profile').then(r => r.ok || process.exit(1))",
+        ]
+      interval: 10s
+      timeout: 10s
+      retries: 10
+
+  kong:
+    image: kong:2.8.1@sha256:1b53405d8680a09d6f44494b7990bf7da2ea43f84a258c59717d4539abf09f6d
+    restart: unless-stopped
+    depends_on:
+      auth:
+        condition: service_healthy
+      rest:
+        condition: service_healthy
+      realtime:
+        condition: service_healthy
+      storage:
+        condition: service_healthy
+      meta:
+        condition: service_healthy
+    environment:
+      KONG_DATABASE: 'off'
+      KONG_DECLARATIVE_CONFIG: /var/lib/kong/kong.yml
+      KONG_DNS_ORDER: LAST,A,CNAME
+      KONG_PLUGINS: request-transformer,cors,key-auth,acl,basic-auth
+      KONG_NGINX_PROXY_PROXY_BUFFER_SIZE: 160k
+      KONG_NGINX_PROXY_PROXY_BUFFERS: 64 160k
+    ports:
+      - '${KONG_HTTP_PORT:-8000}:8000'
+      - '${KONG_HTTPS_PORT:-8443}:8443'
+    volumes:
+      - ./kong.yml:/var/lib/kong/kong.yml:ro
+    healthcheck:
+      test: ['CMD', 'kong', 'health']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+  edge-functions:
+    image: supabase/edge-runtime:v1.58.2@sha256:ffe9ff8f3ed2a961f9bc8559f1c40e3243f6a2ac822ffa29286406777e352a16
+    restart: unless-stopped
+    depends_on:
+      db:
+        condition: service_healthy
+    environment:
+      JWT_SECRET: ${JWT_SECRET:?}
+      SUPABASE_URL: http://kong:8000
+      SUPABASE_ANON_KEY: ${ANON_KEY:?}
+      SUPABASE_SERVICE_ROLE_KEY: ${SERVICE_ROLE_KEY:?}
+      SUPABASE_DB_URL: postgres://postgres:${POSTGRES_PASSWORD:?}@db:5432/${POSTGRES_DB:-postgres}
+      VERIFY_JWT: 'false'
+    volumes:
+      - ./functions:/home/deno/functions:ro
+    healthcheck:
+      test: ['CMD-SHELL', 'pgrep -x edge-runtime >/dev/null || exit 1']
+      interval: 10s
+      timeout: 5s
+      retries: 10
+
+volumes:
+  db-data:
+  storage-data:

--- a/infra/dev/functions/main/index.ts
+++ b/infra/dev/functions/main/index.ts
@@ -1,0 +1,4 @@
+// infra/dev/functions/main/index.ts — placeholder edge function.
+// Real edge functions, if any, land later. This stub is mounted into the
+// supabase/edge-runtime container so the volume bind is non-empty.
+Deno.serve(() => new Response('willbuy edge-functions placeholder\n', { status: 200 }));

--- a/infra/dev/kong.yml
+++ b/infra/dev/kong.yml
@@ -1,0 +1,90 @@
+_format_version: '2.1'
+_transform: true
+
+# infra/dev/kong.yml — minimal Kong declarative config for local self-hosted Supabase.
+# Mirrors the upstream supabase/docker reference; trimmed to what willbuy.dev needs
+# during local dev. Production Kong config lands with the deploy in Sprint 3.
+
+consumers:
+  - username: anon
+    keyauth_credentials:
+      - key: ${SUPABASE_ANON_KEY}
+  - username: service_role
+    keyauth_credentials:
+      - key: ${SUPABASE_SERVICE_KEY}
+
+acls:
+  - consumer: anon
+    group: anon
+  - consumer: service_role
+    group: admin
+
+services:
+  - name: auth-v1
+    url: http://auth:9999/
+    routes:
+      - name: auth-v1-route
+        strip_path: true
+        paths:
+          - /auth/v1/
+    plugins:
+      - name: cors
+
+  - name: rest-v1
+    url: http://rest:3000/
+    routes:
+      - name: rest-v1-route
+        strip_path: true
+        paths:
+          - /rest/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: true
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin
+            - anon
+
+  - name: realtime-v1
+    url: http://realtime:4000/socket/
+    routes:
+      - name: realtime-v1-route
+        strip_path: true
+        paths:
+          - /realtime/v1/
+    plugins:
+      - name: cors
+      - name: key-auth
+        config:
+          hide_credentials: false
+
+  - name: storage-v1
+    url: http://storage:5000/
+    routes:
+      - name: storage-v1-route
+        strip_path: true
+        paths:
+          - /storage/v1/
+    plugins:
+      - name: cors
+
+  - name: meta
+    url: http://meta:8080/
+    routes:
+      - name: meta-route
+        strip_path: true
+        paths:
+          - /pg/
+    plugins:
+      - name: key-auth
+        config:
+          hide_credentials: false
+      - name: acl
+        config:
+          hide_groups_header: true
+          allow:
+            - admin

--- a/infra/migrations/0000_init.sql
+++ b/infra/migrations/0000_init.sql
@@ -1,0 +1,12 @@
+-- 0000_init.sql — placeholder migration. Real schema lands in #26.
+--
+-- Creates the migration tracking table the runner relies on. The runner
+-- (scripts/migrate.sh) creates this table on its own first invocation too
+-- (CREATE TABLE IF NOT EXISTS) — defining it here keeps the SQL surface
+-- self-describing and lets a DBA run migrations by hand if the runner
+-- is unavailable.
+CREATE TABLE IF NOT EXISTS _migrations (
+  filename     TEXT        PRIMARY KEY,
+  checksum     TEXT        NOT NULL,
+  applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);

--- a/package.json
+++ b/package.json
@@ -14,7 +14,8 @@
     "lint": "eslint .",
     "typecheck": "tsc -b --pretty && pnpm -r --if-present run typecheck",
     "test": "vitest run --passWithNoTests && pnpm -r --if-present run test",
-    "format": "prettier --write ."
+    "format": "prettier --write .",
+    "migrate": "bash scripts/migrate.sh"
   },
   "devDependencies": {
     "@eslint/js": "^9.17.0",

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -1,0 +1,141 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+# scripts/migrate.sh — minimal migration runner for willbuy.
+#
+# Reads DATABASE_URL from the environment, applies every *.sql file in
+# MIGRATIONS_DIR (default: infra/migrations) in lexicographic order that
+# is not already recorded in the _migrations tracking table, one
+# transaction per file, idempotent on re-apply.
+#
+# Spec ref: §4.1 (self-hosted Supabase = Postgres). Real schema lands in #26.
+
+readonly DEFAULT_MIGRATIONS_DIR="infra/migrations"
+
+err() {
+  printf '%s\n' "migrate: $*" >&2
+}
+
+require_env() {
+  local name="$1"
+  if [[ -z "${!name:-}" ]]; then
+    err "${name} is required"
+    exit 2
+  fi
+}
+
+ensure_psql() {
+  if ! command -v psql >/dev/null 2>&1; then
+    # Fall back to docker-bundled psql so a contributor without postgres
+    # client tools installed can still apply migrations against any reachable
+    # postgres URL.
+    if command -v docker >/dev/null 2>&1; then
+      PSQL_CMD=(docker run --rm -i --network host postgres:16-alpine psql)
+      return 0
+    fi
+    err "psql not found and docker not available; install postgresql-client"
+    exit 2
+  fi
+  PSQL_CMD=(psql)
+}
+
+run_psql() {
+  # Args: <-c|-f> <value>; reads PSQL_CMD + DATABASE_URL.
+  "${PSQL_CMD[@]}" \
+    -v ON_ERROR_STOP=1 \
+    --quiet \
+    --no-psqlrc \
+    --tuples-only \
+    --no-align \
+    --dbname="${DATABASE_URL}" \
+    "$@"
+}
+
+ensure_tracking_table() {
+  run_psql -c '
+    CREATE TABLE IF NOT EXISTS _migrations (
+      filename     TEXT        PRIMARY KEY,
+      checksum     TEXT        NOT NULL,
+      applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+    );
+  ' >/dev/null
+}
+
+is_applied() {
+  local filename="$1"
+  local count
+  count="$(run_psql -c "SELECT COUNT(*) FROM _migrations WHERE filename = '${filename}';" | tr -d '[:space:]')"
+  [[ "${count}" == "1" ]]
+}
+
+checksum_of() {
+  local file="$1"
+  if command -v sha256sum >/dev/null 2>&1; then
+    sha256sum "${file}" | awk '{print $1}'
+  else
+    shasum -a 256 "${file}" | awk '{print $1}'
+  fi
+}
+
+apply_migration() {
+  local file="$1"
+  local filename
+  filename="$(basename "${file}")"
+  local checksum
+  checksum="$(checksum_of "${file}")"
+
+  err "applying ${filename} (sha256=${checksum:0:12}…)"
+
+  # Atomic-per-file: BEGIN, run the file's statements, INSERT into the
+  # tracking table, COMMIT — all in one psql invocation under
+  # --single-transaction + ON_ERROR_STOP=1. Any error in any statement
+  # aborts the whole transaction (including the tracking INSERT). The
+  # SQL is piped over stdin so the docker-bundled psql fallback works
+  # the same as a local psql.
+  local rc=0
+  {
+    cat "${file}"
+    printf '\n-- migrate.sh: tracking insert\n'
+    printf "INSERT INTO _migrations (filename, checksum) VALUES ('%s', '%s');\n" \
+      "${filename}" "${checksum}"
+  } | "${PSQL_CMD[@]}" \
+    -v ON_ERROR_STOP=1 \
+    --quiet \
+    --no-psqlrc \
+    --tuples-only \
+    --no-align \
+    --single-transaction \
+    --dbname="${DATABASE_URL}" \
+    >/dev/null || rc=$?
+
+  return "${rc}"
+}
+
+main() {
+  require_env DATABASE_URL
+  local migrations_dir="${MIGRATIONS_DIR:-${DEFAULT_MIGRATIONS_DIR}}"
+  if [[ ! -d "${migrations_dir}" ]]; then
+    err "migrations dir not found: ${migrations_dir}"
+    exit 2
+  fi
+
+  ensure_psql
+  ensure_tracking_table
+
+  local applied=0 skipped=0
+  local file filename
+  while IFS= read -r -d '' file; do
+    filename="$(basename "${file}")"
+    if is_applied "${filename}"; then
+      skipped=$((skipped + 1))
+      continue
+    fi
+    apply_migration "${file}"
+    applied=$((applied + 1))
+  done < <(find "${migrations_dir}" -maxdepth 1 -type f -name '*.sql' -print0 | LC_ALL=C sort -z)
+
+  err "done — applied=${applied} skipped=${skipped}"
+}
+
+main "$@"

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -1,0 +1,208 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, copyFileSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const migrateScript = resolve(repoRoot, 'scripts/migrate.sh');
+const realMigrationsDir = resolve(repoRoot, 'infra/migrations');
+
+const dockerCheck = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+  encoding: 'utf8',
+});
+const dockerAvailable = dockerCheck.status === 0;
+const describeIfDocker = dockerAvailable ? describe : describe.skip;
+
+const PG_IMAGE = 'postgres:16-alpine';
+const PG_PASSWORD = 'willbuy_test_pw';
+const CONTAINER_PREFIX = 'willbuy-migrate-test-';
+
+function uid(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+function dockerRun(args: string[]): { code: number; stdout: string; stderr: string } {
+  const r = spawnSync('docker', args, { encoding: 'utf8' });
+  return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function findFreePort(): number {
+  // Pick a random ephemeral port; let docker bind it. If conflict, retry once.
+  return 30000 + Math.floor(Math.random() * 30000);
+}
+
+async function startPostgres(): Promise<{ container: string; port: number; url: string }> {
+  const container = CONTAINER_PREFIX + uid();
+  let port = findFreePort();
+  let attempts = 0;
+  let started = false;
+  let lastErr = '';
+  while (attempts < 3 && !started) {
+    const r = dockerRun([
+      'run',
+      '-d',
+      '--rm',
+      '--name',
+      container,
+      '-e',
+      `POSTGRES_PASSWORD=${PG_PASSWORD}`,
+      '-p',
+      `${port}:5432`,
+      PG_IMAGE,
+    ]);
+    if (r.code === 0) {
+      started = true;
+    } else {
+      lastErr = r.stderr;
+      port = findFreePort();
+      attempts += 1;
+    }
+  }
+  if (!started) {
+    throw new Error(`failed to start postgres container: ${lastErr}`);
+  }
+
+  // Wait for postgres readiness.
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const r = dockerRun(['exec', container, 'pg_isready', '-U', 'postgres']);
+    if (r.code === 0) {
+      const url = `postgres://postgres:${PG_PASSWORD}@127.0.0.1:${port}/postgres`;
+      return { container, port, url };
+    }
+    await new Promise((res) => setTimeout(res, 500));
+  }
+  dockerRun(['rm', '-f', container]);
+  throw new Error('postgres container did not become ready in 30s');
+}
+
+function stopPostgres(container: string): void {
+  dockerRun(['rm', '-f', container]);
+}
+
+function runMigrate(opts: {
+  databaseUrl: string;
+  migrationsDir: string;
+}): { code: number; stdout: string; stderr: string } {
+  const r = spawnSync('bash', [migrateScript], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DATABASE_URL: opts.databaseUrl,
+      MIGRATIONS_DIR: opts.migrationsDir,
+    },
+  });
+  return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function psql(container: string, sql: string): { code: number; stdout: string; stderr: string } {
+  const r = spawnSync(
+    'docker',
+    ['exec', '-i', container, 'psql', '-U', 'postgres', '-d', 'postgres', '-tAc', sql],
+    { encoding: 'utf8' },
+  );
+  return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function copyRealMigrationsTo(dir: string): void {
+  for (const f of readdirSync(realMigrationsDir)) {
+    if (f.endsWith('.sql')) {
+      copyFileSync(join(realMigrationsDir, f), join(dir, f));
+    }
+  }
+}
+
+describeIfDocker('migrations runner', () => {
+  let pg: { container: string; port: number; url: string };
+  let workDir: string;
+
+  beforeAll(async () => {
+    pg = await startPostgres();
+    workDir = mkdtempSync(join(tmpdir(), 'willbuy-mig-'));
+  }, 60_000);
+
+  afterAll(() => {
+    if (pg) stopPostgres(pg.container);
+    if (workDir) rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it('applies the placeholder migration on a fresh DB', () => {
+    const dir = mkdtempSync(join(workDir, 'fresh-'));
+    copyRealMigrationsTo(dir);
+
+    const r = runMigrate({ databaseUrl: pg.url, migrationsDir: dir });
+    expect(r.code, `stdout=${r.stdout}\nstderr=${r.stderr}`).toBe(0);
+
+    const tableCheck = psql(
+      pg.container,
+      "SELECT COUNT(*) FROM information_schema.tables WHERE table_name='_migrations';",
+    );
+    expect(tableCheck.code).toBe(0);
+    expect(tableCheck.stdout.trim()).toBe('1');
+
+    const rowCount = psql(pg.container, 'SELECT COUNT(*) FROM _migrations;');
+    expect(rowCount.code).toBe(0);
+    expect(rowCount.stdout.trim()).toBe('1');
+
+    const filename = psql(pg.container, 'SELECT filename FROM _migrations ORDER BY filename;');
+    expect(filename.stdout.trim()).toBe('0000_init.sql');
+  });
+
+  it('is a no-op on second run', () => {
+    const dir = mkdtempSync(join(workDir, 'reapply-'));
+    copyRealMigrationsTo(dir);
+
+    const r1 = runMigrate({ databaseUrl: pg.url, migrationsDir: dir });
+    expect(r1.code, `r1 stderr=${r1.stderr}`).toBe(0);
+
+    const beforeRow = psql(pg.container, 'SELECT COUNT(*) FROM _migrations;');
+    const beforeCount = Number(beforeRow.stdout.trim());
+
+    const r2 = runMigrate({ databaseUrl: pg.url, migrationsDir: dir });
+    expect(r2.code, `r2 stderr=${r2.stderr}`).toBe(0);
+
+    const afterRow = psql(pg.container, 'SELECT COUNT(*) FROM _migrations;');
+    const afterCount = Number(afterRow.stdout.trim());
+    expect(afterCount).toBe(beforeCount);
+  });
+
+  it('rolls back a failing migration atomically and exits non-zero', () => {
+    const dir = mkdtempSync(join(workDir, 'fail-'));
+    mkdirSync(dir, { recursive: true });
+    copyRealMigrationsTo(dir);
+
+    // Apply the placeholder first so we are testing add-on of a failing fixture.
+    const r1 = runMigrate({ databaseUrl: pg.url, migrationsDir: dir });
+    expect(r1.code, `r1 stderr=${r1.stderr}`).toBe(0);
+
+    const failingSql = [
+      '-- failing fixture: creates a table, then errors mid-way',
+      'CREATE TABLE willbuy_fail_fixture (id INT PRIMARY KEY);',
+      'INSERT INTO willbuy_fail_fixture VALUES (1);',
+      'SELECT 1 / 0;',
+    ].join('\n');
+    writeFileSync(join(dir, '9999_fail_fixture.sql'), failingSql);
+
+    const r2 = runMigrate({ databaseUrl: pg.url, migrationsDir: dir });
+    expect(r2.code).not.toBe(0);
+
+    // Partial change rolled back: the table from the failing migration must NOT exist.
+    const tableCheck = psql(
+      pg.container,
+      "SELECT COUNT(*) FROM information_schema.tables WHERE table_name='willbuy_fail_fixture';",
+    );
+    expect(tableCheck.code).toBe(0);
+    expect(tableCheck.stdout.trim()).toBe('0');
+
+    // _migrations must NOT mark the failing fixture as applied.
+    const recorded = psql(
+      pg.container,
+      "SELECT COUNT(*) FROM _migrations WHERE filename='9999_fail_fixture.sql';",
+    );
+    expect(recorded.code).toBe(0);
+    expect(recorded.stdout.trim()).toBe('0');
+  });
+});


### PR DESCRIPTION
Closes #25

## Summary

- `infra/dev/docker-compose.yml` — self-hosted Supabase for local dev (Postgres, GoTrue, Storage, Realtime, Studio, Kong, postgres-meta, imgproxy, edge-runtime). Every image pinned by tag AND sha256 digest. Healthchecks per service; `depends_on: condition: service_healthy` gates startup ordering. Postgres on a fixed host port (54322 by default).
- `infra/dev/.env.example` — placeholders only (`POSTGRES_PASSWORD`, `JWT_SECRET`, `ANON_KEY`, `SERVICE_ROLE_KEY`, `SITE_URL`, `SECRET_KEY_BASE`, …). Real values via `op inject -i .env.op -o .env` per CLAUDE.md.
- `infra/migrations/0000_init.sql` — placeholder migration creating `_migrations` (filename PK, checksum, applied_at).
- `scripts/migrate.sh` — bash runner: reads `DATABASE_URL`, applies `*.sql` files in `MIGRATIONS_DIR` (default `infra/migrations/`) in lexicographic order, **one transaction per file** (`--single-transaction` + `ON_ERROR_STOP=1`), idempotent on re-apply (skips files already in `_migrations`). SQL is piped over stdin so the bundled `docker run postgres:16-alpine psql` fallback works the same as a locally-installed `psql`.
- `pnpm migrate` workspace script wires the runner.
- `infra/dev/README.md` — fastest-path bring-up + dev-secret minting + tear-down.

## Spec link

§4.1 (Supabase = Postgres + storage + auth + Realtime + Studio + Kong, all self-hosted). §2 #25 (preview-env-per-PR) is **not** in this PR's scope, just kept un-broken.

## TDD evidence (red → green)

History on this branch:

```
test(infra): add red migrations runner tests for #25
feat(infra): migrations runner + placeholder _migrations table
feat(infra): self-hosted Supabase docker-compose for local dev
```

The first commit lands the three failing acceptance tests; the second turns them green. CI runs `tests/migrations.test.ts` against a throwaway `postgres:16-alpine` container (skipped automatically when docker is unavailable, e.g. on a contributor laptop without the daemon).

### Live evidence — three acceptance scenarios

**1. Fresh apply.** `_migrations` table created, placeholder row inserted.

```
$ DATABASE_URL=postgres://postgres:***@127.0.0.1:54399/postgres pnpm migrate
migrate: applying 0000_init.sql (sha256=2be291ad6b2d…)
migrate: done — applied=1 skipped=0

   filename    | checksum_prefix  |          applied_at
---------------+------------------+-------------------------------
 0000_init.sql | 2be291ad6b2db967 | 2026-04-25 13:44:10.366511+00
(1 row)
```

**2. Re-run is a no-op.** Second invocation against the same DB inserts nothing new.

```
$ pnpm migrate
migrate: done — applied=0 skipped=1
_migrations row count: 1
```

**3. Failing fixture rolls back atomically.** Adds `9999_fail_fixture.sql` whose body creates a table, inserts a row, then `SELECT 1/0`. Runner exits non-zero, the fixture table doesn't exist, and `_migrations` does NOT mark it applied.

```
$ MIGRATIONS_DIR=$tmp pnpm migrate
migrate: applying 9999_fail_fixture.sql (sha256=77791a9dcd39…)
ERROR:  division by zero
 ELIFECYCLE  Command failed with exit code 3.
exit code: 3
willbuy_fail_fixture rows in information_schema: 0
9999_fail_fixture rows in _migrations: 0
```

Vitest run (local, all green):

```
✓ tests/migrations.test.ts (3 tests) 2637ms
   ✓ migrations runner > applies the placeholder migration on a fresh DB
   ✓ migrations runner > is a no-op on second run
   ✓ migrations runner > rolls back a failing migration atomically and exits non-zero

 Test Files  1 passed (1)
      Tests  3 passed (3)
```

## Public-repo audit

- Only placeholders ship in `.env.example` (every value starts with `replace-me-…`). The README documents how to mint local dev secrets via `openssl` + a tiny `node` JWT-signing one-liner.
- No IP addresses, tokens, or hostnames. Image pins are sha256 digests of public Docker Hub artifacts only.
- No new entries in `.gitignore` bypass list; the existing allow-list (`.env.example`, `.env.op`, `scripts/push-secrets.sh`) is sufficient.
- No widening of scope: real schema migrations are deferred to #26, production deploy of Supabase to Sprint 3 (per spec §4.1 + roadmap), preview-env-per-PR provisioning to its own work item.

## Test plan

- [x] `pnpm migrate` against a fresh DB inserts exactly one `_migrations` row.
- [x] `pnpm migrate` re-run is a no-op (no second insertion).
- [x] Failing migration → non-zero exit, partial change rolled back, not marked applied.
- [x] `pnpm typecheck` clean.
- [x] `pnpm lint` clean.
- [x] `pnpm test` clean (full suite).
- [x] `docker compose -f infra/dev/docker-compose.yml --env-file infra/dev/.env.example config --quiet` validates.
- [ ] CI green.
- [ ] REV approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)