### PR TITLE
feat(web): report visualization (§5.18 — 7 elements)

### DIFF
--- a/apps/web/app/r/[slug]/fetchReport.ts
+++ b/apps/web/app/r/[slug]/fetchReport.ts
@@ -1,0 +1,26 @@
+// Server-only seam for reading a report payload by slug. Actual fetch
+// against the API (with share-token cookie auth per §5.12) lands when
+// the report-API endpoint is wired (sprint-2 issue S2-6, #31's
+// neighborhood). For now we serve the fixture under a single
+// well-known slug so the report page is testable end-to-end and the
+// lighthouse perf budget can run against it.
+//
+// `WILLBUY_REPORT_FIXTURE` env (default off) gates the fixture path.
+// Production deploy sets it to `disabled`; dev / preview / test set it
+// to `enabled`. This stays out of the prod surface area.
+
+import fixture from '../../../test/fixtures/report.fixture.json';
+
+const FIXTURE_SLUG = 'test-fixture';
+
+export async function fetchReport(slug: string): Promise<unknown | null> {
+  if (
+    process.env.WILLBUY_REPORT_FIXTURE === 'enabled' &&
+    slug === FIXTURE_SLUG
+  ) {
+    return fixture;
+  }
+  // The real lookup lands when the report-API issue ships; for now any
+  // non-fixture slug 404s.
+  return null;
+}

--- a/apps/web/app/r/[slug]/page.tsx
+++ b/apps/web/app/r/[slug]/page.tsx
@@ -1,9 +1,12 @@
 import type { Metadata } from 'next';
 
-// SPEC §5.10: /r/* is the public-report render boundary. We mark it
-// noindex here AND apply the strict CSP via middleware.ts. Real report
-// rendering (§5.18) lands in a follow-up issue once the data shape is
-// stable; this page exists only to anchor the route + headers.
+import { Report, type ReportT } from '@willbuy/shared/report';
+import { ReportView } from '../../../components/report/ReportView';
+import { fetchReport } from './fetchReport';
+
+// Spec §5.10: /r/* is the public-report render boundary. The strict CSP
+// is applied in middleware.ts; we mark the route noindex here and rely
+// on the CSP header for inline-script discipline.
 export const metadata: Metadata = {
   robots: { index: false, follow: false },
 };
@@ -13,15 +16,33 @@ export default async function ReportPage({
 }: {
   params: Promise<{ slug: string }>;
 }) {
-  // Touch the param so the route is treated as dynamic per slug. The
-  // slug is rendered as <code> text — never as a hyperlink — per §5.10.
   const { slug } = await params;
+  const result = await fetchReport(slug);
+
+  if (result === null) {
+    return (
+      <main className="mx-auto max-w-3xl px-6 py-16">
+        <h1 className="text-3xl font-bold tracking-tight">Report not found</h1>
+        <p className="mt-6 text-gray-700">
+          No report exists for <code>{slug}</code>, or the share link has been revoked.
+        </p>
+      </main>
+    );
+  }
+
+  // Parse at the boundary (per CLAUDE.md zod-at-the-boundary rule).
+  // Anything that fails this validation is an aggregator-side bug and
+  // we'd rather 500 than render a malformed report.
+  const report: ReportT = Report.parse(result);
   return (
-    <main className="mx-auto max-w-3xl px-6 py-16">
-      <h1 className="text-3xl font-bold tracking-tight">Public report — pending implementation</h1>
-      <p className="mt-6 text-gray-700">
-        Report <code>{slug}</code> will render once §5.18 is implemented.
-      </p>
+    <main className="mx-auto max-w-6xl px-4 py-10">
+      <header className="mb-6">
+        <p className="text-xs uppercase tracking-wide text-gray-500">willbuy.dev — public report</p>
+        <h1 className="text-2xl font-bold tracking-tight text-gray-900">
+          Study <code className="text-base">{report.meta.slug}</code>
+        </h1>
+      </header>
+      <ReportView report={report} mode="public" />
     </main>
   );
 }

--- a/apps/web/components/report/DisagreementBanner.tsx
+++ b/apps/web/components/report/DisagreementBanner.tsx
@@ -1,0 +1,29 @@
+'use client';
+
+import type { ReportT } from './types';
+
+// Spec §2 #19 — paired-t and Wilcoxon disagreement rule. When one
+// p < 0.05 and the other p ≥ 0.05, the report surfaces an explicit
+// banner, the conclusion is labeled "weak — tests disagree," and the
+// ship-gate copy uses the MORE CONSERVATIVE (larger) p-value.
+
+export function DisagreementBanner({ headline }: { headline: ReportT['headline'] }) {
+  if (!headline.disagreement) return null;
+  const conservativeP = Math.max(headline.paired_t_p, headline.wilcoxon_p);
+  return (
+    <div
+      data-testid="disagreement-banner"
+      role="alert"
+      className="rounded-lg border border-amber-300 bg-amber-50 p-4"
+    >
+      <p className="font-semibold text-amber-900">
+        Weak — tests disagree (paired-t and Wilcoxon).
+      </p>
+      <p className="mt-1 text-sm text-amber-900">
+        Reading the conservative (larger) p-value: {conservativeP.toFixed(3)}.
+        Per spec §2 #19, this run does not clear the significance bar; do not
+        ship a copy change off this study alone.
+      </p>
+    </div>
+  );
+}

--- a/apps/web/components/report/HeadlineDelta.tsx
+++ b/apps/web/components/report/HeadlineDelta.tsx
@@ -1,0 +1,78 @@
+'use client';
+
+import type { ReportT } from './types';
+
+// Spec §5.18 #1 — large-type mean delta + 95% CI + N paired + paired-t
+// + Wilcoxon + McNemar + one-sentence verdict. Disagreement banner per
+// §2 #19 lives in <DisagreementBanner /> as its own component since the
+// rule is named-and-tested.
+
+function fmt(n: number, digits = 2): string {
+  return n.toFixed(digits);
+}
+
+function fmtP(p: number): string {
+  // Standard convention: print exact value to 3 dp; clamp very small.
+  if (p < 0.001) return 'p < 0.001';
+  return `p = ${p.toFixed(3)}`;
+}
+
+function deltaSign(d: number): string {
+  if (d > 0) return '+';
+  return '';
+}
+
+const VERDICT_COPY: Record<ReportT['headline']['verdict'], string> = {
+  better: 'NEW converts better.',
+  worse: 'NEW converts worse.',
+  inconclusive: 'Inconclusive — no clear winner.',
+};
+
+export function HeadlineDelta({ headline }: { headline: ReportT['headline'] }) {
+  const { mean_delta, ci95_low, ci95_high, n_paired, paired_t_p, wilcoxon_p, mcnemar_p, verdict } =
+    headline;
+  return (
+    <section
+      data-testid="headline-delta"
+      className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+    >
+      <div className="flex flex-wrap items-baseline gap-x-6 gap-y-2">
+        <div className="flex items-baseline gap-2">
+          <span className="text-5xl font-bold tracking-tight text-gray-900">
+            {deltaSign(mean_delta)}
+            {fmt(mean_delta)}
+          </span>
+          <span className="text-sm uppercase tracking-wide text-gray-500">
+            mean Δ will-to-buy
+          </span>
+        </div>
+        <div className="text-sm text-gray-700">
+          95% CI [{fmt(ci95_low)}, {fmt(ci95_high)}]
+        </div>
+        <div className="text-sm text-gray-700">N paired = {n_paired}</div>
+      </div>
+      <p className="mt-3 text-lg font-medium text-gray-800">
+        {VERDICT_COPY[verdict]}
+      </p>
+      <dl className="mt-4 grid grid-cols-1 gap-2 text-sm text-gray-700 sm:grid-cols-3">
+        <div>
+          <dt className="font-medium text-gray-900">paired-t</dt>
+          <dd>{fmtP(paired_t_p)}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-gray-900">Wilcoxon signed-rank</dt>
+          <dd>{fmtP(wilcoxon_p)}</dd>
+        </div>
+        <div>
+          <dt className="font-medium text-gray-900">McNemar (binary)</dt>
+          <dd>{fmtP(mcnemar_p)}</dd>
+        </div>
+      </dl>
+      <p className="mt-3 text-xs text-gray-500">
+        Note: the conversion-weighted score (which gives <code>contact_sales</code> weight 0.8) is a
+        different quantity than the McNemar binarization (which counts <code>contact_sales</code>
+        as <code>converted=1</code>). Don&rsquo;t conflate them.
+      </p>
+    </section>
+  );
+}

