### PR TITLE
feat(llm-adapter): transport retry + logical_request_key idempotency

### DIFF
--- a/packages/llm-adapter/src/index.ts
+++ b/packages/llm-adapter/src/index.ts
@@ -16,6 +16,21 @@
 // matches the on-wire request. LocalCliProvider's model() honors
 // WILLBUY_LLM_MODEL (default `local-cli/v1`) and forwards it to the
 // subprocess as WILLBUY_LLM_MODEL.
+//
+// Issue #27 / spec §5.15 — transport retry + idempotency. chat() now wraps
+// a single subprocess invocation in a transport-retry loop:
+//   - transient_safe_retry (exit 130 SIGINT-coded / 137 SIGKILL-coded by an
+//     external supervisor, NOT by us): retry with the SAME logicalRequestKey
+//     up to 3 attempts, jittered backoff 0.5 s → 2 s → 8 s.
+//   - non_transient (exit 1 with non-empty stderr suggesting bad input,
+//     spawn ENOENT, other non-zero exits): no retry, status='error'.
+//   - indeterminate (adapter-fired SIGKILL on timeout — the call may or may
+//     not have reached the model side; spec §5.15 calls this `maybe_executed`
+//     for an idempotency:false provider): no retry, status='indeterminate'.
+//     The daily reconciliation job (Sprint 3) resolves these against
+//     provider billing.
+// transportAttempts in the result counts the actual on-wire attempts and is
+// observability only — it does NOT contribute to the logical_request_key.
 
 import { spawn } from 'node:child_process';
 
@@ -78,6 +93,16 @@ export const LOCAL_CLI_DEFAULT_MODEL = 'local-cli/v1';
 // Spec §4.1 mentions a 120 s default subprocess timeout for the local CLI.
 export const LOCAL_CLI_DEFAULT_TIMEOUT_MS = 120_000;
 
+// Spec §5.15: up to 3 transport retries per logical request with jittered
+// exponential backoff 0.5 s → 2 s → 8 s. The array is the wait BEFORE attempt
+// N+1 (i.e. between attempt 1 and 2, 2 and 3); attempt 1 has no leading wait.
+// We carry 3 entries even though the third is unused on the cap=3 path —
+// keeps the schedule readable and matches the spec text 1:1.
+export const LOCAL_CLI_DEFAULT_BACKOFF_MS: readonly number[] = [500, 2000, 8000];
+
+// Spec §5.15: cap at 3 transport attempts.
+export const LOCAL_CLI_MAX_TRANSPORT_ATTEMPTS = 3;
+
 export interface LocalCliProviderOptions {
   // Test/override hook: pass argv directly. When undefined, the provider
   // resolves the binary from the WILLBUY_LLM_BIN env var (default 'claude'
@@ -87,6 +112,20 @@ export interface LocalCliProviderOptions {
   // injected as WILLBUY_REQ_KEY by chat() regardless of what's passed here.
   env?: Readonly<Record<string, string>>;
   timeoutMs?: number;
+  // Transport-retry backoff schedule (issue #27 / spec §5.15). Tests pass
+  // [0,0,0] for fast runs; production uses LOCAL_CLI_DEFAULT_BACKOFF_MS.
+  // Length must be ≥ LOCAL_CLI_MAX_TRANSPORT_ATTEMPTS - 1 (the wait before
+  // each retry); excess entries are ignored.
+  backoffMs?: readonly number[];
+  // Jitter scale [0,1]. Applied as `wait * (1 + jitter * random())`. Default
+  // 0.2 (i.e. up to +20%). Tests pass 0 for determinism. Spec §5.15 says
+  // "jittered exponential backoff" without pinning a scale; +20% is small
+  // enough to not stretch the 8 s tail meaningfully and large enough to
+  // de-synchronize concurrent transient failures across visitors.
+  jitter?: number;
+  // Test seam — clock for the backoff sleep. Defaults to setTimeout. Tests
+  // can pass an immediate-resolve impl to skip waits without zero-wait races.
+  sleepFn?: (ms: number) => Promise<void>;
 }
 
 export class LocalCliProvider implements LLMProvider {
@@ -121,22 +160,82 @@ export class LocalCliProvider implements LLMProvider {
     const [cmd, ...args] = argv;
     const timeoutMs = this.options.timeoutMs ?? LOCAL_CLI_DEFAULT_TIMEOUT_MS;
     const stdinPayload = `${opts.staticPrefix}\n${opts.dynamicTail}`;
+    const env = {
+      ...process.env,
+      ...(this.options.env ?? {}),
+      WILLBUY_REQ_KEY: opts.logicalRequestKey,
+      // Spec §5.15: the on-wire request and the logical_request_key share
+      // the same model identity. Forwarded so a future provider impl can
+      // pin the model on the subprocess side too.
+      WILLBUY_LLM_MODEL: this.model(),
+    };
 
-    return await runOnce({
-      cmd: cmd!,
-      args,
-      env: {
-        ...process.env,
-        ...(this.options.env ?? {}),
-        WILLBUY_REQ_KEY: opts.logicalRequestKey,
-        // Spec §5.15: the on-wire request and the logical_request_key share
-        // the same model identity. Forwarded so a future provider impl can
-        // pin the model on the subprocess side too.
-        WILLBUY_LLM_MODEL: this.model(),
-      },
-      stdin: stdinPayload,
-      timeoutMs,
-    });
+    const backoff =
+      this.options.backoffMs ?? LOCAL_CLI_DEFAULT_BACKOFF_MS;
+    const jitter = this.options.jitter ?? 0.2;
+    const sleep = this.options.sleepFn ?? defaultSleep;
+
+    // Spec §5.15: same logicalRequestKey across all transport attempts.
+    // The provider-side Idempotency-Key (when capabilities.idempotency is
+    // true) MUST stay byte-identical so a future HTTP backend can dedupe.
+    let lastOutcome: AttemptOutcome | undefined;
+    let transportAttempts = 0;
+
+    for (let i = 0; i < LOCAL_CLI_MAX_TRANSPORT_ATTEMPTS; i += 1) {
+      transportAttempts += 1;
+      const outcome = await runOnceClassified({
+        cmd: cmd!,
+        args,
+        env,
+        stdin: stdinPayload,
+        timeoutMs,
+      });
+      lastOutcome = outcome;
+
+      if (outcome.kind === 'ok') {
+        return {
+          raw: outcome.raw,
+          transportAttempts,
+          status: 'ok',
+        };
+      }
+      if (outcome.kind === 'transient_safe_retry') {
+        if (i + 1 < LOCAL_CLI_MAX_TRANSPORT_ATTEMPTS) {
+          const baseWait = backoff[i] ?? 0;
+          // jitter ∈ [0, 1]; final wait ∈ [baseWait, baseWait * (1 + jitter)].
+          const waitMs = baseWait * (1 + jitter * Math.random());
+          await sleep(waitMs);
+        }
+        continue;
+      }
+      // Spec §5.15: idempotency:false → timeout|connection_reset|unknown_status
+      // does not transport-retry; classify indeterminate and let the
+      // reconciliation job resolve. Idempotent providers (a future HTTP
+      // backend with capabilities.idempotency=true) MAY transport-retry
+      // these classes too — out of scope for this v0.1 LocalCliProvider.
+      if (outcome.kind === 'indeterminate') {
+        return {
+          raw: '',
+          transportAttempts,
+          status: 'indeterminate',
+        };
+      }
+      // non_transient: bad input / spawn failure / unclassified non-zero —
+      // no retry, surface error immediately.
+      return {
+        raw: '',
+        transportAttempts,
+        status: 'error',
+      };
+    }
+
+    // Loop ended → cap reached on transient_safe_retry. lastOutcome is set.
+    void lastOutcome;
+    return {
+      raw: '',
+      transportAttempts,
+      status: 'error',
+    };
   }
 
   private resolveArgv(): string[] {
@@ -161,7 +260,25 @@ interface RunOnceOpts {
   timeoutMs: number;
 }
 
-function runOnce(opts: RunOnceOpts): Promise<LLMChatResult> {
+// Single-attempt outcome classification per spec §5.15 / issue #27.
+//   - 'ok'                    — exit 0, raw stdout payload returned.
+//   - 'transient_safe_retry'  — supervisor-style signal exits (130 SIGINT, 137
+//     SIGKILL by an EXTERNAL killer, NOT us). Effectively the call did not
+//     reach the model side; safe to retry with the same logical key.
+//   - 'indeterminate'         — adapter-fired SIGKILL on our timeout, or
+//     connection-reset / unknown_status. The call MAY have reached the
+//     model; for an idempotency:false provider we don't retry — daily
+//     reconciliation resolves.
+//   - 'non_transient'         — exit 1 with non-empty stderr (bad input),
+//     spawn ENOENT, or any other non-zero code we have no specific
+//     handling for. Conservative default: do not retry.
+type AttemptOutcome =
+  | { kind: 'ok'; raw: string }
+  | { kind: 'transient_safe_retry'; reason: string }
+  | { kind: 'indeterminate'; reason: string }
+  | { kind: 'non_transient'; reason: string };
+
+function runOnceClassified(opts: RunOnceOpts): Promise<AttemptOutcome> {
   return new Promise((resolveP) => {
     const child = spawn(opts.cmd, opts.args, {
       env: opts.env,
@@ -169,28 +286,36 @@ function runOnce(opts: RunOnceOpts): Promise<LLMChatResult> {
     });
 
     const stdoutChunks: Buffer[] = [];
+    const stderrChunks: Buffer[] = [];
+    // Distinguish OUR timer-fired SIGKILL from an EXTERNAL signal kill.
+    // close() reports `signal: 'SIGKILL'` in both cases, so we need this
+    // flag to map adapter-timeout → indeterminate (per spec §5.15 the
+    // provider may have processed the request; pessimistic debit applies).
+    let timedOutByAdapter = false;
     let settled = false;
-    const settle = (result: LLMChatResult) => {
+    const settle = (outcome: AttemptOutcome) => {
       if (settled) return;
       settled = true;
       clearTimeout(timer);
-      resolveP(result);
+      resolveP(outcome);
     };
 
     const timer: NodeJS.Timeout = setTimeout(() => {
       // SIGKILL — the spec wants pessimistic-on-timeout behavior; a polite
       // SIGTERM the child can ignore would defeat the wall-clock guarantee.
+      timedOutByAdapter = true;
       try {
         child.kill('SIGKILL');
       } catch {
         // already exited
       }
-      settle({ raw: '', transportAttempts: 1, status: 'error' });
+      // Don't settle yet — let the close handler observe the kill and
+      // emit the final classification. close fires reliably after kill.
     }, opts.timeoutMs);
 
     child.on('error', () => {
-      // ENOENT (binary not found) and similar spawn failures.
-      settle({ raw: '', transportAttempts: 1, status: 'error' });
+      // ENOENT (binary not found) and similar spawn failures — non-transient.
+      settle({ kind: 'non_transient', reason: 'spawn_error' });
     });
 
     child.stdout.on('data', (c: Buffer) => stdoutChunks.push(c));
@@ -198,28 +323,64 @@ function runOnce(opts: RunOnceOpts): Promise<LLMChatResult> {
       // Stream errors fold into the same error path; the close handler will
       // observe the non-zero exit / signal.
     });
-    child.stderr.on('data', () => {
-      // Captured but intentionally not surfaced — keep logged messages
-      // generic per CLAUDE.md "no vendor name leaks". Future: stream into
-      // structured-log middleware behind an injected sink.
-    });
+    child.stderr.on('data', (c: Buffer) => stderrChunks.push(c));
     child.stderr.on('error', () => {});
 
     child.on('close', (code, signal) => {
-      const raw = Buffer.concat(stdoutChunks).toString('utf8');
-      if (code === 0) {
-        settle({ raw, transportAttempts: 1, status: 'ok' });
-      } else {
-        // Killed by timeout (SIGKILL) OR non-zero exit → error w/ empty raw.
-        void signal;
-        settle({ raw: '', transportAttempts: 1, status: 'error' });
+      if (timedOutByAdapter) {
+        // Spec §5.15 — `maybe_executed` outcome class. For idempotency:false
+        // (LocalCliProvider) the chat() loop will classify indeterminate and
+        // skip retry.
+        settle({ kind: 'indeterminate', reason: 'adapter_timeout' });
+        return;
       }
+      if (code === 0) {
+        const raw = Buffer.concat(stdoutChunks).toString('utf8');
+        settle({ kind: 'ok', raw });
+        return;
+      }
+      // Externally signal-killed (e.g. supervisor OOM-killer, SIGINT during
+      // shutdown). Not us — the call effectively didn't reach the provider,
+      // so it's safe to retry under the same logical key.
+      if (signal === 'SIGKILL' || signal === 'SIGINT' || signal === 'SIGTERM') {
+        settle({
+          kind: 'transient_safe_retry',
+          reason: `signal_${signal}`,
+        });
+        return;
+      }
+      // Issue #27 spec: exit codes 130 (SIGINT-coded) and 137 (SIGKILL-coded)
+      // are the conventional exit-code form when a process self-traps and
+      // re-exits with `128 + signo`. Treat as transient_safe_retry — same
+      // semantics as the signal case above.
+      if (code === 130 || code === 137) {
+        settle({
+          kind: 'transient_safe_retry',
+          reason: `exit_${code}`,
+        });
+        return;
+      }
+      // Issue #27 spec: exit 1 with non-empty stderr suggesting bad input.
+      // No retry — the input itself is the problem; retrying would just
+      // re-fail. Other non-zero codes we don't recognize fall through to
+      // the same conservative non-retry branch.
+      const stderrText = Buffer.concat(stderrChunks).toString('utf8');
+      void stderrText;
+      settle({
+        kind: 'non_transient',
+        reason: `exit_${code ?? 'null'}`,
+      });
     });
 
     child.stdin.on('error', () => {
       // EPIPE on a fast-failing child (e.g. exits before reading stdin).
-      // Close handler will produce the final error result.
+      // Close handler will produce the final classification.
     });
     child.stdin.end(opts.stdin);
   });
+}
+
+function defaultSleep(ms: number): Promise<void> {
+  if (ms <= 0) return Promise.resolve();
+  return new Promise((resolve) => setTimeout(resolve, ms));
 }

--- a/packages/llm-adapter/test/chat.test.ts
+++ b/packages/llm-adapter/test/chat.test.ts
@@ -177,10 +177,15 @@ describe('LocalCliProvider — chat() acceptance #4: error paths', () => {
     expect(result.raw).toBe('');
   });
 
-  it('subprocess timeout → status="error" and the process is killed', async () => {
+  it('subprocess timeout → status="indeterminate" and the process is killed', async () => {
+    // Issue #27 / spec §5.15: an adapter-fired SIGKILL on timeout maps to
+    // `maybe_executed` — the request may have reached the model. For an
+    // idempotency:false provider, we classify indeterminate (no retry;
+    // pessimistic spend reservation; reconciliation resolves later).
     const provider = new LocalCliProvider({
       argv: SLEEP_BIN,
       timeoutMs: 250,
+      backoffMs: [0, 0, 0],
     });
 
     const start = Date.now();
@@ -192,7 +197,7 @@ describe('LocalCliProvider — chat() acceptance #4: error paths', () => {
     });
     const elapsed = Date.now() - start;
 
-    expect(result.status).toBe('error');
+    expect(result.status).toBe('indeterminate');
     expect(result.raw).toBe('');
     // Should resolve well before vitest's per-test timeout, proving the
     // adapter actually killed the child rather than waiting on EOF.

--- a/packages/llm-adapter/test/fixtures/bad-input-bin.mjs
+++ b/packages/llm-adapter/test/fixtures/bad-input-bin.mjs
@@ -1,0 +1,37 @@
+#!/usr/bin/env node
+// Test fixture for issue #27 (transport-retry): exits with code 1 and writes
+// a "bad json" diagnostic to stderr. Used by acceptance #3 to assert the
+// adapter classifies exit-1-with-stderr as a non-transient error, returns
+// immediately, and does NOT transport-retry.
+//
+// Also records each invocation to WILLBUY_TEST_RECORDER so the test can
+// verify exactly one attempt happened.
+
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { stdin, stderr, env, pid, exit } from 'node:process';
+
+const counterPath = env.WILLBUY_TEST_COUNTER;
+const recorderPath = env.WILLBUY_TEST_RECORDER;
+
+let counter = 0;
+if (counterPath) {
+  try {
+    counter = Number(readFileSync(counterPath, 'utf8') || '0') + 1;
+  } catch {
+    counter = 1;
+  }
+  writeFileSync(counterPath, String(counter));
+}
+
+stdin.on('data', () => {});
+stdin.on('end', () => {
+  if (recorderPath) {
+    appendFileSync(
+      recorderPath,
+      JSON.stringify({ pid, counter, kind: 'bad-input' }) + '\n',
+    );
+  }
+  stderr.write('bad json: expected object, got token at line 1 col 1\n');
+  exit(1);
+});
+stdin.on('error', () => exit(2));

--- a/packages/llm-adapter/test/fixtures/flaky-exit-bin.mjs
+++ b/packages/llm-adapter/test/fixtures/flaky-exit-bin.mjs
@@ -1,0 +1,61 @@
+#!/usr/bin/env node
+// Test fixture for issue #27 (transport-retry): consults a counter file
+// (WILLBUY_TEST_COUNTER) and a comma-separated list of exit codes
+// (WILLBUY_TEST_EXIT_CODES, e.g. "137,137,0"). On invocation N (1-based)
+// it exits with the Nth code in the list. Also records each invocation's
+// env (PID, counter, WILLBUY_REQ_KEY, WILLBUY_LLM_MODEL) to
+// WILLBUY_TEST_RECORDER so the test can assert the same logical_request_key
+// is forwarded on every transport attempt.
+//
+// Used by:
+//  - acceptance #1 (137,137,0 → adapter retries up to 3 times, succeeds)
+//  - acceptance #2 (137,137,137 → adapter exhausts 3 attempts, errors)
+//  - acceptance #4 (record env on every attempt; same key across attempts)
+
+import { appendFileSync, readFileSync, writeFileSync } from 'node:fs';
+import { stdin, stdout, env, pid, exit } from 'node:process';
+
+const counterPath = env.WILLBUY_TEST_COUNTER;
+const recorderPath = env.WILLBUY_TEST_RECORDER;
+const codesEnv = env.WILLBUY_TEST_EXIT_CODES ?? '0';
+const codes = codesEnv
+  .split(',')
+  .map((s) => Number(s.trim()))
+  .filter((n) => Number.isFinite(n));
+
+let counter = 0;
+if (counterPath) {
+  try {
+    counter = Number(readFileSync(counterPath, 'utf8') || '0') + 1;
+  } catch {
+    counter = 1;
+  }
+  writeFileSync(counterPath, String(counter));
+}
+
+const idx = Math.min(counter - 1, codes.length - 1);
+const exitCode = codes[idx] ?? 0;
+
+const chunks = [];
+stdin.on('data', (c) => chunks.push(c));
+stdin.on('end', () => {
+  const line = JSON.stringify({
+    pid,
+    counter,
+    exit_code: exitCode,
+    req_key: env.WILLBUY_REQ_KEY ?? null,
+    model: env.WILLBUY_LLM_MODEL ?? null,
+  });
+  if (recorderPath) {
+    appendFileSync(recorderPath, line + '\n');
+  }
+  // On a "successful" attempt, write a recognizable payload to stdout so
+  // the test can assert raw is preserved across retried attempts. On a
+  // "failing" attempt, write nothing — the adapter's error path expects
+  // empty raw on non-zero exit anyway.
+  if (exitCode === 0) {
+    stdout.write(`OK_AFTER_${counter}_ATTEMPTS`);
+  }
+  exit(exitCode);
+});
+stdin.on('error', () => exit(2));

--- a/packages/llm-adapter/test/transport-retry.test.ts
+++ b/packages/llm-adapter/test/transport-retry.test.ts
@@ -1,0 +1,228 @@
+// Issue #27 (spec §5.15, §2 #15) — LLMProvider transport retry +
+// logical_request_key idempotency.
+//
+// Six acceptance scenarios from the issue body:
+//   1. 137 / 137 / 0  → ok with transportAttempts=3
+//   2. 137 / 137 / 137 → error with transportAttempts=3
+//   3. exit 1 + non-empty stderr ("bad json") → error immediately, attempts=1
+//      (non_transient — no retry)
+//   4. Same logicalRequestKey is forwarded as WILLBUY_REQ_KEY on EVERY
+//      transport attempt for the same logical request.
+//   5. provider.capabilities() returns idempotency: false.
+//   6. Subprocess that times out → status 'indeterminate' (separate from
+//      'error'); caller can distinguish.
+//
+// Spec §5.15 wiring assertions:
+//   - transport_attempt counter is observability only (it does NOT change
+//     the logical_request_key).
+//   - For idempotency:false providers, timeout|connection_reset|unknown_status
+//     classify indeterminate — they are NOT transport-retried (pessimistic).
+
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import { mkdtempSync, readFileSync, rmSync, existsSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join, resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+import { LocalCliProvider } from '../src/index.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const fixturesDir = resolve(here, 'fixtures');
+const FLAKY_EXIT_BIN = ['node', resolve(fixturesDir, 'flaky-exit-bin.mjs')];
+const BAD_INPUT_BIN = ['node', resolve(fixturesDir, 'bad-input-bin.mjs')];
+const SLEEP_BIN = ['node', resolve(fixturesDir, 'sleep-bin.mjs')];
+
+let workDir: string;
+
+beforeEach(() => {
+  workDir = mkdtempSync(join(tmpdir(), 'willbuy-llm-adapter-retry-'));
+});
+
+afterEach(() => {
+  if (workDir && existsSync(workDir)) {
+    rmSync(workDir, { recursive: true, force: true });
+  }
+});
+
+describe('LocalCliProvider — transport retry acceptance #1: transient → eventual ok', () => {
+  it('exits 137 on calls 1–2, succeeds on call 3 → status="ok", transportAttempts=3', async () => {
+    const counterPath = join(workDir, 'counter.txt');
+    const recorderPath = join(workDir, 'recorder.jsonl');
+
+    const provider = new LocalCliProvider({
+      argv: FLAKY_EXIT_BIN,
+      env: {
+        WILLBUY_TEST_COUNTER: counterPath,
+        WILLBUY_TEST_RECORDER: recorderPath,
+        WILLBUY_TEST_EXIT_CODES: '137,137,0',
+      },
+      // Zero-out backoff for fast tests; the production default is the
+      // jittered 0.5 s / 2 s / 8 s schedule from spec §5.15.
+      backoffMs: [0, 0, 0],
+    });
+
+    const result = await provider.chat({
+      staticPrefix: 'P',
+      dynamicTail: 'T',
+      logicalRequestKey: 'lk-acc-1',
+      maxOutputTokens: 800,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.transportAttempts).toBe(3);
+    expect(result.raw).toBe('OK_AFTER_3_ATTEMPTS');
+
+    // Three subprocess invocations actually happened — assert via the
+    // recorder rather than just trusting the counter the adapter saw.
+    const lines = readFileSync(recorderPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(3);
+  });
+});
+
+describe('LocalCliProvider — transport retry acceptance #2: transient → exhausted', () => {
+  it('exits 137 on all 3 calls → status="error", transportAttempts=3', async () => {
+    const counterPath = join(workDir, 'counter.txt');
+    const recorderPath = join(workDir, 'recorder.jsonl');
+
+    const provider = new LocalCliProvider({
+      argv: FLAKY_EXIT_BIN,
+      env: {
+        WILLBUY_TEST_COUNTER: counterPath,
+        WILLBUY_TEST_RECORDER: recorderPath,
+        WILLBUY_TEST_EXIT_CODES: '137,137,137',
+      },
+      backoffMs: [0, 0, 0],
+    });
+
+    const result = await provider.chat({
+      staticPrefix: 'P',
+      dynamicTail: 'T',
+      logicalRequestKey: 'lk-acc-2',
+      maxOutputTokens: 800,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.transportAttempts).toBe(3);
+    expect(result.raw).toBe('');
+
+    const lines = readFileSync(recorderPath, 'utf8').trim().split('\n');
+    // Cap is 3 transport attempts, no 4th call.
+    expect(lines).toHaveLength(3);
+  });
+});
+
+describe('LocalCliProvider — transport retry acceptance #3: non-transient (exit 1 + stderr)', () => {
+  it('exits 1 with non-empty stderr "bad json" → status="error" immediately, transportAttempts=1', async () => {
+    const counterPath = join(workDir, 'counter.txt');
+    const recorderPath = join(workDir, 'recorder.jsonl');
+
+    const provider = new LocalCliProvider({
+      argv: BAD_INPUT_BIN,
+      env: {
+        WILLBUY_TEST_COUNTER: counterPath,
+        WILLBUY_TEST_RECORDER: recorderPath,
+      },
+      backoffMs: [0, 0, 0],
+    });
+
+    const result = await provider.chat({
+      staticPrefix: 'P',
+      dynamicTail: 'T',
+      logicalRequestKey: 'lk-acc-3',
+      maxOutputTokens: 800,
+    });
+
+    expect(result.status).toBe('error');
+    expect(result.transportAttempts).toBe(1);
+    expect(result.raw).toBe('');
+
+    // Exactly one subprocess invocation — no retry on non_transient.
+    const lines = readFileSync(recorderPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(1);
+  });
+});
+
+describe('LocalCliProvider — transport retry acceptance #4: same logicalRequestKey across attempts', () => {
+  it('forwards the SAME logicalRequestKey as WILLBUY_REQ_KEY on every transport attempt', async () => {
+    const counterPath = join(workDir, 'counter.txt');
+    const recorderPath = join(workDir, 'recorder.jsonl');
+
+    const provider = new LocalCliProvider({
+      argv: FLAKY_EXIT_BIN,
+      env: {
+        WILLBUY_TEST_COUNTER: counterPath,
+        WILLBUY_TEST_RECORDER: recorderPath,
+        WILLBUY_TEST_EXIT_CODES: '137,137,0',
+      },
+      backoffMs: [0, 0, 0],
+    });
+
+    const SHARED_KEY = 'lk-shared-across-3-attempts';
+    const result = await provider.chat({
+      staticPrefix: 'P',
+      dynamicTail: 'T',
+      logicalRequestKey: SHARED_KEY,
+      maxOutputTokens: 800,
+    });
+
+    expect(result.status).toBe('ok');
+    expect(result.transportAttempts).toBe(3);
+
+    // Spec §5.15: ALL transport retries for the same logical request carry
+    // the SAME Idempotency-Key. The local-cli surface is WILLBUY_REQ_KEY
+    // on the subprocess env; same key on every invocation, no exception.
+    const lines = readFileSync(recorderPath, 'utf8').trim().split('\n');
+    expect(lines).toHaveLength(3);
+    for (const line of lines) {
+      const recorded = JSON.parse(line);
+      expect(recorded.req_key).toBe(SHARED_KEY);
+    }
+
+    // Spec §2 #15: transport_attempt counter is observability only — the
+    // logical_request_key MUST NOT include it (otherwise provider-side
+    // idempotency dedupe would break). Distinct PIDs prove three real
+    // subprocesses; identical req_key proves the logical key is stable.
+    const pids = lines.map((line) => JSON.parse(line).pid);
+    const uniquePids = new Set(pids);
+    expect(uniquePids.size).toBe(3);
+  });
+});
+
+describe('LocalCliProvider — transport retry acceptance #5: capability flag', () => {
+  it('reports idempotency: false (local CLI does not honor Idempotency-Key)', () => {
+    const provider = new LocalCliProvider();
+    expect(provider.capabilities().idempotency).toBe(false);
+  });
+});
+
+describe('LocalCliProvider — transport retry acceptance #6: timeout → indeterminate', () => {
+  it('subprocess that times out → status="indeterminate" (separate from "error"); transportAttempts=1', async () => {
+    const provider = new LocalCliProvider({
+      argv: SLEEP_BIN,
+      timeoutMs: 250,
+      // For an idempotency:false provider, spec §5.15 says
+      // timeout|connection_reset|unknown_status MUST NOT be transport-retried;
+      // they are pessimistically classified indeterminate and resolved by
+      // the daily reconciliation job. Backoff config is therefore moot
+      // here, but pass [0,0,0] for fast tests anyway.
+      backoffMs: [0, 0, 0],
+    });
+
+    const start = Date.now();
+    const result = await provider.chat({
+      staticPrefix: 'P',
+      dynamicTail: 'T',
+      logicalRequestKey: 'lk-acc-6',
+      maxOutputTokens: 800,
+    });
+    const elapsed = Date.now() - start;
+
+    // Distinguishable from 'error' — the caller can branch on this.
+    expect(result.status).toBe('indeterminate');
+    expect(result.raw).toBe('');
+    // No transport retry on timeout for an idempotency:false provider.
+    expect(result.transportAttempts).toBe(1);
+    // Killed promptly; not waiting on EOF or doing a second 250 ms timeout.
+    expect(elapsed).toBeLessThan(2_000);
+  });
+});


### PR DESCRIPTION
Closes #27

## Summary

Implements spec §5.15 transport-retry-with-stable-`logical_request_key` inside `LocalCliProvider`. A transient transport failure (signal-killed / external-supervisor-killed) no longer surfaces as `status: 'error'` to the visitor-worker — the adapter retries up to 3 attempts under the same `logicalRequestKey` (forwarded as `WILLBUY_REQ_KEY` on every attempt) with the documented jittered backoff (0.5 s → 2 s → 8 s).

Three outcome classes:

- `transient_safe_retry` (exit 130/137, external SIGINT/SIGKILL/SIGTERM) → retry, same logical key.
- `non_transient` (exit 1 + non-empty stderr, spawn ENOENT, other non-zero) → no retry, `status: 'error'`.
- `indeterminate` (adapter-fired SIGKILL on timeout = `maybe_executed`) → no retry for `idempotency: false` providers; `status: 'indeterminate'` so the caller distinguishes hard error from "may have run on the provider side; let the daily reconciliation job resolve."

`transportAttempts` now reflects actual on-wire attempts (was always 1 in v0.1) and is observability-only per spec §2 #15 — it does NOT contribute to `logical_request_key`.

`LocalCliProviderOptions` gains `backoffMs` / `jitter` / `sleepFn` for fast tests + operator tunability; defaults match the spec 1:1.

## Test plan

Six TDD acceptance scenarios from issue #27 in `packages/llm-adapter/test/transport-retry.test.ts`, red commit then green commit:

- [x] #1 — exits 137 on calls 1–2, succeeds on 3 → `ok` with `transportAttempts=3`
- [x] #2 — exits 137 on all 3 calls → `error` with `transportAttempts=3`
- [x] #3 — exit 1 + non-empty stderr → `error` immediately, `transportAttempts=1` (no retry)
- [x] #4 — same `logicalRequestKey` forwarded as `WILLBUY_REQ_KEY` on EVERY attempt (recorded by fixture, asserted across all 3 invocations; distinct PIDs prove three real subprocesses)
- [x] #5 — `capabilities().idempotency === false`
- [x] #6 — timeout → `status: 'indeterminate'` (separate from `error`)

Plus the pre-existing `chat.test.ts` timeout assertion flipped from `'error'` to `'indeterminate'` to match the new classification (no other downstream test breakage — `apps/visitor-worker/` untouched; its existing `attempts: 1` transport-error test stays green because it mocks the adapter return value, so the new internal retry loop is invisible at the orchestrator boundary).

Repo-wide CI is green locally:

- `pnpm test` — 70 tests across 6 workspaces all pass
- `pnpm typecheck` — clean
- `pnpm lint` — clean

## Spec link

Implements spec §5.15 (transport retries with same `logical_request_key`, capability-flag-aware, jittered backoff 0.5/2/8 s, pessimistic `indeterminate` on `maybe_executed` for non-idempotent providers) and §2 #15 (transport-attempt counter is observability only).

## Public-repo audit

- No new secrets, IPs, tokens, or vendor identifiers in the diff.
- No new forbidden adapter identifiers (`conversation_id`, `session_id`, `thread_id`, etc.) — AST lint passes.
- The two pre-existing `'claude'` strings (default `WILLBUY_LLM_BIN` argv + comment referencing issue #5) are unchanged from `main` and are out of this PR's scope.