--- a/apps/web/components/report/Histograms.tsx
+++ b/apps/web/components/report/Histograms.tsx
@@ -1,0 +1,62 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { ReportT, VariantId } from './types';
+
+// Spec §5.18 #3 — discrete 0–10 will-to-buy bins per variant; mean and
+// median annotated. Side-by-side; overlay toggle is v0.1.1 (out of scope).
+
+const VARIANT_COLOR: Record<VariantId, string> = {
+  A: '#475569', // slate
+  B: '#16a34a', // green (matches dot-plot "B wins")
+};
+
+function HistOne({ row }: { row: ReportT['histograms'][number] }) {
+  const data = row.bins.map((count, score) => ({ score, count }));
+  return (
+    <div
+      data-testid={`histogram-${row.variant}`}
+      className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+    >
+      <div className="flex items-baseline justify-between">
+        <h3 className="font-semibold text-gray-900">Variant {row.variant}</h3>
+        <span className="text-xs text-gray-600">
+          mean {row.mean.toFixed(2)} · median {row.median}
+        </span>
+      </div>
+      <div className="mt-2 h-48 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="score" tickCount={11} />
+            <YAxis allowDecimals={false} />
+            <Tooltip contentStyle={{ fontSize: 12 }} />
+            <Bar dataKey="count" fill={VARIANT_COLOR[row.variant]} />
+            <ReferenceLine x={row.mean} stroke="#dc2626" strokeDasharray="4 2" />
+            <ReferenceLine x={row.median} stroke="#2563eb" strokeDasharray="2 2" />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+export function Histograms({ histograms }: { histograms: ReportT['histograms'] }) {
+  return (
+    <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
+      {histograms.map((h) => (
+        <HistOne key={h.variant} row={h} />
+      ))}
+    </section>
+  );
+}

--- a/apps/web/components/report/NextActions.tsx
+++ b/apps/web/components/report/NextActions.tsx
@@ -1,0 +1,98 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { NextActionT } from '@willbuy/shared/scoring';
+import type { ReportT } from './types';
+
+// Spec §5.18 #4 + amendment A1 — 8 actions ordered by intent weight.
+// Sankey on toggle is named in §5.18; v0.1 ships the default stacked
+// bar (which is what §5.18 calls out as "scan-ability"). Sankey toggle
+// is plumbed as a flag here but the Sankey component itself is left as
+// a v0.1.1 follow-up (one component, one issue) since it requires
+// additional Recharts plugins.
+
+// Ordered by intent weight (amendment A1) — paid-now first, leave last.
+const ORDERED_ACTIONS: NextActionT[] = [
+  'purchase_paid_today',
+  'contact_sales',
+  'book_demo',
+  'start_paid_trial',
+  'bookmark_compare_later',
+  'ask_teammate',
+  'start_free_hobby',
+  'leave',
+];
+
+const ACTION_COLOR: Record<NextActionT, string> = {
+  purchase_paid_today: '#15803d',
+  contact_sales: '#22c55e',
+  book_demo: '#84cc16',
+  start_paid_trial: '#eab308',
+  bookmark_compare_later: '#f97316',
+  ask_teammate: '#a855f7',
+  start_free_hobby: '#94a3b8',
+  leave: '#dc2626',
+};
+
+const ACTION_LABEL: Record<NextActionT, string> = {
+  purchase_paid_today: 'Purchase today',
+  contact_sales: 'Contact sales',
+  book_demo: 'Book demo',
+  start_paid_trial: 'Start paid trial',
+  bookmark_compare_later: 'Bookmark / compare',
+  ask_teammate: 'Ask teammate',
+  start_free_hobby: 'Free hobby',
+  leave: 'Leave',
+};
+
+export function NextActions({ rows }: { rows: ReportT['next_actions'] }) {
+  // Recharts wants one row per x-axis tick; we want one tick per variant.
+  const data = rows.map((r) => {
+    const obj: Record<string, number | string> = { variant: r.variant };
+    for (const action of ORDERED_ACTIONS) {
+      obj[action] = r.counts[action] ?? 0;
+    }
+    return obj;
+  });
+  return (
+    <section
+      data-testid="next-actions"
+      className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+    >
+      <h2 className="text-lg font-semibold text-gray-900">Next-action distribution</h2>
+      <p className="mt-1 text-sm text-gray-600">
+        8 actions ordered by intent weight (amendment A1). Stacked counts per variant.
+      </p>
+      <div className="mt-4 h-72 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="variant" />
+            <YAxis allowDecimals={false} />
+            <Tooltip contentStyle={{ fontSize: 12 }} />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            {ORDERED_ACTIONS.map((action) => (
+              <Bar
+                key={action}
+                dataKey={action}
+                stackId="next_action"
+                fill={ACTION_COLOR[action]}
+                name={ACTION_LABEL[action]}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/report/PairedDots.tsx
+++ b/apps/web/components/report/PairedDots.tsx
@@ -1,0 +1,111 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  CartesianGrid,
+  ReferenceLine,
+  ResponsiveContainer,
+  Scatter,
+  ScatterChart,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { ReportT } from './types';
+
+// Spec §5.18 #2 — the key viz. Per-visitor dots showing A vs B with a
+// thin connecting segment, color-coded by swing direction. Hover/click
+// reveals backstory + both verdicts.
+//
+// Implementation: we plot two scatter series (A and B) sharing the same
+// x axis (1..n) so each backstory occupies one column. The thin
+// connecting segment is drawn via a SVG <line> overlay keyed off the
+// chart geometry — Recharts' <Customized /> would also work but a
+// per-row segment is cleaner with the data already in column form.
+
+const SWING_COLOR: Record<ReportT['paired_dots'][number]['swing'], string> = {
+  a_wins: '#dc2626', // red — variant A scored higher
+  tie: '#9ca3af', // gray
+  b_wins: '#16a34a', // green — variant B (NEW) scored higher
+};
+
+export function PairedDots({ rows }: { rows: ReportT['paired_dots'] }) {
+  const [active, setActive] = useState<string | null>(null);
+  // Sort by swing magnitude desc so the chart reads left → right as
+  // "biggest moves first." Stable secondary sort by id for determinism.
+  const sorted = [...rows].sort((p, q) => {
+    const dp = Math.abs(p.score_b - p.score_a);
+    const dq = Math.abs(q.score_b - q.score_a);
+    if (dq !== dp) return dq - dp;
+    return p.backstory_id.localeCompare(q.backstory_id);
+  });
+  const data = sorted.map((row, idx) => ({
+    x: idx + 1,
+    score_a: row.score_a,
+    score_b: row.score_b,
+    swing: row.swing,
+    backstory_id: row.backstory_id,
+    backstory_name: row.backstory_name,
+  }));
+
+  const activeRow = sorted.find((r) => r.backstory_id === active) ?? null;
+
+  return (
+    <section
+      data-testid="paired-dots"
+      className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+    >
+      <h2 className="text-lg font-semibold text-gray-900">Paired-delta dot plot</h2>
+      <p className="mt-1 text-sm text-gray-600">
+        One column per backstory. Red = A higher, green = B higher, gray = tie.
+      </p>
+      <div className="mt-4 h-64 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <ScatterChart margin={{ top: 16, right: 16, bottom: 16, left: 0 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis dataKey="x" type="number" name="Backstory" tick={false} />
+            <YAxis type="number" domain={[0, 10]} ticks={[0, 2, 4, 6, 8, 10]} />
+            <ReferenceLine y={5} stroke="#d1d5db" strokeDasharray="4 4" />
+            <Tooltip
+              cursor={{ strokeDasharray: '3 3' }}
+              contentStyle={{ fontSize: 12 }}
+              formatter={(v: number) => v.toFixed(0)}
+            />
+            <Scatter
+              name="A"
+              data={data}
+              dataKey="score_a"
+              fill="#1f2937"
+              shape="circle"
+              onClick={(d) => setActive((d as { backstory_id: string }).backstory_id)}
+            />
+            <Scatter
+              name="B"
+              data={data}
+              dataKey="score_b"
+              shape="circle"
+              onClick={(d) => setActive((d as { backstory_id: string }).backstory_id)}
+            >
+              {data.map((d) => (
+                <Scatter key={d.backstory_id} fill={SWING_COLOR[d.swing]} />
+              ))}
+            </Scatter>
+          </ScatterChart>
+        </ResponsiveContainer>
+      </div>
+      {activeRow ? (
+        <div
+          data-testid="paired-dot-card"
+          className="mt-4 rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-800"
+        >
+          <div className="font-medium">{activeRow.backstory_name}</div>
+          <div className="text-xs text-gray-600">
+            A score: {activeRow.score_a} · B score: {activeRow.score_b} · swing:{' '}
+            {activeRow.swing.replace('_', ' ')}
+          </div>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/components/report/PairedDots.tsx
+++ b/apps/web/components/report/PairedDots.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react';
 import {
   CartesianGrid,
+  Cell,
+  Customized,
   ReferenceLine,
   ResponsiveContainer,
   Scatter,
@@ -18,11 +20,11 @@ import type { ReportT } from './types';
 // thin connecting segment, color-coded by swing direction. Hover/click
 // reveals backstory + both verdicts.
 //
-// Implementation: we plot two scatter series (A and B) sharing the same
-// x axis (1..n) so each backstory occupies one column. The thin
-// connecting segment is drawn via a SVG <line> overlay keyed off the
-// chart geometry — Recharts' <Customized /> would also work but a
-// per-row segment is cleaner with the data already in column form.
+// Implementation: two Scatter series (A and B) share the same x-axis
+// (1..n) so each backstory occupies one column. The thin connecting
+// segment is drawn via Recharts <Customized />, which receives the live
+// chart scales so we can map (x, score_a) → (x, score_b) into SVG
+// pixel coordinates and emit one <line> per backstory.
 
 const SWING_COLOR: Record<ReportT['paired_dots'][number]['swing'], string> = {
   a_wins: '#dc2626', // red — variant A scored higher
@@ -30,17 +32,49 @@ const SWING_COLOR: Record<ReportT['paired_dots'][number]['swing'], string> = {
   b_wins: '#16a34a', // green — variant B (NEW) scored higher
 };
 
-export function PairedDots({ rows }: { rows: ReportT['paired_dots'] }) {
-  const [active, setActive] = useState<string | null>(null);
-  // Sort by swing magnitude desc so the chart reads left → right as
-  // "biggest moves first." Stable secondary sort by id for determinism.
+// Shape passed by Recharts to <Customized component={...} />.
+// We only use the axis maps to compute pixel coordinates.
+interface CustomizedProps {
+  xAxisMap?: Record<string, { scale: (v: number) => number }>;
+  yAxisMap?: Record<string, { scale: (v: number) => number }>;
+}
+
+function Connectors({
+  data,
+  xAxisMap,
+  yAxisMap,
+}: CustomizedProps & { data: ReturnType<typeof buildData> }) {
+  const xScale = xAxisMap && Object.values(xAxisMap)[0]?.scale;
+  const yScale = yAxisMap && Object.values(yAxisMap)[0]?.scale;
+  if (!xScale || !yScale) return null;
+
+  return (
+    <g>
+      {data.map((d) => (
+        <line
+          key={d.backstory_id}
+          data-connector={d.backstory_id}
+          x1={xScale(d.x)}
+          y1={yScale(d.score_a)}
+          x2={xScale(d.x)}
+          y2={yScale(d.score_b)}
+          stroke={SWING_COLOR[d.swing]}
+          strokeWidth={1.5}
+          strokeOpacity={0.6}
+        />
+      ))}
+    </g>
+  );
+}
+
+function buildData(rows: ReportT['paired_dots']) {
   const sorted = [...rows].sort((p, q) => {
     const dp = Math.abs(p.score_b - p.score_a);
     const dq = Math.abs(q.score_b - q.score_a);
     if (dq !== dp) return dq - dp;
     return p.backstory_id.localeCompare(q.backstory_id);
   });
-  const data = sorted.map((row, idx) => ({
+  return sorted.map((row, idx) => ({
     x: idx + 1,
     score_a: row.score_a,
     score_b: row.score_b,
@@ -48,8 +82,13 @@ export function PairedDots({ rows }: { rows: ReportT['paired_dots'] }) {
     backstory_id: row.backstory_id,
     backstory_name: row.backstory_name,
   }));
+}
 
-  const activeRow = sorted.find((r) => r.backstory_id === active) ?? null;
+export function PairedDots({ rows }: { rows: ReportT['paired_dots'] }) {
+  const [active, setActive] = useState<string | null>(null);
+  const data = buildData(rows);
+
+  const activeRow = rows.find((r) => r.backstory_id === active) ?? null;
 
   return (
     <section
@@ -72,6 +111,12 @@ export function PairedDots({ rows }: { rows: ReportT['paired_dots'] }) {
               contentStyle={{ fontSize: 12 }}
               formatter={(v: number) => v.toFixed(0)}
             />
+            {/* Connector lines drawn before dots so dots render on top. */}
+            <Customized
+              component={(props: CustomizedProps) => (
+                <Connectors {...props} data={data} />
+              )}
+            />
             <Scatter
               name="A"
               data={data}
@@ -80,6 +125,7 @@ export function PairedDots({ rows }: { rows: ReportT['paired_dots'] }) {
               shape="circle"
               onClick={(d) => setActive((d as { backstory_id: string }).backstory_id)}
             />
+            {/* F2: use <Cell> for per-dot swing coloring (Recharts contract). */}
             <Scatter
               name="B"
               data={data}
@@ -88,7 +134,7 @@ export function PairedDots({ rows }: { rows: ReportT['paired_dots'] }) {
               onClick={(d) => setActive((d as { backstory_id: string }).backstory_id)}
             >
               {data.map((d) => (
-                <Scatter key={d.backstory_id} fill={SWING_COLOR[d.swing]} />
+                <Cell key={d.backstory_id} fill={SWING_COLOR[d.swing]} />
               ))}
             </Scatter>
           </ScatterChart>

--- a/apps/web/components/report/PersonaGrid.tsx
+++ b/apps/web/components/report/PersonaGrid.tsx
@@ -1,0 +1,141 @@
+'use client';
+
+import { useState } from 'react';
+
+import type { ReportT } from './types';
+
+// Spec §5.18 #7 — persona cards grid, sortable by |score_b - score_a|
+// (largest swings first). Click expands = full response on each variant
+// + WTB reasoning (loaded on demand in production; the fixture inlines
+// preview verdicts).
+
+type Persona = ReportT['personas'][number];
+
+const ROLE_LABEL: Record<Persona['role'], string> = {
+  founder_or_eng_lead: 'founder / eng lead',
+  ic_engineer: 'IC engineer',
+};
+
+function PersonaCard({
+  persona,
+  onClick,
+}: {
+  persona: Persona;
+  onClick: () => void;
+}) {
+  const swing = persona.score_b - persona.score_a;
+  const swingSign = swing > 0 ? '+' : '';
+  const swingColor = swing > 0 ? 'text-green-700' : swing < 0 ? 'text-red-700' : 'text-gray-600';
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      data-testid={`persona-card-${persona.backstory_id}`}
+      data-backstory-id={persona.backstory_id}
+      className="rounded-lg border border-gray-200 bg-white p-4 text-left shadow-sm transition hover:border-gray-400 focus:outline-none focus:ring-2 focus:ring-blue-500"
+    >
+      <div className="flex items-baseline justify-between gap-2">
+        <h3 className="font-semibold text-gray-900">{persona.backstory_name}</h3>
+        <span className={`text-sm font-medium ${swingColor}`}>
+          {swingSign}
+          {swing}
+        </span>
+      </div>
+      <p className="mt-1 text-xs uppercase tracking-wide text-gray-500">
+        {ROLE_LABEL[persona.role]}
+      </p>
+      <dl className="mt-2 space-y-1 text-xs text-gray-700">
+        <div>
+          <dt className="inline font-medium">stage:</dt> <dd className="inline">{persona.stage}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">team:</dt> <dd className="inline">{persona.team_size}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">stack:</dt> <dd className="inline">{persona.stack}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">pain:</dt> <dd className="inline">{persona.current_pain}</dd>
+        </div>
+        <div>
+          <dt className="inline font-medium">entry:</dt> <dd className="inline">{persona.entry_point}</dd>
+        </div>
+      </dl>
+      <div className="mt-3 flex items-center gap-3 text-sm text-gray-800">
+        <span>A: {persona.score_a}</span>
+        <span>B: {persona.score_b}</span>
+      </div>
+    </button>
+  );
+}
+
+function PersonaDrawer({
+  persona,
+  onClose,
+}: {
+  persona: Persona;
+  onClose: () => void;
+}) {
+  return (
+    <div
+      data-testid="persona-drawer"
+      className="rounded-lg border border-gray-300 bg-white p-6 shadow-md"
+    >
+      <div className="flex items-baseline justify-between">
+        <h3 className="text-lg font-semibold text-gray-900">{persona.backstory_name}</h3>
+        <button
+          type="button"
+          onClick={onClose}
+          className="text-sm text-gray-500 underline focus:outline-none focus:ring-2 focus:ring-blue-500"
+        >
+          close
+        </button>
+      </div>
+      <p className="mt-1 text-sm text-gray-600">
+        {ROLE_LABEL[persona.role]} · {persona.stage} · team {persona.team_size} · {persona.stack}
+      </p>
+      <div className="mt-4 grid grid-cols-1 gap-4 md:grid-cols-2">
+        <div data-testid="drawer-verdict-A" className="rounded border border-gray-200 bg-gray-50 p-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+            Variant A · score {persona.score_a}
+          </p>
+          <p className="mt-2 text-sm text-gray-800">{persona.verdict_a}</p>
+        </div>
+        <div data-testid="drawer-verdict-B" className="rounded border border-gray-200 bg-gray-50 p-3">
+          <p className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+            Variant B · score {persona.score_b}
+          </p>
+          <p className="mt-2 text-sm text-gray-800">{persona.verdict_b}</p>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+export function PersonaGrid({ personas }: { personas: ReportT['personas'] }) {
+  const [active, setActive] = useState<string | null>(null);
+  // Sort by |score_b - score_a| desc; stable by id.
+  const sorted = [...personas].sort((p, q) => {
+    const dp = Math.abs(p.score_b - p.score_a);
+    const dq = Math.abs(q.score_b - q.score_a);
+    if (dq !== dp) return dq - dp;
+    return p.backstory_id.localeCompare(q.backstory_id);
+  });
+  const activePersona = sorted.find((p) => p.backstory_id === active) ?? null;
+  return (
+    <section className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-900">Persona cards</h2>
+      <p className="text-sm text-gray-600">
+        Sorted by |Δ score| — largest swings first. Click a card for the full A/B verdicts.
+      </p>
+      <div data-testid="persona-grid" className="grid grid-cols-1 gap-3 md:grid-cols-2 lg:grid-cols-3">
+        {sorted.map((p) => (
+          <PersonaCard key={p.backstory_id} persona={p} onClick={() => setActive(p.backstory_id)} />
+        ))}
+      </div>
+      {activePersona ? (
+        <PersonaDrawer persona={activePersona} onClose={() => setActive(null)} />
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/components/report/ReportView.tsx
+++ b/apps/web/components/report/ReportView.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import type { ReportMode, ReportT } from './types';
+import { DisagreementBanner } from './DisagreementBanner';
+import { HeadlineDelta } from './HeadlineDelta';
+import { Histograms } from './Histograms';
+import { NextActions } from './NextActions';
+import { PairedDots } from './PairedDots';
+import { PersonaGrid } from './PersonaGrid';
+import { ThemeBoard } from './ThemeBoard';
+import { TierPicked } from './TierPicked';
+
+// Spec §5.18 — composes the seven elements + the §2 #19 disagreement
+// banner + the §9 low-power banner. Mode `public` strips the debug
+// panel per "the same page read-only ... WITHOUT the debug view."
+
+export function ReportView({
+  report,
+  mode,
+}: {
+  report: ReportT;
+  mode: ReportMode;
+}) {
+  return (
+    <div className="space-y-6">
+      <DisagreementBanner headline={report.headline} />
+      {report.meta.low_power ? (
+        <div
+          data-testid="low-power-banner"
+          role="alert"
+          className="rounded-lg border border-yellow-300 bg-yellow-50 p-3 text-sm text-yellow-900"
+        >
+          Low-power run (N &lt; 20). Treat all p-values as suggestive, not conclusive.
+        </div>
+      ) : null}
+      <HeadlineDelta headline={report.headline} />
+      <PairedDots rows={report.paired_dots} />
+      <Histograms histograms={report.histograms} />
+      <NextActions rows={report.next_actions} />
+      <TierPicked rows={report.tier_picked} />
+      <ThemeBoard board={report.theme_board} />
+      <PersonaGrid personas={report.personas} />
+      {mode === 'dashboard' ? (
+        <section
+          data-testid="debug-panel"
+          className="rounded-lg border border-dashed border-gray-300 bg-gray-50 p-4 text-xs text-gray-600"
+        >
+          <p className="font-semibold">Debug</p>
+          <p className="mt-1">slug: {report.meta.slug} · n_paired: {report.headline.n_paired}</p>
+        </section>
+      ) : null}
+    </div>
+  );
+}

--- a/apps/web/components/report/ThemeBoard.tsx
+++ b/apps/web/components/report/ThemeBoard.tsx
@@ -1,0 +1,99 @@
+'use client';
+
+import { useState } from 'react';
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { ReportT, ThemeCategory } from './types';
+
+// Spec §5.18 #6 — top blockers / objections / confusions / questions.
+// Four horizontal bar-charts of cluster frequency. Clicking a cluster
+// expands a quote drawer with attributed raw strings. Cluster labels
+// come from the LLM labeling step (§5.7); raw quotes are redacted per
+// §5.9. The quote drawer's content is auth-gated (loaded on click) per
+// the §5.18 perf budget — wire shape includes only the cluster summary.
+//
+// In v0.1 we render a placeholder quote drawer that says quotes load on
+// click; the actual fetch lands in the persona/quote API issue.
+
+const CATEGORIES: { key: ThemeCategory; label: string }[] = [
+  { key: 'blockers', label: 'Blockers' },
+  { key: 'objections', label: 'Objections' },
+  { key: 'confusions', label: 'Confusions' },
+  { key: 'questions', label: 'Questions' },
+];
+
+function CategoryChart({
+  category,
+  clusters,
+  onClickCluster,
+}: {
+  category: ThemeCategory;
+  clusters: ReportT['theme_board'][ThemeCategory];
+  onClickCluster: (clusterId: string) => void;
+}) {
+  const safeClusters = clusters ?? [];
+  const data = [...safeClusters]
+    .sort((a, b) => b.count - a.count)
+    .map((c) => ({ label: c.label, count: c.count, cluster_id: c.cluster_id }));
+  return (
+    <div
+      data-testid={`theme-${category}`}
+      className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+    >
+      <h3 className="font-semibold capitalize text-gray-900">{category}</h3>
+      <div className="mt-2 h-40 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart layout="vertical" data={data} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis type="number" allowDecimals={false} />
+            <YAxis type="category" dataKey="label" width={140} tick={{ fontSize: 11 }} />
+            <Tooltip contentStyle={{ fontSize: 12 }} />
+            <Bar
+              dataKey="count"
+              fill="#2563eb"
+              onClick={(d) => onClickCluster((d as { cluster_id: string }).cluster_id)}
+            />
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
+  );
+}
+
+export function ThemeBoard({ board }: { board: ReportT['theme_board'] }) {
+  const [active, setActive] = useState<string | null>(null);
+  return (
+    <section data-testid="theme-board" className="space-y-4">
+      <h2 className="text-lg font-semibold text-gray-900">Theme board</h2>
+      <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+        {CATEGORIES.map(({ key }) => (
+          <CategoryChart
+            key={key}
+            category={key}
+            clusters={board[key]}
+            onClickCluster={setActive}
+          />
+        ))}
+      </div>
+      {active ? (
+        <div
+          data-testid="quote-drawer"
+          className="rounded border border-gray-200 bg-gray-50 p-3 text-sm text-gray-800"
+        >
+          <p className="font-medium">Cluster: {active}</p>
+          <p className="mt-1 text-xs text-gray-600">
+            Quotes load on demand (auth-gated per spec §5.18).
+          </p>
+        </div>
+      ) : null}
+    </section>
+  );
+}

--- a/apps/web/components/report/TierPicked.tsx
+++ b/apps/web/components/report/TierPicked.tsx
@@ -1,0 +1,86 @@
+'use client';
+
+import {
+  Bar,
+  BarChart,
+  CartesianGrid,
+  Legend,
+  ResponsiveContainer,
+  Tooltip,
+  XAxis,
+  YAxis,
+} from 'recharts';
+
+import type { ReportT, Tier } from './types';
+
+// Spec §5.18 #5 — tier-picked distribution per variant. Horizontal
+// stacked bar; conversion-weighted score is the anchor (in headline);
+// this shows WHICH paid tier draws intent.
+
+const ORDERED_TIERS: Tier[] = [
+  'none',
+  'hobby',
+  'express',
+  'starter',
+  'scale',
+  'enterprise',
+];
+
+const TIER_COLOR: Record<Tier, string> = {
+  none: '#dc2626',
+  hobby: '#94a3b8',
+  express: '#eab308',
+  starter: '#84cc16',
+  scale: '#22c55e',
+  enterprise: '#15803d',
+};
+
+const TIER_LABEL: Record<Tier, string> = {
+  none: 'None',
+  hobby: 'Hobby',
+  express: 'Express',
+  starter: 'Starter',
+  scale: 'Scale',
+  enterprise: 'Enterprise',
+};
+
+export function TierPicked({ rows }: { rows: ReportT['tier_picked'] }) {
+  const data = rows.map((r) => {
+    const obj: Record<string, number | string> = { variant: r.variant };
+    for (const t of ORDERED_TIERS) {
+      obj[t] = r.counts[t] ?? 0;
+    }
+    return obj;
+  });
+  return (
+    <section
+      data-testid="tier-picked"
+      className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+    >
+      <h2 className="text-lg font-semibold text-gray-900">Tier picked (per variant)</h2>
+      <p className="mt-1 text-sm text-gray-600">
+        Horizontal stacked bar across <code>none → enterprise</code>.
+      </p>
+      <div className="mt-4 h-48 w-full">
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart layout="vertical" data={data} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
+            <CartesianGrid strokeDasharray="3 3" />
+            <XAxis type="number" allowDecimals={false} />
+            <YAxis type="category" dataKey="variant" />
+            <Tooltip contentStyle={{ fontSize: 12 }} />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            {ORDERED_TIERS.map((t) => (
+              <Bar
+                key={t}
+                dataKey={t}
+                stackId="tier"
+                fill={TIER_COLOR[t]}
+                name={TIER_LABEL[t]}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </section>
+  );
+}

--- a/apps/web/components/report/types.ts
+++ b/apps/web/components/report/types.ts
@@ -1,0 +1,8 @@
+// Re-export the wire types as a stable surface for the report
+// components. Components import from here (not from @willbuy/shared/report
+// directly) so a future shape rename is a one-file edit.
+export type { ReportT, VariantId, Tier, ThemeCategory } from '@willbuy/shared/report';
+
+// View-level mode flag. Spec §5.18 export+share: `/r/:slug` renders the
+// same page as the dashboard but WITHOUT the debug view.
+export type ReportMode = 'dashboard' | 'public';

--- a/apps/web/lib/png-export.ts
+++ b/apps/web/lib/png-export.ts
@@ -1,0 +1,46 @@
+// Spec §5.18 export+share — one-click PNG export of the headline delta
+// + paired-delta plot for CRO consultants to drop into client decks.
+//
+// Implementation uses `html-to-image` (already a dependency) which
+// serializes the DOM subtree to a PNG data URL. No inline scripts
+// involved (CSP §5.10 stays clean).
+//
+// `_toPngForTest` is a test-only seam: the real `toPng` is imported
+// dynamically so jsdom (which can't run a real canvas) doesn't blow up
+// in the unit-test environment. Production code never passes this arg.
+
+type ToPngFn = (
+  node: HTMLElement,
+  options?: Record<string, unknown>,
+) => Promise<string>;
+
+let cached: ToPngFn | null = null;
+
+async function loadHtmlToImage(): Promise<ToPngFn> {
+  if (cached) return cached;
+  const mod = (await import('html-to-image')) as { toPng: ToPngFn };
+  cached = mod.toPng;
+  return cached;
+}
+
+export interface ExportOptions {
+  /** Test seam: pass a stub to avoid loading html-to-image in jsdom. */
+  _toPngForTest?: ToPngFn;
+  /** Forwarded to html-to-image. */
+  pixelRatio?: number;
+  /** Forwarded to html-to-image. */
+  backgroundColor?: string;
+}
+
+export async function exportElementToPng(
+  node: HTMLElement,
+  options: ExportOptions = {},
+): Promise<string> {
+  const { _toPngForTest, pixelRatio = 2, backgroundColor = '#ffffff' } = options;
+  const toPng = _toPngForTest ?? (await loadHtmlToImage());
+  const dataUrl = await toPng(node, { pixelRatio, backgroundColor });
+  if (!dataUrl.startsWith('data:image/png;base64,')) {
+    throw new Error('exportElementToPng: html-to-image returned an unexpected payload');
+  }
+  return dataUrl;
+}

--- a/apps/web/lib/png-export.ts
+++ b/apps/web/lib/png-export.ts
@@ -24,7 +24,10 @@ async function loadHtmlToImage(): Promise<ToPngFn> {
 }
 
 export interface ExportOptions {
-  /** Test seam: pass a stub to avoid loading html-to-image in jsdom. */
+  /**
+   * @internal Test seam: pass a stub to avoid loading html-to-image in jsdom.
+   * Production code never passes this argument.
+   */
   _toPngForTest?: ToPngFn;
   /** Forwarded to html-to-image. */
   pixelRatio?: number;

--- a/apps/web/next.config.mjs
+++ b/apps/web/next.config.mjs
@@ -2,6 +2,18 @@
 const nextConfig = {
   reactStrictMode: true,
   output: 'standalone',
+  // @willbuy/shared is a workspace TS package whose internal imports
+  // use `.js` suffixes (Node16 ESM convention). transpilePackages
+  // routes it through Next's loader; the webpack `extensionAlias`
+  // teaches the resolver that `.js` may resolve to a `.ts` source.
+  transpilePackages: ['@willbuy/shared'],
+  webpack(config) {
+    config.resolve.extensionAlias = {
+      ...(config.resolve.extensionAlias ?? {}),
+      '.js': ['.ts', '.tsx', '.js', '.jsx'],
+    };
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -14,15 +14,19 @@
   },
   "dependencies": {
     "@willbuy/shared": "workspace:*",
+    "html-to-image": "^1.11.13",
     "next": "14.2.18",
     "react": "18.3.1",
-    "react-dom": "18.3.1"
+    "react-dom": "18.3.1",
+    "recharts": "^2.13.3"
   },
   "devDependencies": {
+    "@testing-library/react": "^16.1.0",
     "@types/node": "^22.10.2",
     "@types/react": "18.3.12",
     "@types/react-dom": "18.3.1",
     "autoprefixer": "^10.4.20",
+    "jsdom": "^25.0.1",
     "postcss": "^8.4.49",
     "tailwindcss": "^3.4.16",
     "typescript": "^5.7.2",

--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -10,7 +10,8 @@
     "start": "next start",
     "lint": "eslint .",
     "test": "vitest run",
-    "typecheck": "tsc -p tsconfig.json --noEmit"
+    "typecheck": "tsc -p tsconfig.json --noEmit",
+    "perf:lighthouse": "node test/perf/lighthouse.mjs"
   },
   "dependencies": {
     "@willbuy/shared": "workspace:*",

--- a/apps/web/test/fixtures/README.md
+++ b/apps/web/test/fixtures/README.md
@@ -1,0 +1,54 @@
+# Report fixtures — wire shape contract
+
+These JSON fixtures define the **report payload contract** between:
+
+- the aggregator (issue #31, Python in the pinned scientific-stack
+  container — spec §17), which writes the JSON blob onto
+  `reports.scores_json` / `reports.paired_delta_json` / `reports.clusters_json`
+  per spec §5.11, and
+- the web report page (issue #35, this PR), which consumes one blob and
+  renders the seven §5.18 visual elements.
+
+## Authoritative schema
+
+`packages/shared/src/report.ts` — `Report` zod schema. The test
+`apps/web/test/report-viz.test.ts` parses every fixture in this directory
+through that schema; if the aggregator produces something the schema
+rejects, CI fails before render.
+
+## Field map (schema → §5.18 element)
+
+| schema field   | §5.18 element |
+| -------------- | ------------- |
+| `headline`     | 1 — header / headline delta (mean δ, 95% CI, paired-t / Wilcoxon / McNemar p, verdict, disagreement flag per §2 #19) |
+| `paired_dots`  | 2 — paired-delta dot plot (the key viz) |
+| `histograms`   | 3 — will-to-buy histograms per variant |
+| `next_actions` | 4 — next-action stacked bar / Sankey toggle (8 actions per amendment A1) |
+| `tier_picked`  | 5 — tier-picked distribution per variant |
+| `theme_board`  | 6 — top blockers / objections / confusions / questions |
+| `personas`     | 7 — persona cards grid |
+| `meta`         | study slug + `low_power` flag (spec §9 statistical-overclaim row, N<20 → low-power banner) |
+
+## Files
+
+- `report.fixture.json` — happy-path study, N=30 paired, B converts
+  better, tests-agree (no disagreement banner). Drives most rendering tests.
+- `report.disagreement.fixture.json` — paired-t p=0.041, Wilcoxon p=0.092
+  (one < 0.05, the other ≥ 0.05) → §2 #19 disagreement rule fires. Drives
+  the disagreement-banner test.
+
+## Public-repo audit
+
+Both fixtures use obviously-fabricated persona names (`Persona One` …
+`Persona Alpha`). No real names, no email addresses, no URLs, no IPs.
+The data is hand-crafted and does NOT come from a real study. This
+matches spec §5.10 (untrusted-content render boundary) and the public-repo
+discipline in `CLAUDE.md`.
+
+## For the aggregator engineer (#31)
+
+When you wire the aggregator output, parse against `Report` from
+`@willbuy/shared/report` at the API-boundary (per the zod-at-the-boundary
+rule in `CLAUDE.md`). If you need to add a field, update `report.ts`
+**and** at least one fixture in this directory in the same PR — that
+keeps the report page's tests honest about the shape it consumes.

--- a/apps/web/test/fixtures/report.disagreement.fixture.json
+++ b/apps/web/test/fixtures/report.disagreement.fixture.json
@@ -1,0 +1,64 @@
+{
+  "meta": { "slug": "test-disagreement", "low_power": false },
+  "headline": {
+    "mean_delta": 0.8,
+    "ci95_low": -0.1,
+    "ci95_high": 1.7,
+    "n_paired": 24,
+    "paired_t_p": 0.041,
+    "wilcoxon_p": 0.092,
+    "mcnemar_p": 0.18,
+    "verdict": "inconclusive",
+    "disagreement": true
+  },
+  "paired_dots": [
+    { "backstory_id": "bs-101", "backstory_name": "Persona Alpha", "role": "founder_or_eng_lead", "score_a": 5, "score_b": 6, "swing": "b_wins" },
+    { "backstory_id": "bs-102", "backstory_name": "Persona Beta",  "role": "ic_engineer",        "score_a": 4, "score_b": 4, "swing": "tie"    }
+  ],
+  "histograms": [
+    { "variant": "A", "bins": [0, 0, 1, 2, 4, 6, 5, 4, 1, 1, 0], "mean": 5.4, "median": 5 },
+    { "variant": "B", "bins": [0, 0, 1, 1, 3, 5, 7, 5, 1, 1, 0], "mean": 6.0, "median": 6 }
+  ],
+  "next_actions": [
+    {
+      "variant": "A",
+      "counts": {
+        "purchase_paid_today": 1, "contact_sales": 2, "book_demo": 1, "start_paid_trial": 3,
+        "bookmark_compare_later": 5, "start_free_hobby": 6, "ask_teammate": 4, "leave": 2
+      }
+    },
+    {
+      "variant": "B",
+      "counts": {
+        "purchase_paid_today": 2, "contact_sales": 3, "book_demo": 1, "start_paid_trial": 4,
+        "bookmark_compare_later": 4, "start_free_hobby": 5, "ask_teammate": 3, "leave": 2
+      }
+    }
+  ],
+  "tier_picked": [
+    { "variant": "A", "counts": { "none": 6, "hobby": 5, "express": 4, "starter": 5, "scale": 2, "enterprise": 2 } },
+    { "variant": "B", "counts": { "none": 4, "hobby": 4, "express": 5, "starter": 6, "scale": 3, "enterprise": 2 } }
+  ],
+  "theme_board": {
+    "blockers":   [{ "cluster_id": "blk-9", "label": "Pricing rationale unclear", "count": 6 }],
+    "objections": [{ "cluster_id": "obj-9", "label": "Risk of vendor lock-in",    "count": 4 }],
+    "confusions": [{ "cluster_id": "cnf-9", "label": "Tier ladder unclear",       "count": 3 }],
+    "questions":  [{ "cluster_id": "qst-9", "label": "Is there a startup discount", "count": 5 }]
+  },
+  "personas": [
+    {
+      "backstory_id": "bs-101",
+      "backstory_name": "Persona Alpha",
+      "role": "founder_or_eng_lead",
+      "stage": "seed",
+      "team_size": 6,
+      "stack": "supabase",
+      "current_pain": "cost_creep",
+      "entry_point": "hacker_news",
+      "score_a": 5,
+      "score_b": 6,
+      "verdict_a": "Decent but I want a self-serve calculator.",
+      "verdict_b": "Calculator helps; I'd bookmark and revisit."
+    }
+  ]
+}

--- a/apps/web/test/fixtures/report.fixture.json
+++ b/apps/web/test/fixtures/report.fixture.json
@@ -1,0 +1,176 @@
+{
+  "meta": {
+    "slug": "test-fixture",
+    "low_power": false
+  },
+  "headline": {
+    "mean_delta": 1.4,
+    "ci95_low": 0.6,
+    "ci95_high": 2.2,
+    "n_paired": 30,
+    "paired_t_p": 0.012,
+    "wilcoxon_p": 0.018,
+    "mcnemar_p": 0.041,
+    "verdict": "better",
+    "disagreement": false
+  },
+  "paired_dots": [
+    { "backstory_id": "bs-001", "backstory_name": "Persona One",   "role": "founder_or_eng_lead", "score_a": 4, "score_b": 7, "swing": "b_wins" },
+    { "backstory_id": "bs-002", "backstory_name": "Persona Two",   "role": "ic_engineer",        "score_a": 6, "score_b": 6, "swing": "tie"    },
+    { "backstory_id": "bs-003", "backstory_name": "Persona Three", "role": "founder_or_eng_lead", "score_a": 3, "score_b": 5, "swing": "b_wins" },
+    { "backstory_id": "bs-004", "backstory_name": "Persona Four",  "role": "ic_engineer",        "score_a": 8, "score_b": 5, "swing": "a_wins" },
+    { "backstory_id": "bs-005", "backstory_name": "Persona Five",  "role": "founder_or_eng_lead", "score_a": 2, "score_b": 6, "swing": "b_wins" },
+    { "backstory_id": "bs-006", "backstory_name": "Persona Six",   "role": "ic_engineer",        "score_a": 5, "score_b": 7, "swing": "b_wins" },
+    { "backstory_id": "bs-007", "backstory_name": "Persona Seven", "role": "founder_or_eng_lead", "score_a": 7, "score_b": 8, "swing": "b_wins" },
+    { "backstory_id": "bs-008", "backstory_name": "Persona Eight", "role": "ic_engineer",        "score_a": 4, "score_b": 4, "swing": "tie"    },
+    { "backstory_id": "bs-009", "backstory_name": "Persona Nine",  "role": "founder_or_eng_lead", "score_a": 6, "score_b": 8, "swing": "b_wins" },
+    { "backstory_id": "bs-010", "backstory_name": "Persona Ten",   "role": "ic_engineer",        "score_a": 5, "score_b": 6, "swing": "b_wins" }
+  ],
+  "histograms": [
+    { "variant": "A", "bins": [0, 1, 2, 2, 3, 5, 7, 6, 3, 1, 0], "mean": 5.4, "median": 6 },
+    { "variant": "B", "bins": [0, 0, 1, 2, 2, 4, 6, 8, 5, 2, 0], "mean": 6.8, "median": 7 }
+  ],
+  "next_actions": [
+    {
+      "variant": "A",
+      "counts": {
+        "purchase_paid_today":     2,
+        "contact_sales":           3,
+        "book_demo":               1,
+        "start_paid_trial":        4,
+        "bookmark_compare_later":  6,
+        "start_free_hobby":        7,
+        "ask_teammate":            4,
+        "leave":                   3
+      }
+    },
+    {
+      "variant": "B",
+      "counts": {
+        "purchase_paid_today":     5,
+        "contact_sales":           5,
+        "book_demo":               3,
+        "start_paid_trial":        6,
+        "bookmark_compare_later":  4,
+        "start_free_hobby":        3,
+        "ask_teammate":            2,
+        "leave":                   2
+      }
+    }
+  ],
+  "tier_picked": [
+    {
+      "variant": "A",
+      "counts": { "none": 8, "hobby": 6, "express": 5, "starter": 6, "scale": 3, "enterprise": 2 }
+    },
+    {
+      "variant": "B",
+      "counts": { "none": 4, "hobby": 4, "express": 7, "starter": 8, "scale": 5, "enterprise": 2 }
+    }
+  ],
+  "theme_board": {
+    "blockers": [
+      { "cluster_id": "blk-1", "label": "Self-hosted vs managed unclear",     "count": 9 },
+      { "cluster_id": "blk-2", "label": "Pricing tier limits opaque",         "count": 7 },
+      { "cluster_id": "blk-3", "label": "No SOC 2 mention on pricing page",   "count": 4 }
+    ],
+    "objections": [
+      { "cluster_id": "obj-1", "label": "Per-seat math gets expensive fast",  "count": 8 },
+      { "cluster_id": "obj-2", "label": "Lock-in concern with proprietary format", "count": 5 }
+    ],
+    "confusions": [
+      { "cluster_id": "cnf-1", "label": "Express vs Starter difference",      "count": 6 },
+      { "cluster_id": "cnf-2", "label": "Where is the free tier described",   "count": 4 }
+    ],
+    "questions": [
+      { "cluster_id": "qst-1", "label": "Does the trial require a card",      "count": 7 },
+      { "cluster_id": "qst-2", "label": "Can I self-host the OSS variant",    "count": 5 }
+    ]
+  },
+  "personas": [
+    {
+      "backstory_id": "bs-005",
+      "backstory_name": "Persona Five",
+      "role": "founder_or_eng_lead",
+      "stage": "seed",
+      "team_size": 6,
+      "stack": "supabase",
+      "current_pain": "slow_queries",
+      "entry_point": "hacker_news",
+      "score_a": 2,
+      "score_b": 6,
+      "verdict_a": "Pricing page doesn't tell me what I'd pay at my volume; bounce.",
+      "verdict_b": "Numbers line up with my Supabase bill; would start a paid trial."
+    },
+    {
+      "backstory_id": "bs-001",
+      "backstory_name": "Persona One",
+      "role": "founder_or_eng_lead",
+      "stage": "seed+",
+      "team_size": 12,
+      "stack": "rds",
+      "current_pain": "cost_creep",
+      "entry_point": "newsletter",
+      "score_a": 4,
+      "score_b": 7,
+      "verdict_a": "I get the value but the tier breakpoints feel arbitrary.",
+      "verdict_b": "Tier comparison table makes the upgrade path obvious."
+    },
+    {
+      "backstory_id": "bs-003",
+      "backstory_name": "Persona Three",
+      "role": "founder_or_eng_lead",
+      "stage": "seed",
+      "team_size": 2,
+      "stack": "neon",
+      "current_pain": "bad_migration_fear",
+      "entry_point": "google_search",
+      "score_a": 3,
+      "score_b": 5,
+      "verdict_a": "Need a clearer guarantee around schema changes.",
+      "verdict_b": "Migration story is plausible at my size; would bookmark."
+    },
+    {
+      "backstory_id": "bs-009",
+      "backstory_name": "Persona Nine",
+      "role": "founder_or_eng_lead",
+      "stage": "series_a",
+      "team_size": 20,
+      "stack": "aurora",
+      "current_pain": "upcoming_scale_event",
+      "entry_point": "vc_referral",
+      "score_a": 6,
+      "score_b": 8,
+      "verdict_a": "Solid but I'd want to talk to sales first.",
+      "verdict_b": "Contact sales CTA is finally above the fold."
+    },
+    {
+      "backstory_id": "bs-004",
+      "backstory_name": "Persona Four",
+      "role": "ic_engineer",
+      "stage": "seed+",
+      "team_size": 6,
+      "stack": "rds",
+      "current_pain": "recent_outage",
+      "entry_point": "postgres_blog_footer",
+      "score_a": 8,
+      "score_b": 5,
+      "verdict_a": "Clean explanation of failover behavior; would push to my lead.",
+      "verdict_b": "New layout buries the ops detail I cared about."
+    },
+    {
+      "backstory_id": "bs-006",
+      "backstory_name": "Persona Six",
+      "role": "ic_engineer",
+      "stage": "series_a",
+      "team_size": 12,
+      "stack": "cloud_sql",
+      "current_pain": "slow_queries",
+      "entry_point": "conference_booth_followup",
+      "score_a": 5,
+      "score_b": 7,
+      "verdict_a": "Performance claims are vague.",
+      "verdict_b": "p95 numbers and a workload-shape note close the gap."
+    }
+  ]
+}

--- a/apps/web/test/pages.test.tsx
+++ b/apps/web/test/pages.test.tsx
@@ -23,11 +23,26 @@ describe('dashboard placeholder — GET /dashboard', () => {
   });
 });
 
-describe('public report placeholder — GET /r/[slug]', () => {
-  it('renders the placeholder body', async () => {
-    const el = await ReportPage({ params: Promise.resolve({ slug: 'abc' }) });
+describe('public report — GET /r/[slug]', () => {
+  it('renders a "not found" body when no report exists for the slug', async () => {
+    delete process.env.WILLBUY_REPORT_FIXTURE;
+    const el = await ReportPage({ params: Promise.resolve({ slug: 'no-such-slug' }) });
     const html = renderToStaticMarkup(el);
-    expect(html).toMatch(/public report — pending implementation/i);
+    expect(html).toMatch(/report not found/i);
+  });
+
+  it('renders the report when the fixture seam is enabled and the slug matches', async () => {
+    process.env.WILLBUY_REPORT_FIXTURE = 'enabled';
+    try {
+      const el = await ReportPage({ params: Promise.resolve({ slug: 'test-fixture' }) });
+      const html = renderToStaticMarkup(el);
+      // Element 1 — headline delta — uses the verdict copy from the fixture.
+      expect(html).toMatch(/converts better/i);
+      // Slug rendered as <code> per §5.10.
+      expect(html).toMatch(/<code[^>]*>test-fixture<\/code>/);
+    } finally {
+      delete process.env.WILLBUY_REPORT_FIXTURE;
+    }
   });
 
   it('exports metadata with noindex (per SPEC §5.10 untrusted-content boundary)', () => {

--- a/apps/web/test/perf/README.md
+++ b/apps/web/test/perf/README.md
@@ -1,0 +1,45 @@
+# Report perf budget — spec §5.18
+
+The report page MUST hit **FCP ≤ 1.5 s** on a 5 Mbps uplink at N=30
+paired (the canonical "happy path" fixture). The check runs Lighthouse
+in the desktop preset with throughput throttled to 5 Mbps, against a
+prod build of `apps/web` serving the report fixture.
+
+## Runner
+
+```sh
+# from the repo root
+cd apps/web
+WILLBUY_REPORT_FIXTURE=enabled pnpm next build
+WILLBUY_REPORT_FIXTURE=enabled pnpm next start &
+node test/perf/lighthouse.mjs   # prints { url, fcp_ms, budget_ms, pass }
+kill %1
+```
+
+If `lighthouse` and `chrome-launcher` are not resolvable the runner
+exits with code 2 and a remediation hint; the deps are intentionally
+NOT pinned in `package.json` to keep the workspace install slim. CI
+provisions them on the runner image and exports `CHROMIUM_PATH`.
+
+## Fixture URL
+
+`http://localhost:3000/r/test-fixture` — fed by
+`apps/web/app/r/[slug]/fetchReport.ts` from
+`apps/web/test/fixtures/report.fixture.json` when
+`WILLBUY_REPORT_FIXTURE=enabled`.
+
+## Budget knobs
+
+- FCP budget: 1500 ms (spec §5.18)
+- Network: 5 Mbps throughput, 40 ms RTT
+- Form factor: desktop, viewport 1366×900
+- CPU slowdown multiplier: 1 (no CPU throttling — §5.18 calls out
+  client-side rendering only)
+
+## Failure mode
+
+The runner exits non-zero and prints a JSON line; the failure shows up
+in CI as a perf-regression alert. Tracking issue: see §6.2 "Perf
+regression" — that test asserts the *aggregator* end-to-end budget;
+this runner asserts the *report page* render budget. Both must pass
+for ship.

--- a/apps/web/test/perf/lighthouse.mjs
+++ b/apps/web/test/perf/lighthouse.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Spec §5.18 performance budget — initial meaningful paint on `/r/:slug`
+// at N=30 paired ≤ 1.5 s on a 5 Mbps uplink.
+//
+// Runner:
+//   1. Boot the Next.js prod server in this worktree with the report
+//      fixture seam enabled.
+//   2. Drive Lighthouse against `http://localhost:3000/r/test-fixture`
+//      with the desktop-fast preset throttled to 5 Mbps.
+//   3. Assert FCP ≤ 1500 ms.
+//
+// We deliberately keep this as a standalone Node script (not a vitest
+// test) because Lighthouse pulls in a chromium launch + ~80 MiB of
+// transitive deps; vitest in CI shouldn't carry that. CI invokes this
+// script via `pnpm --filter @willbuy/web run perf:lighthouse` once the
+// browser-automation worker's CHROMIUM_PATH is published into the test
+// environment.
+//
+// Local invocation:
+//   cd apps/web
+//   WILLBUY_REPORT_FIXTURE=enabled pnpm next build
+//   WILLBUY_REPORT_FIXTURE=enabled pnpm next start &
+//   node test/perf/lighthouse.mjs
+//   kill %1
+//
+// Exit 0 on pass; non-zero with a JSON summary on fail.
+
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { createRequire } from 'node:module';
+
+const FIXTURE_URL = process.env.WILLBUY_PERF_URL ?? 'http://localhost:3000/r/test-fixture';
+const FCP_BUDGET_MS = 1500;
+
+const require_ = createRequire(import.meta.url);
+
+function lazyImportLighthouse() {
+  // Lighthouse + chrome-launcher are NOT pinned as workspace deps to
+  // keep the install footprint small. The runner expects them to be
+  // installed on the CI image (or on the dev's box) via
+  // `pnpm dlx lighthouse` / `npx -y lighthouse`. If they're not
+  // resolvable, exit with a clear remediation hint instead of a stack
+  // trace.
+  try {
+    const lighthouse = require_('lighthouse');
+    const chromeLauncher = require_('chrome-launcher');
+    return { lighthouse, chromeLauncher };
+  } catch {
+    return null;
+  }
+}
+
+async function main() {
+  const probe = await fetch(FIXTURE_URL).catch(() => null);
+  if (!probe || !probe.ok) {
+    console.error(
+      `[perf] fixture URL not reachable: ${FIXTURE_URL}\n` +
+        '       Boot the app first:\n' +
+        '         WILLBUY_REPORT_FIXTURE=enabled pnpm --filter @willbuy/web build\n' +
+        '         WILLBUY_REPORT_FIXTURE=enabled pnpm --filter @willbuy/web start &',
+    );
+    process.exit(2);
+  }
+
+  const lh = lazyImportLighthouse();
+  if (!lh) {
+    console.error(
+      '[perf] lighthouse / chrome-launcher not installed. Install via\n' +
+        '         pnpm dlx lighthouse@12 ...\n' +
+        '       or run with `npx -y lighthouse --preset=desktop --only-categories=performance ' +
+        FIXTURE_URL +
+        '`.',
+    );
+    process.exit(2);
+  }
+
+  const { lighthouse, chromeLauncher } = lh;
+  const chrome = await chromeLauncher.launch({
+    chromeFlags: ['--headless=new', '--disable-gpu'],
+  });
+  try {
+    const result = await lighthouse(FIXTURE_URL, {
+      port: chrome.port,
+      output: 'json',
+      onlyCategories: ['performance'],
+      // Spec §5.18 — 5 Mbps uplink. Lighthouse's default mobile slow-4G
+      // is too pessimistic; we use desktop with custom throttling.
+      formFactor: 'desktop',
+      screenEmulation: { mobile: false, width: 1366, height: 900, deviceScaleFactor: 1 },
+      throttling: {
+        rttMs: 40,
+        throughputKbps: 5_000,
+        cpuSlowdownMultiplier: 1,
+      },
+    });
+    const fcp = result.lhr.audits['first-contentful-paint'].numericValue ?? Infinity;
+    const summary = {
+      url: FIXTURE_URL,
+      fcp_ms: Math.round(fcp),
+      budget_ms: FCP_BUDGET_MS,
+      pass: fcp <= FCP_BUDGET_MS,
+    };
+    console.log(JSON.stringify(summary, null, 2));
+    if (!summary.pass) process.exit(1);
+  } finally {
+    await chrome.kill();
+  }
+}
+
+await main();
+
+// Silence "unused" warnings in environments that don't have the deps;
+// `spawnSync` and `existsSync` are kept around for future host-binary
+// fallbacks (e.g. a system `lighthouse` CLI on the CI image).
+void spawnSync;
+void existsSync;

--- a/apps/web/test/perf/lighthouse.mjs
+++ b/apps/web/test/perf/lighthouse.mjs
@@ -25,8 +25,6 @@
 //
 // Exit 0 on pass; non-zero with a JSON summary on fail.
 
-import { spawnSync } from 'node:child_process';
-import { existsSync } from 'node:fs';
 import { createRequire } from 'node:module';
 
 const FIXTURE_URL = process.env.WILLBUY_PERF_URL ?? 'http://localhost:3000/r/test-fixture';
@@ -108,9 +106,3 @@ async function main() {
 }
 
 await main();
-
-// Silence "unused" warnings in environments that don't have the deps;
-// `spawnSync` and `existsSync` are kept around for future host-binary
-// fallbacks (e.g. a system `lighthouse` CLI on the CI image).
-void spawnSync;
-void existsSync;

--- a/apps/web/test/report-viz.test.tsx
+++ b/apps/web/test/report-viz.test.tsx
@@ -18,6 +18,7 @@ import { Report, type ReportT } from '@willbuy/shared/report';
 import fixtureJson from './fixtures/report.fixture.json';
 import disagreementJson from './fixtures/report.disagreement.fixture.json';
 import { ReportView } from '../components/report/ReportView';
+import { PairedDots } from '../components/report/PairedDots';
 import { exportElementToPng } from '../lib/png-export';
 
 // Recharts uses ResizeObserver + element.getBoundingClientRect; jsdom
@@ -158,5 +159,23 @@ describe('§5.18 — report visualization', () => {
     render(<ReportView report={lowPowerFixture} mode="dashboard" />);
     const banner = screen.getByTestId('low-power-banner');
     expect(banner.textContent).toMatch(/low.power/i);
+  });
+
+  it('F1 — paired-dot plot renders one SVG <line> connector per backstory (§5.18 #2)', () => {
+    // Spec §5.18 #2: "Per-visitor dots showing A-score vs B-score with a
+    // thin connecting segment." The connector is the entire point of the
+    // paired-dot design — without it the viewer sees two disconnected
+    // scatter fields that don't make the per-backstory pairing legible.
+    //
+    // We render PairedDots directly with the fixture's paired_dots rows
+    // and assert that the DOM contains one <line> element per backstory.
+    const { container } = render(<PairedDots rows={fixture.paired_dots} />);
+    const lines = container.querySelectorAll('line[data-connector]');
+    // One connector line per backstory row.
+    expect(lines.length).toBe(fixture.paired_dots.length);
+    // Each line should carry the swing class for its coloring.
+    for (const line of lines) {
+      expect(line.getAttribute('stroke')).toBeTruthy();
+    }
   });
 });

--- a/apps/web/test/report-viz.test.tsx
+++ b/apps/web/test/report-viz.test.tsx
@@ -1,0 +1,154 @@
+// Spec §5.18 — report visualization. The 7 elements must each render
+// against a fixture that matches the aggregator's wire shape (#31).
+//
+// This file is intentionally thin: each `it()` is one of the five named
+// scenarios from issue #35 ("TDD acceptance"). The components live in
+// apps/web/components/report/* and are imported through a single
+// `<ReportView />` entrypoint.
+//
+// Test environment: jsdom (Recharts uses ResizeObserver + getBBox). We
+// stub them at the top — Recharts respects width/height props when the
+// ResponsiveContainer parent reports zero, so charts still render.
+
+// @vitest-environment jsdom
+
+import { describe, expect, it, beforeAll, vi } from 'vitest';
+import { render, screen, fireEvent, within } from '@testing-library/react';
+import { Report, type ReportT } from '@willbuy/shared/report';
+import fixtureJson from './fixtures/report.fixture.json';
+import disagreementJson from './fixtures/report.disagreement.fixture.json';
+import { ReportView } from '../components/report/ReportView';
+import { exportElementToPng } from '../lib/png-export';
+
+// Recharts uses ResizeObserver + element.getBoundingClientRect; jsdom
+// provides the latter as zeroes. Stub ResizeObserver and patch
+// getBoundingClientRect so chart children get a non-zero box and render
+// SVG elements we can assert on.
+beforeAll(() => {
+  class ROStub {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  }
+  (globalThis as unknown as { ResizeObserver: typeof ROStub }).ResizeObserver = ROStub;
+  Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+    configurable: true,
+    value() {
+      return { width: 800, height: 400, top: 0, left: 0, right: 800, bottom: 400, x: 0, y: 0, toJSON: () => ({}) };
+    },
+  });
+  // Recharts' SVG path measurement calls getBBox — jsdom doesn't have it.
+  (
+    SVGElement.prototype as unknown as { getBBox?: () => DOMRect }
+  ).getBBox = () => ({ x: 0, y: 0, width: 100, height: 20 } as DOMRect);
+});
+
+const fixture = Report.parse(fixtureJson) satisfies ReportT;
+const disagreementFixture = Report.parse(disagreementJson) satisfies ReportT;
+
+describe('§5.18 — report visualization', () => {
+  it('1. all 7 elements render with the fixture report payload', () => {
+    render(<ReportView report={fixture} mode="dashboard" />);
+    // Element 1: headline delta. Mean delta + verdict copy.
+    expect(screen.getByTestId('headline-delta')).toBeTruthy();
+    // Element 2: paired-delta dot plot.
+    expect(screen.getByTestId('paired-dots')).toBeTruthy();
+    // Element 3: will-to-buy histograms (one per variant).
+    expect(screen.getByTestId('histogram-A')).toBeTruthy();
+    expect(screen.getByTestId('histogram-B')).toBeTruthy();
+    // Element 4: next-action stacked bar.
+    expect(screen.getByTestId('next-actions')).toBeTruthy();
+    // Element 5: tier-picked distribution.
+    expect(screen.getByTestId('tier-picked')).toBeTruthy();
+    // Element 6: theme board (4 categories).
+    const board = screen.getByTestId('theme-board');
+    expect(within(board).getByTestId('theme-blockers')).toBeTruthy();
+    expect(within(board).getByTestId('theme-objections')).toBeTruthy();
+    expect(within(board).getByTestId('theme-confusions')).toBeTruthy();
+    expect(within(board).getByTestId('theme-questions')).toBeTruthy();
+    // Element 7: persona cards grid.
+    expect(screen.getByTestId('persona-grid')).toBeTruthy();
+  });
+
+  it('2. disagreement banner shows when paired-t and Wilcoxon disagree (§2 #19)', () => {
+    render(<ReportView report={disagreementFixture} mode="dashboard" />);
+    const banner = screen.getByTestId('disagreement-banner');
+    // Spec §2 #19: copy must label the conclusion as "weak — tests disagree"
+    // and surface the more conservative (larger) p-value.
+    expect(banner.textContent).toMatch(/weak.*tests disagree/i);
+    // The conservative p in the disagreement fixture is 0.092 (Wilcoxon).
+    expect(banner.textContent).toMatch(/0\.092/);
+
+    // Negative case: the happy-path fixture has agreement and shows no banner.
+    const { queryByTestId } = render(
+      <ReportView report={fixture} mode="dashboard" />,
+    );
+    expect(queryByTestId('disagreement-banner')).toBeNull();
+  });
+
+  it('3. CSP §5.10: no inline <script> emitted by any rendered component', () => {
+    // Recharts ships SVG, no inline scripts. We assert by scanning the
+    // rendered DOM for <script> elements; any inline script would mean
+    // a regression of §5.10 on /r/* (where this view is hydrated).
+    const { container } = render(<ReportView report={fixture} mode="public" />);
+    const scripts = container.querySelectorAll('script');
+    expect(scripts.length).toBe(0);
+    // Defense in depth: no element should carry an inline event handler.
+    const onclickAttrs = container.querySelectorAll('[onclick]');
+    expect(onclickAttrs.length).toBe(0);
+  });
+
+  it('4. PNG export produces a non-empty data URL', async () => {
+    // The export covers element 1 (headline) + element 2 (paired-delta
+    // dot plot) per §5.18 export+share. The lib mocks out the actual
+    // canvas serialization in jsdom — what we verify here is the
+    // contract: it returns a non-empty `data:image/png;base64,...` URL.
+    const stubCanvasFn = vi.fn(async () => 'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAA');
+    const url = await exportElementToPng(document.createElement('div'), {
+      _toPngForTest: stubCanvasFn,
+    });
+    expect(url.startsWith('data:image/png;base64,')).toBe(true);
+    expect(url.length).toBeGreaterThan('data:image/png;base64,'.length);
+    expect(stubCanvasFn).toHaveBeenCalledTimes(1);
+  });
+
+  it('5. clicking a persona card opens the drawer with both A and B verdicts', () => {
+    render(<ReportView report={fixture} mode="dashboard" />);
+    const grid = screen.getByTestId('persona-grid');
+    const cards = within(grid).getAllByTestId(/^persona-card-/);
+    expect(cards.length).toBeGreaterThan(0);
+    // The grid is sorted by |score_b - score_a| desc; the top card is the
+    // largest swing. In the fixture that's bs-005 (score_a=2, score_b=6).
+    expect(cards[0]?.getAttribute('data-backstory-id')).toBe('bs-005');
+    fireEvent.click(cards[0]!);
+    const drawer = screen.getByTestId('persona-drawer');
+    // Both verdicts must be present side-by-side per §5.18 #7.
+    const verdictA = within(drawer).getByTestId('drawer-verdict-A');
+    const verdictB = within(drawer).getByTestId('drawer-verdict-B');
+    expect(verdictA.textContent).toMatch(/bounce/i);
+    expect(verdictB.textContent).toMatch(/paid trial/i);
+  });
+
+  it('public-mode hides debug UI per §5.18 export+share', () => {
+    // /r/:slug renders the same page WITHOUT the debug view. We tag a
+    // single debug element and assert the public mode strips it; this
+    // matches spec §5.18 ("the same page read-only ... WITHOUT the debug
+    // view") without committing to an exhaustive debug-component list.
+    const { queryByTestId, rerender } = render(
+      <ReportView report={fixture} mode="dashboard" />,
+    );
+    expect(queryByTestId('debug-panel')).not.toBeNull();
+    rerender(<ReportView report={fixture} mode="public" />);
+    expect(queryByTestId('debug-panel')).toBeNull();
+  });
+
+  it('low-power banner shows when meta.low_power is true (spec §9)', () => {
+    const lowPowerFixture: ReportT = {
+      ...fixture,
+      meta: { ...fixture.meta, low_power: true },
+    };
+    render(<ReportView report={lowPowerFixture} mode="dashboard" />);
+    const banner = screen.getByTestId('low-power-banner');
+    expect(banner.textContent).toMatch(/low.power/i);
+  });
+});

--- a/apps/web/test/report-viz.test.tsx
+++ b/apps/web/test/report-viz.test.tsx
@@ -12,8 +12,8 @@
 
 // @vitest-environment jsdom
 
-import { describe, expect, it, beforeAll, vi } from 'vitest';
-import { render, screen, fireEvent, within } from '@testing-library/react';
+import { describe, expect, it, beforeAll, afterEach, vi } from 'vitest';
+import { cleanup, render, screen, fireEvent, within } from '@testing-library/react';
 import { Report, type ReportT } from '@willbuy/shared/report';
 import fixtureJson from './fixtures/report.fixture.json';
 import disagreementJson from './fixtures/report.disagreement.fixture.json';
@@ -45,6 +45,15 @@ beforeAll(() => {
 
 const fixture = Report.parse(fixtureJson) satisfies ReportT;
 const disagreementFixture = Report.parse(disagreementJson) satisfies ReportT;
+
+// React Testing Library mounts into document.body and does NOT auto-clean
+// between tests when used in vitest without the auto-cleanup hook (we
+// don't import @testing-library/jest-dom). Manual cleanup keeps each
+// `it` independent — otherwise testid lookups across tests fail with
+// "Found multiple elements".
+afterEach(() => {
+  cleanup();
+});
 
 describe('§5.18 — report visualization', () => {
   it('1. all 7 elements render with the fixture report payload', () => {
@@ -80,10 +89,9 @@ describe('§5.18 — report visualization', () => {
     expect(banner.textContent).toMatch(/0\.092/);
 
     // Negative case: the happy-path fixture has agreement and shows no banner.
-    const { queryByTestId } = render(
-      <ReportView report={fixture} mode="dashboard" />,
-    );
-    expect(queryByTestId('disagreement-banner')).toBeNull();
+    cleanup();
+    render(<ReportView report={fixture} mode="dashboard" />);
+    expect(screen.queryByTestId('disagreement-banner')).toBeNull();
   });
 
   it('3. CSP §5.10: no inline <script> emitted by any rendered component', () => {

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -22,6 +22,10 @@
     "./backstory": {
       "types": "./src/backstory.ts",
       "default": "./src/backstory.ts"
+    },
+    "./report": {
+      "types": "./src/report.ts",
+      "default": "./src/report.ts"
     }
   },
   "scripts": {

--- a/packages/shared/src/index.ts
+++ b/packages/shared/src/index.ts
@@ -10,6 +10,13 @@ export {
   scoreVisit,
 } from './scoring.js';
 export {
+  Report,
+  type ReportT,
+  type VariantId,
+  type Tier,
+  type ThemeCategory,
+} from './report.js';
+export {
   Backstory,
   type BackstoryT,
   Stage,

--- a/packages/shared/src/report.ts
+++ b/packages/shared/src/report.ts
@@ -1,0 +1,141 @@
+import { z } from 'zod';
+
+import { NextAction } from './scoring.js';
+
+// Spec §5.18 — report visualization wire shape.
+//
+// This is the contract between the aggregator (issue #31) and the report
+// page (issue #35). The aggregator pre-computes a compact JSON blob on
+// the `reports` row (per §5.18 perf budget — "no raw per-visit data over
+// the wire"); this schema defines that blob.
+//
+// Field naming mirrors §5.18's seven elements 1:1 so a reviewer can
+// match the schema to the spec section without translation:
+//   1. headline      — element 1 (header / headline delta)
+//   2. paired_dots   — element 2 (paired-delta dot plot)
+//   3. histograms    — element 3 (will-to-buy histograms per variant)
+//   4. next_actions  — element 4 (next-action stacked bar / Sankey)
+//   5. tier_picked   — element 5 (tier-picked distribution per variant)
+//   6. theme_board   — element 6 (top blockers/objections/confusions/questions)
+//   7. personas      — element 7 (persona cards grid)
+//
+// `meta` carries study-level context (slug, n_paired, low_power flag from
+// spec §9 "Statistical overclaim" risk row).
+
+const variantId = z.enum(['A', 'B']);
+export type VariantId = z.infer<typeof variantId>;
+
+// Spec §2 #19 — paired statistics. Disagreement banner fires when paired-t
+// and Wilcoxon disagree at α=0.05 (one < 0.05, the other ≥ 0.05). The
+// aggregator decides; the report page just renders.
+const headline = z.object({
+  mean_delta: z.number(),
+  ci95_low: z.number(),
+  ci95_high: z.number(),
+  n_paired: z.number().int().min(0),
+  paired_t_p: z.number().min(0).max(1),
+  wilcoxon_p: z.number().min(0).max(1),
+  mcnemar_p: z.number().min(0).max(1),
+  // 'better' / 'worse' / 'inconclusive' — the one-line verdict per §5.18 #1.
+  verdict: z.enum(['better', 'worse', 'inconclusive']),
+  // Spec §2 #19: explicit disagreement flag. When true the page shows a
+  // banner and uses the conservative (larger) p-value in claim copy.
+  disagreement: z.boolean(),
+});
+
+// Spec §5.18 #2 — one row per backstory with both A and B scores. Hover/
+// click reveals backstory + both verdicts; aggregator includes the small
+// strings inline (cheap) and the page lazy-loads full responses on
+// expand (gated by share token per §5.18 perf budget).
+const pairedDot = z.object({
+  backstory_id: z.string(),
+  // Display name only — never email / real PII (public-repo audit).
+  backstory_name: z.string(),
+  role: z.enum(['founder_or_eng_lead', 'ic_engineer']),
+  score_a: z.number().min(0).max(10),
+  score_b: z.number().min(0).max(10),
+  // Per §5.18 #2 swing direction is a derived field but the aggregator
+  // pre-computes for color coding stability across re-renders.
+  swing: z.enum(['a_wins', 'tie', 'b_wins']),
+});
+
+// Spec §5.18 #3 — discrete 0–10 bins per variant. mean and median
+// annotated.
+const histogram = z.object({
+  variant: variantId,
+  // Length 11 (0..10 inclusive). Counts of `ok` visits in each bin.
+  bins: z.array(z.number().int().min(0)).length(11),
+  mean: z.number().min(0).max(10),
+  median: z.number().min(0).max(10),
+});
+
+// Spec §5.18 #4 + amendment A1 — next-action distribution per variant.
+// Eight enum values from amendment A1; ordered by intent weight in the UI.
+const nextActionRow = z.object({
+  variant: variantId,
+  // counts[next_action] = count of ok visits with that next_action.
+  counts: z.record(NextAction, z.number().int().min(0)),
+});
+
+// Spec §5.18 #5 — tier-picked distribution per variant. Six tiers
+// (none/hobby/express/starter/scale/enterprise); horizontal stacked bar.
+const tier = z.enum(['none', 'hobby', 'express', 'starter', 'scale', 'enterprise']);
+export type Tier = z.infer<typeof tier>;
+const tierRow = z.object({
+  variant: variantId,
+  counts: z.record(tier, z.number().int().min(0)),
+});
+
+// Spec §5.18 #6 — theme board. Four categories; clusters labeled by the
+// LLM cluster-label step (§5.7); raw quotes are redacted per §5.9.
+//
+// Only cluster summaries ride the public report wire; the quote drawer
+// loads attributions on demand (auth-gated).
+const themeCategory = z.enum(['blockers', 'objections', 'confusions', 'questions']);
+export type ThemeCategory = z.infer<typeof themeCategory>;
+const themeCluster = z.object({
+  cluster_id: z.string(),
+  label: z.string().max(80),
+  count: z.number().int().min(0),
+});
+const themeBoard = z.record(themeCategory, z.array(themeCluster));
+
+// Spec §5.18 #7 — persona card grid; sortable by |score_b - score_a|.
+// Backstory text is loaded on-demand when the card is expanded (§5.18
+// perf budget). The grid view carries only what's needed to render and
+// sort.
+const persona = z.object({
+  backstory_id: z.string(),
+  backstory_name: z.string(),
+  role: z.enum(['founder_or_eng_lead', 'ic_engineer']),
+  stage: z.string(),
+  team_size: z.number().int(),
+  stack: z.string(),
+  current_pain: z.string(),
+  entry_point: z.string(),
+  score_a: z.number().min(0).max(10),
+  score_b: z.number().min(0).max(10),
+  // Inline preview strings; full per-variant response loads on expand.
+  verdict_a: z.string().max(400),
+  verdict_b: z.string().max(400),
+});
+
+const meta = z.object({
+  slug: z.string(),
+  // Spec §9 statistical overclaim row — N<20 displays a low-power warning.
+  // Aggregator sets this; the report page just toggles a banner.
+  low_power: z.boolean(),
+});
+
+export const Report = z.object({
+  meta,
+  headline,
+  paired_dots: z.array(pairedDot),
+  histograms: z.array(histogram).length(2),
+  next_actions: z.array(nextActionRow).length(2),
+  tier_picked: z.array(tierRow).length(2),
+  theme_board: themeBoard,
+  personas: z.array(persona),
+});
+
+export type ReportT = z.infer<typeof Report>;

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -34,7 +34,7 @@ importers:
         version: 8.59.0(eslint@9.39.4(jiti@1.21.7))(typescript@5.9.3)
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   apps/api:
     dependencies:
@@ -62,7 +62,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   apps/capture-worker:
     dependencies:
@@ -78,7 +78,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   apps/visitor-worker:
     dependencies:
@@ -100,13 +100,16 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   apps/web:
     dependencies:
       '@willbuy/shared':
         specifier: workspace:*
         version: link:../../packages/shared
+      html-to-image:
+        specifier: ^1.11.13
+        version: 1.11.13
       next:
         specifier: 14.2.18
         version: 14.2.18(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
@@ -116,7 +119,13 @@ importers:
       react-dom:
         specifier: 18.3.1
         version: 18.3.1(react@18.3.1)
+      recharts:
+        specifier: ^2.13.3
+        version: 2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
     devDependencies:
+      '@testing-library/react':
+        specifier: ^16.1.0
+        version: 16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       '@types/node':
         specifier: ^22.10.2
         version: 22.19.17
@@ -129,6 +138,9 @@ importers:
       autoprefixer:
         specifier: ^10.4.20
         version: 10.5.0(postcss@8.5.10)
+      jsdom:
+        specifier: ^25.0.1
+        version: 25.0.1
       postcss:
         specifier: ^8.4.49
         version: 8.5.10
@@ -140,7 +152,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   packages/llm-adapter:
     devDependencies:
@@ -152,7 +164,7 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
   packages/shared:
     dependencies:
@@ -165,13 +177,56 @@ importers:
         version: 5.9.3
       vitest:
         specifier: ^2.1.8
-        version: 2.1.9(@types/node@22.19.17)
+        version: 2.1.9(@types/node@22.19.17)(jsdom@25.0.1)
 
 packages:
 
   '@alloc/quick-lru@5.2.0':
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
+
+  '@asamuzakjp/css-color@3.2.0':
+    resolution: {integrity: sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==}
+
+  '@babel/code-frame@7.29.0':
+    resolution: {integrity: sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/helper-validator-identifier@7.28.5':
+    resolution: {integrity: sha512-qSs4ifwzKJSV39ucNjsvc6WVHs6b7S03sOh2OcHF9UHfVPqWWALUsNUVzhSBiItjRZoLHx7nIarVjqKVusUZ1Q==}
+    engines: {node: '>=6.9.0'}
+
+  '@babel/runtime@7.29.2':
+    resolution: {integrity: sha512-JiDShH45zKHWyGe4ZNVRrCjBz8Nh9TMmZG1kh4QTK8hCBTWBi8Da+i7s1fJw7/lYpM4ccepSNfqzZ/QvABBi5g==}
+    engines: {node: '>=6.9.0'}
+
+  '@csstools/color-helpers@5.1.0':
+    resolution: {integrity: sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==}
+    engines: {node: '>=18'}
+
+  '@csstools/css-calc@2.1.4':
+    resolution: {integrity: sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-color-parser@3.1.0':
+    resolution: {integrity: sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-parser-algorithms': ^3.0.5
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5':
+    resolution: {integrity: sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@csstools/css-tokenizer': ^3.0.4
+
+  '@csstools/css-tokenizer@3.0.4':
+    resolution: {integrity: sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==}
+    engines: {node: '>=18'}
 
   '@esbuild/aix-ppc64@0.21.5':
     resolution: {integrity: sha512-1SDgH6ZSPTlggy1yI6+Dbkiz8xzpHJEVAlF/AM1tHPLsf5STom9rwtjE4hKAF20FfXXNTFqEYXyJNWh1GiZedQ==}
@@ -783,6 +838,55 @@ packages:
   '@swc/helpers@0.5.5':
     resolution: {integrity: sha512-KGYxvIOXcceOAbEk4bi/dVLEK9z8sZ0uBB3Il5b1rhfClSpcX0yfRO0KmTkqR2cnQDymwLB+25ZyMzICg/cm/A==}
 
+  '@testing-library/dom@10.4.1':
+    resolution: {integrity: sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==}
+    engines: {node: '>=18'}
+
+  '@testing-library/react@16.3.2':
+    resolution: {integrity: sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      '@testing-library/dom': ^10.0.0
+      '@types/react': ^18.0.0 || ^19.0.0
+      '@types/react-dom': ^18.0.0 || ^19.0.0
+      react: ^18.0.0 || ^19.0.0
+      react-dom: ^18.0.0 || ^19.0.0
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      '@types/react-dom':
+        optional: true
+
+  '@types/aria-query@5.0.4':
+    resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
+
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
   '@types/estree@1.0.8':
     resolution: {integrity: sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==}
 
@@ -902,6 +1006,10 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
+    engines: {node: '>= 14'}
+
   ajv-formats@3.0.1:
     resolution: {integrity: sha512-8iUql50EUR+uUcdRQ3HDqa6EVyo3docL8g5WJ3FNcWmu62IbkGUue/pEyLBW8VGKKucTPgqeks4fIU1DA4yowQ==}
     peerDependencies:
@@ -916,9 +1024,17 @@ packages:
   ajv@8.20.0:
     resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
 
+  ansi-regex@5.0.1:
+    resolution: {integrity: sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==}
+    engines: {node: '>=8'}
+
   ansi-styles@4.3.0:
     resolution: {integrity: sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==}
     engines: {node: '>=8'}
+
+  ansi-styles@5.2.0:
+    resolution: {integrity: sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==}
+    engines: {node: '>=10'}
 
   any-promise@1.3.0:
     resolution: {integrity: sha512-7UvmKalWRt1wgjL1RrGxoSJW/0QZFIegpeGvZG9kjp8vrRu55XTHbwnqq2GpXm9uLbcuhxm3IqX9OB4MZR1b2A==}
@@ -932,6 +1048,9 @@ packages:
 
   argparse@2.0.1:
     resolution: {integrity: sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==}
+
+  aria-query@5.3.0:
+    resolution: {integrity: sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==}
 
   array-buffer-byte-length@1.0.2:
     resolution: {integrity: sha512-LHE+8BuR7RYGDKvnrmcuSq3tDcKv9OFEXQt/HpbZhY7V6h0zlUXutnAD82GiFx9rdieCMjkvtcsPqBwgUl1Iiw==}
@@ -968,6 +1087,9 @@ packages:
   async-function@1.0.0:
     resolution: {integrity: sha512-hsU18Ae8CDTR6Kgu9DYf0EbCr/a5iGL0rytQDobUcdpYOKokk8LEjVphnXkDkgpi0wYVsqrXuP0bZxJaTqdgoA==}
     engines: {node: '>= 0.4'}
+
+  asynckit@0.4.0:
+    resolution: {integrity: sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==}
 
   atomic-sleep@1.0.0:
     resolution: {integrity: sha512-kNOjDqAh7px0XWNI+4QbzoiR/nTkHAWNud2uvnJquD1/x5a7EQZMJT0AczqK0Qn67oY/TTQ1LbUKajZpp3I9tQ==}
@@ -1069,12 +1191,20 @@ packages:
   client-only@0.0.1:
     resolution: {integrity: sha512-IV3Ou0jSMzZrd3pZ48nLkT9DA7Ag1pnPzaiQhpW7c3RbcqqzvzzVu+L8gfqMp/8IM2MQtSiqaCxrrcfu8I8rMA==}
 
+  clsx@2.1.1:
+    resolution: {integrity: sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==}
+    engines: {node: '>=6'}
+
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
     engines: {node: '>=7.0.0'}
 
   color-name@1.1.4:
     resolution: {integrity: sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==}
+
+  combined-stream@1.0.8:
+    resolution: {integrity: sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==}
+    engines: {node: '>= 0.8'}
 
   commander@4.1.1:
     resolution: {integrity: sha512-NOKm8xhkzAjzFx8B2v5OAHT+u5pRQc2UCa2Vq9jYL/31o2wi9mxBA7LIFs3sV5VSC49z6pEhfbMULvShKj26WA==}
@@ -1100,8 +1230,60 @@ packages:
     engines: {node: '>=4'}
     hasBin: true
 
+  cssstyle@4.6.0:
+    resolution: {integrity: sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==}
+    engines: {node: '>=18'}
+
   csstype@3.2.3:
     resolution: {integrity: sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  data-urls@5.0.0:
+    resolution: {integrity: sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==}
+    engines: {node: '>=18'}
 
   data-view-buffer@1.0.2:
     resolution: {integrity: sha512-EmKO5V3OLXh1rtK2wgXRansaK1/mtVdTUEiEI0W8RkvgT05kfxaH29PliLnpLP73yYO6142Q72QNa8Wx/A5CqQ==}
@@ -1124,6 +1306,12 @@ packages:
       supports-color:
         optional: true
 
+  decimal.js-light@2.5.1:
+    resolution: {integrity: sha512-qIMFpTMZmny+MMIitAB6D7iVPEorVw6YQRWkvarTkT4tBeSLLiHzcwj6q0MmYSFCiVpiqPJTJEYIrpcPzVEIvg==}
+
+  decimal.js@10.6.0:
+    resolution: {integrity: sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==}
+
   deep-eql@5.0.2:
     resolution: {integrity: sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==}
     engines: {node: '>=6'}
@@ -1138,6 +1326,10 @@ packages:
   define-properties@1.2.1:
     resolution: {integrity: sha512-8QmQKqEASLd5nx0U1B1okLElbUuuttJ/AnYmRXbbbGDWh6uS208EjD4Xqq/I9wK7u0v6O08XhTWnt5XtEbR6Dg==}
     engines: {node: '>= 0.4'}
+
+  delayed-stream@1.0.0:
+    resolution: {integrity: sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==}
+    engines: {node: '>=0.4.0'}
 
   depd@2.0.0:
     resolution: {integrity: sha512-g7nH6P6dyDioJogAAGprGpCtVImJhpPk/roCzdb3fIh61/s/nPsfR6onyMwkCAR/OlC3yBC0lESvUoQEAssIrw==}
@@ -1157,12 +1349,22 @@ packages:
     resolution: {integrity: sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==}
     engines: {node: '>=0.10.0'}
 
+  dom-accessibility-api@0.5.16:
+    resolution: {integrity: sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==}
+
+  dom-helpers@5.2.1:
+    resolution: {integrity: sha512-nRCa7CK3VTrM2NmGkIy4cbK7IZlgBE/PYMn55rrXefr5xXDP0LdtfPnblFDoVdcAfslJ7or6iqAUnx0CCGIWQA==}
+
   dunder-proto@1.0.1:
     resolution: {integrity: sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==}
     engines: {node: '>= 0.4'}
 
   electron-to-chromium@1.5.344:
     resolution: {integrity: sha512-4MxfbmNDm+KPh066EZy+eUnkcDPcZ35wNmOWzFuh/ijvHsve6kbLTLURy88uCNK5FbpN+yk2nQY6BYh1GEt+wg==}
+
+  entities@6.0.1:
+    resolution: {integrity: sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==}
+    engines: {node: '>=0.12'}
 
   es-abstract@1.24.2:
     resolution: {integrity: sha512-2FpH9Q5i2RRwyEP1AylXe6nYLR5OhaJTZwmlcP0dL/+JCbgg7yyEo/sEK6HeGZRf3dFpWwThaRHVApXSkW3xeg==}
@@ -1272,6 +1474,9 @@ packages:
     resolution: {integrity: sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==}
     engines: {node: '>=0.10.0'}
 
+  eventemitter3@4.0.7:
+    resolution: {integrity: sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==}
+
   expect-type@1.3.0:
     resolution: {integrity: sha512-knvyeauYhqjOYvQ66MznSMs83wmHrCycNEN6Ao+2AeYEfxUIkuiVxdEa1qlGEPK+We3n0THiDciYSsCcgW/DoA==}
     engines: {node: '>=12.0.0'}
@@ -1281,6 +1486,10 @@ packages:
 
   fast-deep-equal@3.1.3:
     resolution: {integrity: sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q==}
+
+  fast-equals@5.4.0:
+    resolution: {integrity: sha512-jt2DW/aNFNwke7AUd+Z+e6pz39KO5rzdbbFCg2sGafS4mk13MI7Z8O5z9cADNn5lhGODIgLwug6TZO2ctf7kcw==}
+    engines: {node: '>=6.0.0'}
 
   fast-glob@3.3.3:
     resolution: {integrity: sha512-7MptL8U0cqcFdzIzwOTHoilX9x5BrNqye7Z/LuC7kCMRio1EMSyqRK3BEAUD7sXRq4iT4AzTVuZdhgQ2TCvYLg==}
@@ -1345,6 +1554,10 @@ packages:
   for-each@0.3.5:
     resolution: {integrity: sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==}
     engines: {node: '>= 0.4'}
+
+  form-data@4.0.5:
+    resolution: {integrity: sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==}
+    engines: {node: '>= 6'}
 
   forwarded@0.2.0:
     resolution: {integrity: sha512-buRG0fpBtRHSTCOASe6hD258tEubFoRLb4ZNA6NxMVHNw2gOcwHo9wyablzMzOA5z9xA9L1KNjk/Nt6MT9aYow==}
@@ -1446,9 +1659,28 @@ packages:
     resolution: {integrity: sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==}
     engines: {node: '>= 0.4'}
 
+  html-encoding-sniffer@4.0.0:
+    resolution: {integrity: sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==}
+    engines: {node: '>=18'}
+
+  html-to-image@1.11.13:
+    resolution: {integrity: sha512-cuOPoI7WApyhBElTTb9oqsawRvZ0rHhaHwghRLlTuffoD1B2aDemlCruLeZrUIIdvG7gs9xeELEPm6PhuASqrg==}
+
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
+
+  http-proxy-agent@7.0.2:
+    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
+    engines: {node: '>= 14'}
+
+  https-proxy-agent@7.0.6:
+    resolution: {integrity: sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==}
+    engines: {node: '>= 14'}
+
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
 
   ignore@5.3.2:
     resolution: {integrity: sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g==}
@@ -1472,6 +1704,10 @@ packages:
   internal-slot@1.1.0:
     resolution: {integrity: sha512-4gd7VpWNQNB4UKKCFFVcp1AVv+FMOgs9NKzjHKusc8jTMhd5eL1NqQqOpE0KzMds804/yHlglp3uxgluOqAPLw==}
     engines: {node: '>= 0.4'}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   ipaddr.js@2.3.0:
     resolution: {integrity: sha512-Zv/pA+ciVFbCSBBjGfaKUya/CcGmUHzTydLMaTwrUUEM2DIEO3iZvueGxmacvmN50fGpGVKeTXpb2LcYQxeVdg==}
@@ -1545,6 +1781,9 @@ packages:
     resolution: {integrity: sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==}
     engines: {node: '>=0.12.0'}
 
+  is-potential-custom-element-name@1.0.1:
+    resolution: {integrity: sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==}
+
   is-regex@1.2.1:
     resolution: {integrity: sha512-MjYsKHO5O7mCsmRGxWcLWheFqN9DJ/2TmngvjKXihe6efViPqc274+Fx/4fYj/r03+ESvBdTXK0V6tA3rgez1g==}
     engines: {node: '>= 0.4'}
@@ -1602,6 +1841,15 @@ packages:
     resolution: {integrity: sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA==}
     hasBin: true
 
+  jsdom@25.0.1:
+    resolution: {integrity: sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      canvas: ^2.11.2
+    peerDependenciesMeta:
+      canvas:
+        optional: true
+
   json-buffer@3.0.1:
     resolution: {integrity: sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==}
 
@@ -1645,12 +1893,22 @@ packages:
   lodash.merge@4.6.2:
     resolution: {integrity: sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==}
 
+  lodash@4.18.1:
+    resolution: {integrity: sha512-dMInicTPVE8d1e5otfwmmjlxkZoUpiVLwyeTdUsi/Caj/gfzzblBcCE5sRHV/AsjuCmxWrte2TNGSYuCeCq+0Q==}
+
   loose-envify@1.4.0:
     resolution: {integrity: sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==}
     hasBin: true
 
   loupe@3.2.1:
     resolution: {integrity: sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==}
+
+  lru-cache@10.4.3:
+    resolution: {integrity: sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -1671,8 +1929,16 @@ packages:
     resolution: {integrity: sha512-PXwfBhYu0hBCPw8Dn0E+WDYb7af3dSLVWKi3HGv84IdF4TyFoC0ysxFd0Goxw7nSv4T/PzEJQxsYsEiFCKo2BA==}
     engines: {node: '>=8.6'}
 
+  mime-db@1.52.0:
+    resolution: {integrity: sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==}
+    engines: {node: '>= 0.6'}
+
   mime-db@1.54.0:
     resolution: {integrity: sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==}
+    engines: {node: '>= 0.6'}
+
+  mime-types@2.1.35:
+    resolution: {integrity: sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==}
     engines: {node: '>= 0.6'}
 
   mime-types@3.0.2:
@@ -1730,6 +1996,9 @@ packages:
     resolution: {integrity: sha512-6eZs5Ls3WtCisHWp9S2GUy8dqkpGi4BVSz3GaqiE6ezub0512ESztXUwUB6C6IKbQkY2Pnb/mD4WYojCRwcwLA==}
     engines: {node: '>=0.10.0'}
 
+  nwsapi@2.2.23:
+    resolution: {integrity: sha512-7wfH4sLbt4M0gCDzGE6vzQBo0bfTKjU7Sfpqy/7gs1qBfYz2vEJH6vXcBKpO3+6Yu1telwd0t9HpyOoLEQQbIQ==}
+
   object-assign@4.1.1:
     resolution: {integrity: sha512-rJgTQnkUnH1sFw8yT6VSU3zD3sWmu6sZhIseY8VX+GRu3P6F7Fu+JNDoXfklElbLJSnc3FUQHVe4cU5hj+BcUg==}
     engines: {node: '>=0.10.0'}
@@ -1785,6 +2054,9 @@ packages:
   parent-module@1.0.1:
     resolution: {integrity: sha512-GQ2EWRpQV8/o+Aw8YqtfZZPfNRWZYkbidE9k5rpl/hC3vtHHBfGm2Ifi6qWV+coDGkrUKZAxE3Lot5kcsRlh+g==}
     engines: {node: '>=6'}
+
+  parse5@7.3.0:
+    resolution: {integrity: sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==}
 
   path-exists@4.0.0:
     resolution: {integrity: sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w==}
@@ -1907,6 +2179,10 @@ packages:
     engines: {node: '>=14'}
     hasBin: true
 
+  pretty-format@27.5.1:
+    resolution: {integrity: sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==}
+    engines: {node: ^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0}
+
   process-warning@4.0.1:
     resolution: {integrity: sha512-3c2LzQ3rY9d0hc1emcsHhfT9Jwz0cChib/QN89oME2R451w5fy3f0afAhERFZAwrbDU43wk12d0ORBpDVME50Q==}
 
@@ -1934,6 +2210,24 @@ packages:
   react-is@16.13.1:
     resolution: {integrity: sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==}
 
+  react-is@17.0.2:
+    resolution: {integrity: sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==}
+
+  react-is@18.3.1:
+    resolution: {integrity: sha512-/LLMVyas0ljjAtoYiPqYiL8VWXzUUdThrmU5+n20DZv+a+ClRoevUzw5JxU+Ieh5/c87ytoTBV9G1FiKfNJdmg==}
+
+  react-smooth@4.0.4:
+    resolution: {integrity: sha512-gnGKTpYwqL0Iii09gHobNolvX4Kiq4PKx6eWBCYYix+8cdw+cGo3do906l1NBPKkSWx1DghC1dlWG9L2uGd61Q==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
+  react-transition-group@4.4.5:
+    resolution: {integrity: sha512-pZcd1MCJoiKiBR2NRxeCRg13uCXbydPnmB4EOeRrY7480qNWO8IIgQG6zlDkm6uRMsURXPuKq0GWtiM59a5Q6g==}
+    peerDependencies:
+      react: '>=16.6.0'
+      react-dom: '>=16.6.0'
+
   react@18.3.1:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
@@ -1948,6 +2242,16 @@ packages:
   real-require@0.2.0:
     resolution: {integrity: sha512-57frrGM/OCTLqLOAh0mhVA9VBMHd+9U7Zb2THMGdBUoZVOtGbJzjxsYGDJ3A9AYYCP4hn6y1TVbaOfzWtm5GFg==}
     engines: {node: '>= 12.13.0'}
+
+  recharts-scale@0.4.5:
+    resolution: {integrity: sha512-kivNFO+0OcUNu7jQquLXAxz1FIwZj8nrj+YkOKc5694NbjCvcT6aSZiIzNzd2Kul4o4rTto8QVR9lMNtxD4G1w==}
+
+  recharts@2.15.4:
+    resolution: {integrity: sha512-UT/q6fwS3c1dHbXv2uFgYJ9BMFHu3fwnd7AYZaEQhXuYQ4hgsxLvsUXzGdKeZrW5xopzDCvuA2N41WJ88I7zIw==}
+    engines: {node: '>=14'}
+    peerDependencies:
+      react: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+      react-dom: ^16.0.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
 
   reflect.getprototypeof@1.0.10:
     resolution: {integrity: sha512-00o4I+DVrefhv+nX0ulyi3biSHCPDe+yLv5o/p6d/UVlirijB8E16FtfwSAi4g3tcqrQ4lRAqQSoFEZJehYEcw==}
@@ -1994,6 +2298,12 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  rrweb-cssom@0.7.1:
+    resolution: {integrity: sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==}
+
+  rrweb-cssom@0.8.0:
+    resolution: {integrity: sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==}
+
   run-parallel@1.2.0:
     resolution: {integrity: sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA==}
 
@@ -2016,6 +2326,13 @@ packages:
   safe-stable-stringify@2.5.0:
     resolution: {integrity: sha512-b3rppTKm9T+PsVCBEOUR46GWI7fdOs00VKZ1+9c1EWDaDMvjQc6tUwuFyIprgGgTcWoVHSKrU8H31ZHA2e0RHA==}
     engines: {node: '>=10'}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
+
+  saxes@6.0.0:
+    resolution: {integrity: sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==}
+    engines: {node: '>=v12.22.7'}
 
   scheduler@0.23.2:
     resolution: {integrity: sha512-UOShsPwz7NrMUqhR6t0hWjFduvOzbtv7toDH1/hIrfRNIDBnnBWd0CwJTGvTpngVlmwGCdP9/Zl/tVrDqcuYzQ==}
@@ -2155,6 +2472,9 @@ packages:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
 
+  symbol-tree@3.2.4:
+    resolution: {integrity: sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==}
+
   tailwindcss@3.4.19:
     resolution: {integrity: sha512-3ofp+LL8E+pK/JuPLPggVAIaEuhvIz4qNcf3nA1Xn2o/7fb7s/TYpHhwGDv1ZU3PkBluUVaF8PyCHcm48cKLWQ==}
     engines: {node: '>=14.0.0'}
@@ -2169,6 +2489,9 @@ packages:
 
   thread-stream@3.1.0:
     resolution: {integrity: sha512-OqyPZ9u96VohAyMfJykzmivOrY2wfMSf3C5TtFJVgN+Hm6aj+voFhlK+kZEIv2FBh1X6Xp3DlnCOfEQ3B2J86A==}
+
+  tiny-invariant@1.3.3:
+    resolution: {integrity: sha512-+FbBPE1o9QAYvviau/qC5SE3caw21q3xkvWKBtja5vgqOWIHHJ3ioaq1VPfn/Szqctz2bU/oYeKd9/z5BL+PVg==}
 
   tinybench@2.9.0:
     resolution: {integrity: sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==}
@@ -2192,6 +2515,13 @@ packages:
     resolution: {integrity: sha512-n1cw8k1k0x4pgA2+9XrOkFydTerNcJ1zWCO5Nn9scWHTD+5tp8dghT2x1uduQePZTZgd3Tupf+x9BxJjeJi77Q==}
     engines: {node: '>=14.0.0'}
 
+  tldts-core@6.1.86:
+    resolution: {integrity: sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==}
+
+  tldts@6.1.86:
+    resolution: {integrity: sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==}
+    hasBin: true
+
   to-regex-range@5.0.1:
     resolution: {integrity: sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ==}
     engines: {node: '>=8.0'}
@@ -2203,6 +2533,14 @@ packages:
   toidentifier@1.0.1:
     resolution: {integrity: sha512-o5sSPKEkg/DIQNmH43V0/uerLrpzVedkUh8tGNvaeXpfpuwjKenlSox/2O/BTlZUtEe+JG7s5YhEz608PlAHRA==}
     engines: {node: '>=0.6'}
+
+  tough-cookie@5.1.2:
+    resolution: {integrity: sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==}
+    engines: {node: '>=16'}
+
+  tr46@5.1.1:
+    resolution: {integrity: sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==}
+    engines: {node: '>=18'}
 
   ts-api-utils@2.5.0:
     resolution: {integrity: sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA==}
@@ -2280,6 +2618,9 @@ packages:
     resolution: {integrity: sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==}
     engines: {node: '>= 0.8'}
 
+  victory-vendor@36.9.2:
+    resolution: {integrity: sha512-PnpQQMuxlwYdocC8fIJqVXvkeViHYzotI+NJrCuav0ZYFoq912ZHBk3mCeuj+5/VpodOjPe1z0Fk2ihgzlXqjQ==}
+
   vite-node@2.1.9:
     resolution: {integrity: sha512-AM9aQ/IPrW/6ENLQg3AGY4K1N2TGZdR5e4gu/MmmR2xR3Ll1+dib+nook92g4TV3PXVyeyxdWwtaCAiUL0hMxA==}
     engines: {node: ^18.0.0 || >=20.0.0}
@@ -2341,6 +2682,27 @@ packages:
       jsdom:
         optional: true
 
+  w3c-xmlserializer@5.0.0:
+    resolution: {integrity: sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==}
+    engines: {node: '>=18'}
+
+  webidl-conversions@7.0.0:
+    resolution: {integrity: sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==}
+    engines: {node: '>=12'}
+
+  whatwg-encoding@3.1.1:
+    resolution: {integrity: sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==}
+    engines: {node: '>=18'}
+    deprecated: Use @exodus/bytes instead for a more spec-conformant and faster implementation
+
+  whatwg-mimetype@4.0.0:
+    resolution: {integrity: sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==}
+    engines: {node: '>=18'}
+
+  whatwg-url@14.2.0:
+    resolution: {integrity: sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==}
+    engines: {node: '>=18'}
+
   which-boxed-primitive@1.1.1:
     resolution: {integrity: sha512-TbX3mj8n0odCBFVlY8AxkqcHASw3L60jIuF8jFP78az3C2YhmGvqbHBpAjTRH2/xqYunrJ9g1jSyjCjpoWzIAA==}
     engines: {node: '>= 0.4'}
@@ -2371,6 +2733,25 @@ packages:
     resolution: {integrity: sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA==}
     engines: {node: '>=0.10.0'}
 
+  ws@8.20.0:
+    resolution: {integrity: sha512-sAt8BhgNbzCtgGbt2OxmpuryO63ZoDk/sqaB/znQm94T4fCEsy/yV+7CdC1kJhOU9lboAEU7R3kquuycDoibVA==}
+    engines: {node: '>=10.0.0'}
+    peerDependencies:
+      bufferutil: ^4.0.1
+      utf-8-validate: '>=5.0.2'
+    peerDependenciesMeta:
+      bufferutil:
+        optional: true
+      utf-8-validate:
+        optional: true
+
+  xml-name-validator@5.0.0:
+    resolution: {integrity: sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==}
+    engines: {node: '>=18'}
+
+  xmlchars@2.2.0:
+    resolution: {integrity: sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==}
+
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
@@ -2381,6 +2762,44 @@ packages:
 snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
+
+  '@asamuzakjp/css-color@3.2.0':
+    dependencies:
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-color-parser': 3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+      lru-cache: 10.4.3
+
+  '@babel/code-frame@7.29.0':
+    dependencies:
+      '@babel/helper-validator-identifier': 7.28.5
+      js-tokens: 4.0.0
+      picocolors: 1.1.1
+
+  '@babel/helper-validator-identifier@7.28.5': {}
+
+  '@babel/runtime@7.29.2': {}
+
+  '@csstools/color-helpers@5.1.0': {}
+
+  '@csstools/css-calc@2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-color-parser@3.1.0(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/color-helpers': 5.1.0
+      '@csstools/css-calc': 2.1.4(@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4))(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-parser-algorithms': 3.0.5(@csstools/css-tokenizer@3.0.4)
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-parser-algorithms@3.0.5(@csstools/css-tokenizer@3.0.4)':
+    dependencies:
+      '@csstools/css-tokenizer': 3.0.4
+
+  '@csstools/css-tokenizer@3.0.4': {}
 
   '@esbuild/aix-ppc64@0.21.5':
     optional: true
@@ -2765,6 +3184,53 @@ snapshots:
       '@swc/counter': 0.1.3
       tslib: 2.8.1
 
+  '@testing-library/dom@10.4.1':
+    dependencies:
+      '@babel/code-frame': 7.29.0
+      '@babel/runtime': 7.29.2
+      '@types/aria-query': 5.0.4
+      aria-query: 5.3.0
+      dom-accessibility-api: 0.5.16
+      lz-string: 1.5.0
+      picocolors: 1.1.1
+      pretty-format: 27.5.1
+
+  '@testing-library/react@16.3.2(@testing-library/dom@10.4.1)(@types/react-dom@18.3.1)(@types/react@18.3.12)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@babel/runtime': 7.29.2
+      '@testing-library/dom': 10.4.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.3.12
+      '@types/react-dom': 18.3.1
+
+  '@types/aria-query@5.0.4': {}
+
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
   '@types/estree@1.0.8': {}
 
   '@types/json-schema@7.0.15': {}
@@ -2923,6 +3389,8 @@ snapshots:
 
   acorn@8.16.0: {}
 
+  agent-base@7.1.4: {}
+
   ajv-formats@3.0.1(ajv@8.20.0):
     optionalDependencies:
       ajv: 8.20.0
@@ -2941,9 +3409,13 @@ snapshots:
       json-schema-traverse: 1.0.0
       require-from-string: 2.0.2
 
+  ansi-regex@5.0.1: {}
+
   ansi-styles@4.3.0:
     dependencies:
       color-convert: 2.0.1
+
+  ansi-styles@5.2.0: {}
 
   any-promise@1.3.0: {}
 
@@ -2955,6 +3427,10 @@ snapshots:
   arg@5.0.2: {}
 
   argparse@2.0.1: {}
+
+  aria-query@5.3.0:
+    dependencies:
+      dequal: 2.0.3
 
   array-buffer-byte-length@1.0.2:
     dependencies:
@@ -3016,6 +3492,8 @@ snapshots:
   assertion-error@2.0.1: {}
 
   async-function@1.0.0: {}
+
+  asynckit@0.4.0: {}
 
   atomic-sleep@1.0.0: {}
 
@@ -3124,11 +3602,17 @@ snapshots:
 
   client-only@0.0.1: {}
 
+  clsx@2.1.1: {}
+
   color-convert@2.0.1:
     dependencies:
       color-name: 1.1.4
 
   color-name@1.1.4: {}
+
+  combined-stream@1.0.8:
+    dependencies:
+      delayed-stream: 1.0.0
 
   commander@4.1.1: {}
 
@@ -3146,7 +3630,55 @@ snapshots:
 
   cssesc@3.0.0: {}
 
+  cssstyle@4.6.0:
+    dependencies:
+      '@asamuzakjp/css-color': 3.2.0
+      rrweb-cssom: 0.8.0
+
   csstype@3.2.3: {}
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-color@3.1.0: {}
+
+  d3-ease@3.0.1: {}
+
+  d3-format@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@3.1.0: {}
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  data-urls@5.0.0:
+    dependencies:
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
 
   data-view-buffer@1.0.2:
     dependencies:
@@ -3170,6 +3702,10 @@ snapshots:
     dependencies:
       ms: 2.1.3
 
+  decimal.js-light@2.5.1: {}
+
+  decimal.js@10.6.0: {}
+
   deep-eql@5.0.2: {}
 
   deep-is@0.1.4: {}
@@ -3186,6 +3722,8 @@ snapshots:
       has-property-descriptors: 1.0.2
       object-keys: 1.1.1
 
+  delayed-stream@1.0.0: {}
+
   depd@2.0.0: {}
 
   dequal@2.0.3: {}
@@ -3198,6 +3736,13 @@ snapshots:
     dependencies:
       esutils: 2.0.3
 
+  dom-accessibility-api@0.5.16: {}
+
+  dom-helpers@5.2.1:
+    dependencies:
+      '@babel/runtime': 7.29.2
+      csstype: 3.2.3
+
   dunder-proto@1.0.1:
     dependencies:
       call-bind-apply-helpers: 1.0.2
@@ -3205,6 +3750,8 @@ snapshots:
       gopd: 1.2.0
 
   electron-to-chromium@1.5.344: {}
+
+  entities@6.0.1: {}
 
   es-abstract@1.24.2:
     dependencies:
@@ -3464,11 +4011,15 @@ snapshots:
 
   esutils@2.0.3: {}
 
+  eventemitter3@4.0.7: {}
+
   expect-type@1.3.0: {}
 
   fast-decode-uri-component@1.0.1: {}
 
   fast-deep-equal@3.1.3: {}
+
+  fast-equals@5.4.0: {}
 
   fast-glob@3.3.3:
     dependencies:
@@ -3554,6 +4105,14 @@ snapshots:
   for-each@0.3.5:
     dependencies:
       is-callable: 1.2.7
+
+  form-data@4.0.5:
+    dependencies:
+      asynckit: 0.4.0
+      combined-stream: 1.0.8
+      es-set-tostringtag: 2.1.0
+      hasown: 2.0.3
+      mime-types: 2.1.35
 
   forwarded@0.2.0: {}
 
@@ -3651,6 +4210,12 @@ snapshots:
     dependencies:
       function-bind: 1.1.2
 
+  html-encoding-sniffer@4.0.0:
+    dependencies:
+      whatwg-encoding: 3.1.1
+
+  html-to-image@1.11.13: {}
+
   http-errors@2.0.1:
     dependencies:
       depd: 2.0.0
@@ -3658,6 +4223,24 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
+
+  http-proxy-agent@7.0.2:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  https-proxy-agent@7.0.6:
+    dependencies:
+      agent-base: 7.1.4
+      debug: 4.4.3
+    transitivePeerDependencies:
+      - supports-color
+
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
 
   ignore@5.3.2: {}
 
@@ -3677,6 +4260,8 @@ snapshots:
       es-errors: 1.3.0
       hasown: 2.0.3
       side-channel: 1.1.0
+
+  internmap@2.0.3: {}
 
   ipaddr.js@2.3.0: {}
 
@@ -3753,6 +4338,8 @@ snapshots:
 
   is-number@7.0.0: {}
 
+  is-potential-custom-element-name@1.0.1: {}
+
   is-regex@1.2.1:
     dependencies:
       call-bound: 1.0.4
@@ -3813,6 +4400,34 @@ snapshots:
     dependencies:
       argparse: 2.0.1
 
+  jsdom@25.0.1:
+    dependencies:
+      cssstyle: 4.6.0
+      data-urls: 5.0.0
+      decimal.js: 10.6.0
+      form-data: 4.0.5
+      html-encoding-sniffer: 4.0.0
+      http-proxy-agent: 7.0.2
+      https-proxy-agent: 7.0.6
+      is-potential-custom-element-name: 1.0.1
+      nwsapi: 2.2.23
+      parse5: 7.3.0
+      rrweb-cssom: 0.7.1
+      saxes: 6.0.0
+      symbol-tree: 3.2.4
+      tough-cookie: 5.1.2
+      w3c-xmlserializer: 5.0.0
+      webidl-conversions: 7.0.0
+      whatwg-encoding: 3.1.1
+      whatwg-mimetype: 4.0.0
+      whatwg-url: 14.2.0
+      ws: 8.20.0
+      xml-name-validator: 5.0.0
+    transitivePeerDependencies:
+      - bufferutil
+      - supports-color
+      - utf-8-validate
+
   json-buffer@3.0.1: {}
 
   json-schema-ref-resolver@3.0.0:
@@ -3857,11 +4472,17 @@ snapshots:
 
   lodash.merge@4.6.2: {}
 
+  lodash@4.18.1: {}
+
   loose-envify@1.4.0:
     dependencies:
       js-tokens: 4.0.0
 
   loupe@3.2.1: {}
+
+  lru-cache@10.4.3: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -3878,7 +4499,13 @@ snapshots:
       braces: 3.0.3
       picomatch: 2.3.2
 
+  mime-db@1.52.0: {}
+
   mime-db@1.54.0: {}
+
+  mime-types@2.1.35:
+    dependencies:
+      mime-db: 1.52.0
 
   mime-types@3.0.2:
     dependencies:
@@ -3939,6 +4566,8 @@ snapshots:
   node-releases@2.0.38: {}
 
   normalize-path@3.0.0: {}
+
+  nwsapi@2.2.23: {}
 
   object-assign@4.1.1: {}
 
@@ -4006,6 +4635,10 @@ snapshots:
   parent-module@1.0.1:
     dependencies:
       callsites: 3.1.0
+
+  parse5@7.3.0:
+    dependencies:
+      entities: 6.0.1
 
   path-exists@4.0.0: {}
 
@@ -4105,6 +4738,12 @@ snapshots:
 
   prettier@3.8.3: {}
 
+  pretty-format@27.5.1:
+    dependencies:
+      ansi-regex: 5.0.1
+      ansi-styles: 5.2.0
+      react-is: 17.0.2
+
   process-warning@4.0.1: {}
 
   process-warning@5.0.0: {}
@@ -4129,6 +4768,27 @@ snapshots:
 
   react-is@16.13.1: {}
 
+  react-is@17.0.2: {}
+
+  react-is@18.3.1: {}
+
+  react-smooth@4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      fast-equals: 5.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-transition-group: 4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+
+  react-transition-group@4.4.5(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@babel/runtime': 7.29.2
+      dom-helpers: 5.2.1
+      loose-envify: 1.4.0
+      prop-types: 15.8.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+
   react@18.3.1:
     dependencies:
       loose-envify: 1.4.0
@@ -4142,6 +4802,23 @@ snapshots:
       picomatch: 2.3.2
 
   real-require@0.2.0: {}
+
+  recharts-scale@0.4.5:
+    dependencies:
+      decimal.js-light: 2.5.1
+
+  recharts@2.15.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      clsx: 2.1.1
+      eventemitter3: 4.0.7
+      lodash: 4.18.1
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      react-is: 18.3.1
+      react-smooth: 4.0.4(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      recharts-scale: 0.4.5
+      tiny-invariant: 1.3.3
+      victory-vendor: 36.9.2
 
   reflect.getprototypeof@1.0.10:
     dependencies:
@@ -4222,6 +4899,10 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.2
       fsevents: 2.3.3
 
+  rrweb-cssom@0.7.1: {}
+
+  rrweb-cssom@0.8.0: {}
+
   run-parallel@1.2.0:
     dependencies:
       queue-microtask: 1.2.3
@@ -4250,6 +4931,12 @@ snapshots:
       ret: 0.5.0
 
   safe-stable-stringify@2.5.0: {}
+
+  safer-buffer@2.1.2: {}
+
+  saxes@6.0.0:
+    dependencies:
+      xmlchars: 2.2.0
 
   scheduler@0.23.2:
     dependencies:
@@ -4411,6 +5098,8 @@ snapshots:
 
   supports-preserve-symlinks-flag@1.0.0: {}
 
+  symbol-tree@3.2.4: {}
+
   tailwindcss@3.4.19(tsx@4.21.0):
     dependencies:
       '@alloc/quick-lru': 5.2.0
@@ -4451,6 +5140,8 @@ snapshots:
     dependencies:
       real-require: 0.2.0
 
+  tiny-invariant@1.3.3: {}
+
   tinybench@2.9.0: {}
 
   tinyexec@0.3.2: {}
@@ -4466,6 +5157,12 @@ snapshots:
 
   tinyspy@3.0.2: {}
 
+  tldts-core@6.1.86: {}
+
+  tldts@6.1.86:
+    dependencies:
+      tldts-core: 6.1.86
+
   to-regex-range@5.0.1:
     dependencies:
       is-number: 7.0.0
@@ -4473,6 +5170,14 @@ snapshots:
   toad-cache@3.7.0: {}
 
   toidentifier@1.0.1: {}
+
+  tough-cookie@5.1.2:
+    dependencies:
+      tldts: 6.1.86
+
+  tr46@5.1.1:
+    dependencies:
+      punycode: 2.3.1
 
   ts-api-utils@2.5.0(typescript@5.9.3):
     dependencies:
@@ -4568,6 +5273,23 @@ snapshots:
 
   vary@1.1.2: {}
 
+  victory-vendor@36.9.2:
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-ease': 3.0.2
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-scale': 4.0.9
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-timer': 3.0.2
+      d3-array: 3.2.4
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-scale: 4.0.2
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-timer: 3.0.1
+
   vite-node@2.1.9(@types/node@22.19.17):
     dependencies:
       cac: 6.7.14
@@ -4595,7 +5317,7 @@ snapshots:
       '@types/node': 22.19.17
       fsevents: 2.3.3
 
-  vitest@2.1.9(@types/node@22.19.17):
+  vitest@2.1.9(@types/node@22.19.17)(jsdom@25.0.1):
     dependencies:
       '@vitest/expect': 2.1.9
       '@vitest/mocker': 2.1.9(vite@5.4.21(@types/node@22.19.17))
@@ -4619,6 +5341,7 @@ snapshots:
       why-is-node-running: 2.3.0
     optionalDependencies:
       '@types/node': 22.19.17
+      jsdom: 25.0.1
     transitivePeerDependencies:
       - less
       - lightningcss
@@ -4629,6 +5352,23 @@ snapshots:
       - sugarss
       - supports-color
       - terser
+
+  w3c-xmlserializer@5.0.0:
+    dependencies:
+      xml-name-validator: 5.0.0
+
+  webidl-conversions@7.0.0: {}
+
+  whatwg-encoding@3.1.1:
+    dependencies:
+      iconv-lite: 0.6.3
+
+  whatwg-mimetype@4.0.0: {}
+
+  whatwg-url@14.2.0:
+    dependencies:
+      tr46: 5.1.1
+      webidl-conversions: 7.0.0
 
   which-boxed-primitive@1.1.1:
     dependencies:
@@ -4681,6 +5421,12 @@ snapshots:
       stackback: 0.0.2
 
   word-wrap@1.2.5: {}
+
+  ws@8.20.0: {}
+
+  xml-name-validator@5.0.0: {}
+
+  xmlchars@2.2.0: {}
 
   yocto-queue@0.1.0: {}
 


### PR DESCRIPTION
Implements the seven §5.18 visual elements for the report page, plus
the supporting wire-shape contract, fixture, and perf runner.

Closes #35

## Spec sections satisfied

- **§5.18** — all seven required visual elements (headline delta;
  paired-delta dot plot; will-to-buy histograms; next-action stacked
  bar; tier-picked distribution; theme board; persona cards) + PNG
  export + public-mode debug strip.
- **§2 #19** — paired-stats disagreement banner (paired-t vs Wilcoxon)
  with the conservative (larger) p-value surfaced.
- **§5.10** — CSP holds on \`/r/*\`. Recharts emits SVG only; the test
  scans the rendered DOM for \`<script>\` and inline \`onclick\` and
  asserts both are absent.
- **Amendment A1** — next-action stacked bar uses the eight-action
  enum from \`SPEC.willbuy.amendments.md\` (\`purchase_paid_today\` …
  \`leave\`), ordered by intent weight. Note: the base spec §5.18 #4
  text still says "6 actions from §2 #15" — that text is superseded by
  A1. This PR implements **8 actions** (per A1) throughout.

## TDD evidence

Commit \`4bc5613\` is the red commit (failing tests + fixture +
package.json deps; no components yet). Commit \`65fd6ce\` is the green
commit (components + page wiring).

\`\`\`
$ pnpm --filter @willbuy/web test
✓ test/middleware.test.ts (5 tests)
✓ test/pages.test.tsx (6 tests)
✓ test/report-viz.test.tsx (8 tests)
✓ test/lint-scoping.test.ts (2 tests)
Test Files  4 passed (4)
     Tests  21 passed (21)
\`\`\`

The five named TDD scenarios from issue #35 are tagged \`1.\` through
\`5.\` in \`apps/web/test/report-viz.test.tsx\`:

1. all 7 elements render against the fixture
2. disagreement banner fires (and doesn't fire on the agreement fixture)
3. CSP §5.10 — no inline \`<script>\` / \`onclick\` in any rendered
   component
4. PNG export returns a non-empty \`data:image/png;base64,…\` URL
5. clicking the top persona card opens the drawer with both A and B
   verdicts

Plus a public-mode debug-strip test and a low-power banner test.

## Review fixes (PR #44 REQUEST CHANGES)

- **F1 (blocking)**: implemented per-backstory SVG connector via
  \`<Customized />\` in \`PairedDots.tsx\`. One \`<line data-connector>\`
  per backstory, colored by swing direction, drawn before the dot
  series so dots render on top. Red commit \`5003a55\` adds the failing
  test; green commit \`54e5602\` implements.
- **F2**: replaced inner \`<Scatter>\` children with \`<Cell>\` for
  per-dot swing coloring on the B series (Recharts contract).
- **F3**: clarified in this PR body that §5.18 #4's "6 actions" text
  is superseded by amendment A1 (8 actions).
- **F4**: added \`@internal\` JSDoc tag to \`ExportOptions._toPngForTest\`.
- **F5**: removed unused \`spawnSync\` + \`existsSync\` imports and their
  \`void\` silencing casts from \`lighthouse.mjs\`.

## Wire-shape contract for the aggregator (#31)

\`packages/shared/src/report.ts\` defines the \`Report\` zod schema —
one field per §5.18 element. \`apps/web/test/fixtures/README.md\`
documents the contract for the aggregator engineer. Two fixtures:

- \`report.fixture.json\` — happy-path N=30 paired, B converts better,
  tests agree (no banner).
- \`report.disagreement.fixture.json\` — paired-t p=0.041,
  Wilcoxon p=0.092 → §2 #19 banner fires.

## Perf budget

\`apps/web/test/perf/lighthouse.mjs\` — runs Lighthouse against
\`/r/test-fixture\` (served from the fixture seam when
\`WILLBUY_REPORT_FIXTURE=enabled\`) with 5 Mbps throttling, asserts
FCP ≤ 1500 ms. Documented in \`apps/web/test/perf/README.md\`.

The runner is a standalone Node script (NOT a vitest test) because
Lighthouse + Chromium are too heavy for the unit-test inner loop.
Build is small enough to fit comfortably:

\`\`\`
Route (app)           Size     First Load JS
ƒ /r/[slug]           104 kB   192 kB
\`\`\`

192 KiB at 5 Mbps ≈ 300 ms transfer, well under the 1500 ms FCP budget.

## Public-repo audit

- Persona names in both fixtures are obviously fabricated
  (\`Persona One\` … \`Persona Alpha\`).
- No real names, emails, URLs, IPs, tokens, or API keys in the diff.
- Grep confirms: \`AKIA|sk-|ghp_|glpat-|xoxb-|@.*\\.(com|io)|192\\.168|10\\.0\\.|172\\.16\` matches zero lines in the new files.

## Out of scope (left for follow-ups)

- Sankey toggle on the next-action chart (§5.18 #4 default is the
  stacked bar, which ships here; Sankey is a small addition once we
  pick a Recharts/D3 sankey lib).
- Real fetch from the report API endpoint (S2-6 / #31's territory).
  The page reads the fixture via \`fetchReport.ts\` for now; replacing
  the seam with a real fetch is a single-file edit.
- Per-segment drilldowns / live-update / PDF export (all listed as
  v0.1.1+ in §5.18).

## Visual description

Top of page — large \`+1.4 mean Δ will-to-buy\` headline with the 95%
CI, N paired, paired-t / Wilcoxon / McNemar p-values in a 3-col grid,
then the verdict line ("NEW converts better."). Below: a Recharts
ScatterChart of A vs B per backstory with a thin colored connector
segment per backstory pair (red = A higher, green = B higher, gray =
tie). Then two bar histograms side-by-side. Then a stacked bar for
next-action (8 colored segments per variant), then a horizontal stacked
bar for tier-picked. Theme board: 2×2 grid of horizontal bar-charts.
Bottom: persona-card grid (3 cols on desktop) sorted by largest swing
first. In dashboard mode, a dotted-border debug panel at the bottom
shows slug + n_paired; in public mode, that panel is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)