### PR TITLE
feat(infra): postgres schema migrations 0001..0011 (#26)

### DIFF
--- a/infra/migrations/0001_accounts_and_keys.sql
+++ b/infra/migrations/0001_accounts_and_keys.sql
@@ -1,0 +1,69 @@
+-- 0001_accounts_and_keys.sql — accounts + api_keys (spec §4.1, §2 #21).
+--
+-- accounts: one row per signed-up willbuy.dev tenant. owner_email is the
+--   billing/admin contact; verified_domains and other policy state land in
+--   later sprints. Account-level FKs across the rest of the schema cascade
+--   on account delete (account-deletion semantics in spec §2 #33 — the
+--   tombstone + 21-day backup window are out of scope for this migration).
+-- api_keys: per-account pluggable API auth. Spec §2 #21 caps active keys
+--   at ≤ 2 per account; revoked keys are kept for audit but do not count.
+--   The cap is enforced by a trigger because a partial unique index
+--   ("≤ 2 NULL revoked_at rows per account_id") is not expressible in
+--   plain index syntax.
+
+create table if not exists accounts (
+  id          int8        generated always as identity primary key,
+  owner_email text        not null,
+  created_at  timestamptz not null default now()
+);
+
+comment on table accounts is 'willbuy.dev tenant — one per signed-up customer (spec §4.1)';
+comment on column accounts.owner_email is 'Billing/admin contact email; not auth — auth is API key or Supabase session';
+
+create table if not exists api_keys (
+  id            int8        generated always as identity primary key,
+  account_id    int8        not null references accounts (id) on delete cascade,
+  key_hash      text        not null unique,
+  prefix        text        not null,
+  last_used_at  timestamptz,
+  revoked_at    timestamptz,
+  created_at    timestamptz not null default now()
+);
+
+comment on table api_keys is 'Per-account API keys — sk_live_… (spec §2 #21, §5.8). ≤ 2 active per account.';
+comment on column api_keys.key_hash is 'SHA-256 of the raw key; the raw key is shown to the user once and never persisted';
+comment on column api_keys.prefix is 'sk_live_<first8> for UI display so the user can identify the key without unmasking';
+comment on column api_keys.revoked_at is 'NULL = active; non-NULL = revoked at this timestamp';
+
+create index if not exists idx_api_keys_account_active
+  on api_keys (account_id)
+  where revoked_at is null;
+
+/* ≤ 2 active keys per account — enforced by trigger. spec §2 #21. */
+create or replace function enforce_api_keys_active_cap()
+  returns trigger
+  language plpgsql
+as $$
+declare
+  active_count int;
+begin
+  if new.revoked_at is null then
+    select count(*) into active_count
+    from api_keys
+    where account_id = new.account_id
+      and revoked_at is null
+      and (tg_op = 'INSERT' or id <> new.id);
+    if active_count >= 2 then
+      raise exception 'api_keys: account % already has 2 active keys', new.account_id
+        using errcode = 'check_violation';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_api_keys_active_cap on api_keys;
+create trigger trg_api_keys_active_cap
+  before insert or update of account_id, revoked_at on api_keys
+  for each row
+  execute function enforce_api_keys_active_cap();

--- a/infra/migrations/0002_studies.sql
+++ b/infra/migrations/0002_studies.sql
@@ -1,4 +1,4 @@
--- 0002_studies.sql — studies table (spec §4.1, §5.3).
+-- 0002_studies.sql — studies table (spec §4.1, §4.3, §5.3).
 --
 -- studies.kind: single | paired (paired = exactly two URLs, A and B).
 -- studies.status flow per spec §5.3:
@@ -7,6 +7,13 @@
 -- The single-writer aggregator lock (spec §5.11) is taken via
 --   `select 1 from studies where id = $1 and status = 'aggregating' for update skip locked`
 -- — no extra column needed; the row lock + status filter are the lock.
+--
+-- NB5 (PR #46 review): spec §4.3 lists additional columns for studies:
+--   urls[], authorization_mode, icp_id, n, seed, screenshots_enabled, cost_cents.
+-- These are intentionally omitted from this migration — issue #26 scoped the
+-- schema batch to infrastructure tables only. The API migration (issue #xx,
+-- which adds the REST endpoints and worker config) will add these columns via
+-- ALTER TABLE. This is a deliberate scope split, not an oversight.
 
 create table if not exists studies (
   id            int8        generated always as identity primary key,

--- a/infra/migrations/0002_studies.sql
+++ b/infra/migrations/0002_studies.sql
@@ -1,0 +1,28 @@
+-- 0002_studies.sql — studies table (spec §4.1, §5.3).
+--
+-- studies.kind: single | paired (paired = exactly two URLs, A and B).
+-- studies.status flow per spec §5.3:
+--   pending → capturing → visiting → aggregating → ready | failed.
+-- finalized_at is set when status reaches a terminal value (ready/failed).
+-- The single-writer aggregator lock (spec §5.11) is taken via
+--   `select 1 from studies where id = $1 and status = 'aggregating' for update skip locked`
+-- — no extra column needed; the row lock + status filter are the lock.
+
+create table if not exists studies (
+  id            int8        generated always as identity primary key,
+  account_id    int8        not null references accounts (id) on delete cascade,
+  kind          text        not null
+    check (kind in ('single', 'paired')),
+  status        text        not null default 'pending'
+    check (status in ('pending', 'capturing', 'visiting', 'aggregating', 'ready', 'failed')),
+  created_at    timestamptz not null default now(),
+  finalized_at  timestamptz
+);
+
+comment on table studies is 'One row per study — single URL or paired A/B. State machine in spec §5.3.';
+comment on column studies.kind is 'single = one URL, N visits; paired = two URLs (A,B), N paired visits';
+comment on column studies.status is 'State machine: pending → capturing → visiting → aggregating → ready | failed (§5.3)';
+comment on column studies.finalized_at is 'Set when status reaches ready or failed; NULL while in flight';
+
+create index if not exists idx_studies_account_id on studies (account_id);
+create index if not exists idx_studies_status on studies (status);

--- a/infra/migrations/0003_page_captures.sql
+++ b/infra/migrations/0003_page_captures.sql
@@ -1,0 +1,38 @@
+-- 0003_page_captures.sql — page_captures (spec §4.1, §5.13).
+--
+-- One row per (study, side). For single studies side is NULL; for paired
+-- studies side is 'A' or 'B'. The Capture Broker writes this row after it
+-- validates the typed message from the capture container (§5.13) and
+-- persists artifacts to object storage. The unique index covers both
+-- shapes via COALESCE so a single study cannot insert two captures, and
+-- a paired study cannot insert two same-side captures.
+
+create table if not exists page_captures (
+  id                     int8        generated always as identity primary key,
+  study_id               int8        not null references studies (id) on delete cascade,
+  side                   text
+    check (side is null or side in ('A', 'B')),
+  url_hash               text        not null,
+  a11y_storage_key       text        not null,
+  screenshot_storage_key text,
+  host_count             int4        not null,
+  status                 text        not null
+    check (status in ('ok', 'blocked', 'error')),
+  breach_reason          text,
+  captured_at            timestamptz not null default now()
+);
+
+comment on table page_captures is 'Capture Broker artifact row (spec §5.13). One per (study, side).';
+comment on column page_captures.side is 'A or B for paired studies; NULL for single-URL studies';
+comment on column page_captures.url_hash is 'Salted SHA-256 of the captured URL — raw URLs never logged (spec §5.12)';
+comment on column page_captures.a11y_storage_key is 'Object-storage key for the redacted a11y-tree dump (≤ 10 MB; 30-day TTL)';
+comment on column page_captures.screenshot_storage_key is 'Opt-in only (spec §2 #32); 7-day TTL; never sent to LLM providers';
+comment on column page_captures.host_count is 'Distinct egress host count observed during capture; cap is 50 (spec §2 #5)';
+comment on column page_captures.status is 'ok = artifact persisted; blocked = bot wall (§2 #28); error = breach/timeout';
+comment on column page_captures.breach_reason is 'Set when a resource ceiling tripped (spec §2 #6) — wall, RAM, byte cap, host cap';
+
+/* (study_id, side) unique — including the single-URL case where side IS NULL. */
+create unique index if not exists uq_page_captures_study_side
+  on page_captures (study_id, coalesce(side, ''));
+
+create index if not exists idx_page_captures_status on page_captures (status);

--- a/infra/migrations/0004_backstories_and_leases.sql
+++ b/infra/migrations/0004_backstories_and_leases.sql
@@ -1,4 +1,4 @@
--- 0004_backstories_and_leases.sql — backstories + backstory_leases (spec §2 #12, §5.11).
+-- 0004_backstories_and_leases.sql — backstories + backstory_leases (spec §2 #12, §4.3, §5.11).
 --
 -- backstories: deterministic per-study sample (seeded; spec §5.7). idx is the
 --   stable ordinal within the study; (study_id, idx) is unique.
@@ -6,10 +6,14 @@
 --   lease. Spec §2 #12 enforces "one backstory in exactly one in-flight LLM
 --   context at a time" — the lease row is INSERTed on acquisition, UPDATEd on
 --   heartbeat, DELETEd on visit terminal commit OR lease_until expiry.
---   Primary key is (backstory_id) so the lease is naturally exclusive. The
---   lease_until + heartbeat_at + lease_owner mirror spec §4.3 and §5.3.
--- Inline lease_until/lease_owner/heartbeat_at columns on backstories are kept
---   as a denormalized hint for read paths; the canonical lease state lives in
+--   Primary key is (backstory_id) so the lease is naturally exclusive.
+--   holder_visit_id: typed FK to visits(id) per spec §4.3 — tightens
+--     lease-release correctness from string comparison to PK comparison.
+--     The FK constraint itself is added in 0005_visits.sql (after visits
+--     is created) via ALTER TABLE to avoid a forward-reference at CREATE
+--     TABLE time.
+-- Inline lease_until/heartbeat_at columns on backstories are kept as a
+--   denormalized hint for read paths; the canonical lease state lives in
 --   backstory_leases. The dual-write happens inside the visit-worker
 --   transaction so the two cannot diverge across a commit boundary.
 
@@ -19,7 +23,6 @@ create table if not exists backstories (
   idx           int4        not null,
   payload       jsonb       not null,
   lease_until   timestamptz,
-  lease_owner   text,
   heartbeat_at  timestamptz,
   unique (study_id, idx)
 );
@@ -30,16 +33,20 @@ comment on column backstories.payload is 'jsonb structured fields + rendered_tex
 comment on column backstories.lease_until is 'Denormalized hint mirroring backstory_leases.lease_until; NULL when not leased';
 
 create table if not exists backstory_leases (
-  backstory_id  int8        primary key references backstories (id) on delete cascade,
-  study_id      int8        not null references studies (id) on delete cascade,
-  lease_until   timestamptz not null,
-  lease_owner   text        not null,
-  heartbeat_at  timestamptz not null default now()
+  backstory_id    int8        primary key references backstories (id) on delete cascade,
+  study_id        int8        not null references studies (id) on delete cascade,
+  holder_visit_id int8        not null,
+  -- FK to visits(id) added below in 0005_visits.sql after visits table exists.
+  -- Column is int8 NOT NULL here; constraint is deferred to keep migration
+  -- ordering clean.
+  lease_until     timestamptz not null,
+  heartbeat_at    timestamptz not null default now()
 );
 
-comment on table backstory_leases is 'Per-backstory lease — exactly one in-flight LLM context per backstory (spec §2 #12, §5.11)';
+comment on table backstory_leases is 'Per-backstory lease — exactly one in-flight LLM context per backstory (spec §2 #12, §4.3, §5.11)';
+comment on column backstory_leases.holder_visit_id is 'FK to visits.id — the visit holding this lease (spec §4.3); FK constraint added in 0005_visits.sql';
 comment on column backstory_leases.lease_until is '120 s from acquisition; refreshed by heartbeat every 15 s';
-comment on column backstory_leases.lease_owner is 'visit_id (or worker id) holding the lease; logged for contention metrics (§5.12)';
 
 create index if not exists idx_backstory_leases_study on backstory_leases (study_id);
 create index if not exists idx_backstory_leases_lease_until on backstory_leases (lease_until);
+create index if not exists idx_backstory_leases_holder_visit_id on backstory_leases (holder_visit_id);

--- a/infra/migrations/0004_backstories_and_leases.sql
+++ b/infra/migrations/0004_backstories_and_leases.sql
@@ -1,0 +1,45 @@
+-- 0004_backstories_and_leases.sql — backstories + backstory_leases (spec §2 #12, §5.11).
+--
+-- backstories: deterministic per-study sample (seeded; spec §5.7). idx is the
+--   stable ordinal within the study; (study_id, idx) is unique.
+-- backstory_leases: separate row per active lease, distinct from the visit-job
+--   lease. Spec §2 #12 enforces "one backstory in exactly one in-flight LLM
+--   context at a time" — the lease row is INSERTed on acquisition, UPDATEd on
+--   heartbeat, DELETEd on visit terminal commit OR lease_until expiry.
+--   Primary key is (backstory_id) so the lease is naturally exclusive. The
+--   lease_until + heartbeat_at + lease_owner mirror spec §4.3 and §5.3.
+-- Inline lease_until/lease_owner/heartbeat_at columns on backstories are kept
+--   as a denormalized hint for read paths; the canonical lease state lives in
+--   backstory_leases. The dual-write happens inside the visit-worker
+--   transaction so the two cannot diverge across a commit boundary.
+
+create table if not exists backstories (
+  id            int8        generated always as identity primary key,
+  study_id      int8        not null references studies (id) on delete cascade,
+  idx           int4        not null,
+  payload       jsonb       not null,
+  lease_until   timestamptz,
+  lease_owner   text,
+  heartbeat_at  timestamptz,
+  unique (study_id, idx)
+);
+
+comment on table backstories is 'Per-study sampled backstories (spec §2 #12, §5.7). Deterministic by (seed, study_id, idx).';
+comment on column backstories.idx is 'Stable ordinal within the study, 0..n-1; (study_id, idx) is unique';
+comment on column backstories.payload is 'jsonb structured fields + rendered_text; shape owned by zod schema in packages/shared';
+comment on column backstories.lease_until is 'Denormalized hint mirroring backstory_leases.lease_until; NULL when not leased';
+
+create table if not exists backstory_leases (
+  backstory_id  int8        primary key references backstories (id) on delete cascade,
+  study_id      int8        not null references studies (id) on delete cascade,
+  lease_until   timestamptz not null,
+  lease_owner   text        not null,
+  heartbeat_at  timestamptz not null default now()
+);
+
+comment on table backstory_leases is 'Per-backstory lease — exactly one in-flight LLM context per backstory (spec §2 #12, §5.11)';
+comment on column backstory_leases.lease_until is '120 s from acquisition; refreshed by heartbeat every 15 s';
+comment on column backstory_leases.lease_owner is 'visit_id (or worker id) holding the lease; logged for contention metrics (§5.12)';
+
+create index if not exists idx_backstory_leases_study on backstory_leases (study_id);
+create index if not exists idx_backstory_leases_lease_until on backstory_leases (lease_until);

--- a/infra/migrations/0005_visits.sql
+++ b/infra/migrations/0005_visits.sql
@@ -1,43 +1,85 @@
--- 0005_visits.sql — visits (spec §4.1, §5.1, §5.3, §2 #15).
+-- 0005_visits.sql — visits (spec §4.1, §4.3, §5.1, §5.3, §2 #15).
 --
--- One row per (backstory, side). Status flow per spec §5.3:
---   started → ok | failed | indeterminate.
+-- One row per (study_id, backstory_id, variant_idx) — spec §4.3 canonical shape.
+-- Status flow per spec §5.3: started → ok | failed | indeterminate.
+-- variant_idx: 0 = variant A, 1 = variant B; for single-URL studies always 0.
+--   (The `side` text column mapped to 'A'/'B'; variant_idx carries the same
+--   semantics as a typed int, and the UNIQUE aligns with spec §4.3.)
+-- capture_id FK links each visit to the page_captures row it scored; this is
+--   the join §5.18 persona cards depend on.
+-- provider/model/cost_cents: audit trail for partial_finalize (spec §5.4).
+-- terminal_reason: set on failed/indeterminate per spec §5.3
+--   {schema, transient, cap_exceeded, provider_error, lease_lost, indeterminate}.
+-- latency_ms: round-trip from provider call start to first token (observability).
 -- parsed jsonb holds the validated visitor output — see spec §2 #15 +
--- amendment A1 for the exact zod-validated shape (next_action enum is
--- validated at the API/worker boundary, not in the DB; columns stay
--- text-jsonb-flexible so amendment churn lands in zod, not in migrations).
+--   amendment A1 for the exact zod-validated shape (next_action enum is
+--   validated at the API/worker boundary, not in the DB; columns stay
+--   text-jsonb-flexible so amendment churn lands in zod, not in migrations).
 -- raw_storage_key points to the un-parsed provider response held for
--- 30-day forensic retention.
+--   30-day forensic retention.
 -- repair_generation: 0..2 per spec §2 #14 — each schema-repair retry
--- increments and produces a NEW logical_request_key.
+--   increments and produces a NEW logical_request_key.
 -- transport_attempts: monotonic counter for the same logical request
--- (spec §5.15 — observability only).
+--   (spec §5.15 — observability only).
 
 create table if not exists visits (
   id                  int8        generated always as identity primary key,
+  study_id            int8        not null references studies (id) on delete cascade,
   backstory_id        int8        not null references backstories (id) on delete cascade,
-  side                text        not null
-    check (side in ('A', 'B')),
+  variant_idx         int4        not null
+    check (variant_idx in (0, 1)),
+  capture_id          int8        references page_captures (id) on delete set null,
+  provider            text,
+  model               text,
   status              text        not null
     check (status in ('started', 'ok', 'failed', 'indeterminate')),
   parsed              jsonb,
   raw_storage_key     text,
+  terminal_reason     text,
   repair_generation   int4        not null default 0,
   transport_attempts  int4        not null default 0,
+  cost_cents          int4,
+  latency_ms          int4,
   score               numeric,
   started_at          timestamptz not null default now(),
   ended_at            timestamptz,
-  unique (backstory_id, side)
+  unique (study_id, backstory_id, variant_idx)
 );
 
-comment on table visits is 'One row per (backstory, side). State machine in spec §5.3.';
-comment on column visits.side is 'A or B; for single-URL studies all visits use side A';
+comment on table visits is 'One row per (study_id, backstory_id, variant_idx). State machine in spec §5.3.';
+comment on column visits.study_id is 'FK to studies; denormalised from backstory for efficient per-study queries';
+comment on column visits.backstory_id is 'FK to backstories; the paired A/B join key is (study_id, backstory_id)';
+comment on column visits.variant_idx is '0 = variant A, 1 = variant B; single-URL studies always 0 (spec §4.3)';
+comment on column visits.capture_id is 'FK to page_captures; NULL when capture is still pending at visit start (spec §5.18)';
+comment on column visits.provider is 'LLM provider name (e.g. anthropic) — audit trail for partial_finalize (spec §5.4)';
+comment on column visits.model is 'LLM model id (e.g. claude-haiku-4-5) — audit trail for partial_finalize (spec §5.4)';
 comment on column visits.status is 'started → ok | failed | indeterminate (spec §5.3)';
 comment on column visits.parsed is 'Validated visitor JSON output (spec §2 #15 + amendment A1). Schema enforced at boundary, not in DB.';
 comment on column visits.raw_storage_key is 'Object-storage key for the raw provider response (30-day TTL, §2 #33)';
+comment on column visits.terminal_reason is 'Set on failed/indeterminate: schema|transient|cap_exceeded|provider_error|lease_lost|indeterminate (§5.3)';
 comment on column visits.repair_generation is '0..2; each schema-repair retry increments and gets a new logical_request_key (§2 #14)';
 comment on column visits.transport_attempts is 'Observability counter for transport retries under the same logical_request_key (§5.15)';
+comment on column visits.cost_cents is 'Actual cost in cents for this visit; NULL until committed; capped at 5¢ (spec §5.6)';
+comment on column visits.latency_ms is 'Provider round-trip latency in ms (observability)';
 comment on column visits.score is 'Per-visit conversion-weighted score from amendment A1 scoreVisit(parsed); NULL until visit reaches ok';
 
+create index if not exists idx_visits_study_id on visits (study_id);
 create index if not exists idx_visits_backstory_id on visits (backstory_id);
 create index if not exists idx_visits_status on visits (status);
+create index if not exists idx_visits_capture_id on visits (capture_id);
+
+-- B4: add FK from backstory_leases.holder_visit_id → visits.id now that
+-- visits exists. The column was added without a FK in 0004 to avoid a
+-- forward-reference; the constraint is safe to add here idempotently.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conname = 'backstory_leases_holder_visit_id_fkey'
+       and conrelid = 'backstory_leases'::regclass
+  ) then
+    alter table backstory_leases
+      add constraint backstory_leases_holder_visit_id_fkey
+        foreign key (holder_visit_id) references visits (id) on delete cascade;
+  end if;
+end $$;

--- a/infra/migrations/0005_visits.sql
+++ b/infra/migrations/0005_visits.sql
@@ -1,0 +1,43 @@
+-- 0005_visits.sql — visits (spec §4.1, §5.1, §5.3, §2 #15).
+--
+-- One row per (backstory, side). Status flow per spec §5.3:
+--   started → ok | failed | indeterminate.
+-- parsed jsonb holds the validated visitor output — see spec §2 #15 +
+-- amendment A1 for the exact zod-validated shape (next_action enum is
+-- validated at the API/worker boundary, not in the DB; columns stay
+-- text-jsonb-flexible so amendment churn lands in zod, not in migrations).
+-- raw_storage_key points to the un-parsed provider response held for
+-- 30-day forensic retention.
+-- repair_generation: 0..2 per spec §2 #14 — each schema-repair retry
+-- increments and produces a NEW logical_request_key.
+-- transport_attempts: monotonic counter for the same logical request
+-- (spec §5.15 — observability only).
+
+create table if not exists visits (
+  id                  int8        generated always as identity primary key,
+  backstory_id        int8        not null references backstories (id) on delete cascade,
+  side                text        not null
+    check (side in ('A', 'B')),
+  status              text        not null
+    check (status in ('started', 'ok', 'failed', 'indeterminate')),
+  parsed              jsonb,
+  raw_storage_key     text,
+  repair_generation   int4        not null default 0,
+  transport_attempts  int4        not null default 0,
+  score               numeric,
+  started_at          timestamptz not null default now(),
+  ended_at            timestamptz,
+  unique (backstory_id, side)
+);
+
+comment on table visits is 'One row per (backstory, side). State machine in spec §5.3.';
+comment on column visits.side is 'A or B; for single-URL studies all visits use side A';
+comment on column visits.status is 'started → ok | failed | indeterminate (spec §5.3)';
+comment on column visits.parsed is 'Validated visitor JSON output (spec §2 #15 + amendment A1). Schema enforced at boundary, not in DB.';
+comment on column visits.raw_storage_key is 'Object-storage key for the raw provider response (30-day TTL, §2 #33)';
+comment on column visits.repair_generation is '0..2; each schema-repair retry increments and gets a new logical_request_key (§2 #14)';
+comment on column visits.transport_attempts is 'Observability counter for transport retries under the same logical_request_key (§5.15)';
+comment on column visits.score is 'Per-visit conversion-weighted score from amendment A1 scoreVisit(parsed); NULL until visit reaches ok';
+
+create index if not exists idx_visits_backstory_id on visits (backstory_id);
+create index if not exists idx_visits_status on visits (status);

--- a/infra/migrations/0006_provider_attempts.sql
+++ b/infra/migrations/0006_provider_attempts.sql
@@ -1,0 +1,44 @@
+-- 0006_provider_attempts.sql — unified provider-attempt ledger (spec §2 #16, §5.15).
+--
+-- Every outbound provider call across kinds {visit, embedding, cluster_label,
+-- probe} writes a row here. logical_request_key is UNIQUE — it is
+-- sha256(visit_id || provider || model || request_kind || repair_generation)
+-- per spec §5.15 and is reused as the provider Idempotency-Key across
+-- transport retries. transport_attempts counts on-wire retries that share
+-- this logical key. status flow: started → ended | indeterminate
+-- → indeterminate_refunded (spec §5.3, §5.4 reconciliation).
+--
+-- Embeddings are local in-process (spec §17) but still recorded here for
+-- observability (count, duration, status); they never debit the spend cap.
+
+create table if not exists provider_attempts (
+  id                   int8        generated always as identity primary key,
+  account_id           int8        not null references accounts (id) on delete cascade,
+  study_id             int8        not null references studies (id) on delete cascade,
+  kind                 text        not null
+    check (kind in ('visit', 'embedding', 'cluster_label', 'probe')),
+  logical_request_key  text        not null unique,
+  provider             text        not null,
+  model                text        not null,
+  transport_attempts   int4        not null default 0,
+  status               text        not null
+    check (status in ('started', 'ended', 'indeterminate', 'indeterminate_refunded')),
+  cost_cents           int4        not null default 0,
+  started_at           timestamptz not null default now(),
+  ended_at             timestamptz,
+  raw_output_key       text,
+  error_class          text
+);
+
+comment on table provider_attempts is 'Unified provider-call ledger across all kinds (spec §2 #16, §5.15).';
+comment on column provider_attempts.kind is 'visit | embedding | cluster_label | probe — all kinds participate in cap + reconciliation';
+comment on column provider_attempts.logical_request_key is 'sha256(visit_id||provider||model||kind||repair_generation); reused as Idempotency-Key (§5.15)';
+comment on column provider_attempts.transport_attempts is 'On-wire retries sharing the same logical_request_key; observability only';
+comment on column provider_attempts.status is 'started → ended | indeterminate → indeterminate_refunded (resolved by reconciliation, §5.4)';
+comment on column provider_attempts.cost_cents is 'Actual cost when ended; pessimistic ceiling (5¢) while indeterminate (§5.5)';
+comment on column provider_attempts.raw_output_key is 'Object-storage key for the raw provider response (NULL for failed/indeterminate)';
+comment on column provider_attempts.error_class is 'Coarse classification when not ended-ok: timeout, connection_reset, schema, 5xx, etc.';
+
+create index if not exists idx_provider_attempts_study_kind_status
+  on provider_attempts (study_id, kind, status);
+create index if not exists idx_provider_attempts_account_id on provider_attempts (account_id);

--- a/infra/migrations/0007_credit_ledger.sql
+++ b/infra/migrations/0007_credit_ledger.sql
@@ -1,4 +1,4 @@
--- 0007_credit_ledger.sql — credit_ledger + account_balance view (spec §5.4).
+-- 0007_credit_ledger.sql — credit_ledger + account_balance view (spec §5.4, §4.3).
 --
 -- Append-only signed-cents ledger. kind ∈ {top_up, reserve, commit, refund,
 -- partial_finalize}. idempotency_key is UNIQUE — Stripe webhook event id,
@@ -7,27 +7,35 @@
 -- negative; commit zero-net inside a partial_finalize; refund positive;
 -- partial_finalize captures the per-study terminal commit + refund residue).
 --
+-- provider_attempt_id FK: spec §4.3/§5.4 — commit(…, provider_attempt_id, …)
+-- idempotency is enforced both by idempotency_key UNIQUE and by this FK which
+-- guarantees that every commit/refund row references a real provider_attempts
+-- row. NULL for top_up and reserve rows (no provider attempt yet).
+--
 -- account_balance(view): sum of cents per account for fast balance lookups.
 -- Views over append-only ledgers are race-free by construction.
 
 create table if not exists credit_ledger (
-  id               int8        generated always as identity primary key,
-  account_id       int8        not null references accounts (id) on delete cascade,
-  kind             text        not null
+  id                   int8        generated always as identity primary key,
+  account_id           int8        not null references accounts (id) on delete cascade,
+  kind                 text        not null
     check (kind in ('top_up', 'reserve', 'commit', 'refund', 'partial_finalize')),
-  study_id         int8        references studies (id) on delete set null,
-  cents            int4        not null,
-  idempotency_key  text        not null unique,
-  created_at       timestamptz not null default now()
+  study_id             int8        references studies (id) on delete set null,
+  provider_attempt_id  int8        references provider_attempts (id) on delete set null,
+  cents                int4        not null,
+  idempotency_key      text        not null unique,
+  created_at           timestamptz not null default now()
 );
 
 comment on table credit_ledger is 'Append-only credit ledger — top_up/reserve/commit/refund/partial_finalize (spec §5.4)';
 comment on column credit_ledger.cents is 'Signed cents — top_up > 0; reserve < 0; refund > 0; commit/partial_finalize per §5.4';
 comment on column credit_ledger.idempotency_key is 'UNIQUE: Stripe event id (top_up), study_id-scoped (reserve), provider_attempt_id (commit/refund)';
 comment on column credit_ledger.study_id is 'NULL for top_ups; set for any study-scoped op so reconciliation joins are cheap';
+comment on column credit_ledger.provider_attempt_id is 'FK to provider_attempts; NULL for top_up/reserve; required for commit/refund idempotency (spec §4.3/§5.4)';
 
 create index if not exists idx_credit_ledger_account_id on credit_ledger (account_id);
 create index if not exists idx_credit_ledger_study_id on credit_ledger (study_id);
+create index if not exists idx_credit_ledger_provider_attempt_id on credit_ledger (provider_attempt_id);
 
 create or replace view account_balance as
   select

--- a/infra/migrations/0007_credit_ledger.sql
+++ b/infra/migrations/0007_credit_ledger.sql
@@ -12,6 +12,10 @@
 -- guarantees that every commit/refund row references a real provider_attempts
 -- row. NULL for top_up and reserve rows (no provider attempt yet).
 --
+-- provider_attempt_id NOT NULL CHECK: spec §5.4 — a commit or refund row with
+-- NULL provider_attempt_id is unauditable; the CHECK enforces the invariant.
+-- kind ∈ {top_up, reserve, partial_finalize} may have NULL provider_attempt_id.
+--
 -- account_balance(view): sum of cents per account for fast balance lookups.
 -- Views over append-only ledgers are race-free by construction.
 
@@ -24,7 +28,8 @@ create table if not exists credit_ledger (
   provider_attempt_id  int8        references provider_attempts (id) on delete set null,
   cents                int4        not null,
   idempotency_key      text        not null unique,
-  created_at           timestamptz not null default now()
+  created_at           timestamptz not null default now(),
+  check (kind not in ('commit', 'refund') or provider_attempt_id is not null)
 );
 
 comment on table credit_ledger is 'Append-only credit ledger — top_up/reserve/commit/refund/partial_finalize (spec §5.4)';

--- a/infra/migrations/0007_credit_ledger.sql
+++ b/infra/migrations/0007_credit_ledger.sql
@@ -1,0 +1,39 @@
+-- 0007_credit_ledger.sql — credit_ledger + account_balance view (spec §5.4).
+--
+-- Append-only signed-cents ledger. kind ∈ {top_up, reserve, commit, refund,
+-- partial_finalize}. idempotency_key is UNIQUE — Stripe webhook event id,
+-- study_id-scoped reserve key, provider_attempt_id-scoped commit key per
+-- spec §5.4. Caller writes the sign convention (top_up positive; reserve
+-- negative; commit zero-net inside a partial_finalize; refund positive;
+-- partial_finalize captures the per-study terminal commit + refund residue).
+--
+-- account_balance(view): sum of cents per account for fast balance lookups.
+-- Views over append-only ledgers are race-free by construction.
+
+create table if not exists credit_ledger (
+  id               int8        generated always as identity primary key,
+  account_id       int8        not null references accounts (id) on delete cascade,
+  kind             text        not null
+    check (kind in ('top_up', 'reserve', 'commit', 'refund', 'partial_finalize')),
+  study_id         int8        references studies (id) on delete set null,
+  cents            int4        not null,
+  idempotency_key  text        not null unique,
+  created_at       timestamptz not null default now()
+);
+
+comment on table credit_ledger is 'Append-only credit ledger — top_up/reserve/commit/refund/partial_finalize (spec §5.4)';
+comment on column credit_ledger.cents is 'Signed cents — top_up > 0; reserve < 0; refund > 0; commit/partial_finalize per §5.4';
+comment on column credit_ledger.idempotency_key is 'UNIQUE: Stripe event id (top_up), study_id-scoped (reserve), provider_attempt_id (commit/refund)';
+comment on column credit_ledger.study_id is 'NULL for top_ups; set for any study-scoped op so reconciliation joins are cheap';
+
+create index if not exists idx_credit_ledger_account_id on credit_ledger (account_id);
+create index if not exists idx_credit_ledger_study_id on credit_ledger (study_id);
+
+create or replace view account_balance as
+  select
+    account_id,
+    coalesce(sum(cents), 0)::int8 as balance_cents
+  from credit_ledger
+  group by account_id;
+
+comment on view account_balance is 'Per-account balance: sum of credit_ledger.cents (spec §5.4)';

--- a/infra/migrations/0008_llm_spend_daily.sql
+++ b/infra/migrations/0008_llm_spend_daily.sql
@@ -1,0 +1,40 @@
+-- 0008_llm_spend_daily.sql — daily spend cap accounting (spec §5.5) + cap_warnings.
+--
+-- llm_spend_daily: row-per-(account, date, kind). The atomic-INSERT-with-WHERE
+-- pattern in spec §5.5 is taken on EVERY provider-call kind before the
+-- outbound call:
+--   insert into llm_spend_daily (account_id, date, kind, cents)
+--     values ($acct, current_date, $kind, $est)
+--     on conflict (account_id, date, kind)
+--     do update set cents = llm_spend_daily.cents + excluded.cents
+--     where llm_spend_daily.cents + excluded.cents <= $cap
+--     returning cents;
+-- No row returned → cap exceeded → caller transitions to failed:cap_exceeded
+-- and posts a refund. PK is (account_id, date, kind) so the upsert is race-free.
+--
+-- cap_warnings: side table gating the 50%-of-cap email so exactly one fires
+-- per account per day per kind. PK (account_id, date, kind) per spec §5.5.
+
+create table if not exists llm_spend_daily (
+  account_id  int8        not null references accounts (id) on delete cascade,
+  date        date        not null,
+  kind        text        not null
+    check (kind in ('visit', 'embedding', 'cluster_label', 'probe')),
+  cents       int4        not null default 0,
+  primary key (account_id, date, kind)
+);
+
+comment on table llm_spend_daily is 'Daily spend bucket per (account, date, kind) — race-free cap enforcement (spec §5.5)';
+comment on column llm_spend_daily.kind is 'visit | embedding | cluster_label | probe; embeddings cost 0¢ but still write rows';
+comment on column llm_spend_daily.cents is 'Sum of provider-call cost_cents for this (account, date, kind)';
+
+create table if not exists cap_warnings (
+  account_id  int8        not null references accounts (id) on delete cascade,
+  date        date        not null,
+  kind        text        not null,
+  sent_at     timestamptz not null default now(),
+  primary key (account_id, date, kind)
+);
+
+comment on table cap_warnings is '50%-of-cap warning email gate — at most one per (account, date, kind) (spec §5.5)';
+comment on column cap_warnings.kind is 'Free-form gate kind (e.g. cap_50_warning); not constrained to the spend kinds';

--- a/infra/migrations/0009_reports.sql
+++ b/infra/migrations/0009_reports.sql
@@ -1,4 +1,4 @@
--- 0009_reports.sql — reports (spec §4.1, §5.18, §5.11).
+-- 0009_reports.sql — reports (spec §4.1, §4.3, §5.18, §5.11).
 --
 -- One report per study. UNIQUE(study_id) is the integrity constraint that
 -- guarantees "exactly one report per study" — spec §5.11 explicitly notes
@@ -7,16 +7,34 @@
 -- public/expires_at gate visibility on /r/<slug>; raw token never stored
 -- (only its hash). conv_score and paired_delta_json are the headline
 -- numbers per spec §5.7 + §5.18.
+--
+-- clusters_json: pre-computed HDBSCAN cluster blobs written by the aggregator
+--   for §5.18 theme board; avoids re-computation on every /r/<slug> load.
+-- scores_json: per-variant and per-backstory conversion-weighted scores,
+--   pre-computed for §5.18 histogram + Sankey.
+-- paired_tests_disagreement: boolean flag written by the aggregator when
+--   paired-t and Wilcoxon disagree in direction (spec §2 #19); the §5.18
+--   disagreement banner reads this column at report-render time. NULL for
+--   single-URL studies (no paired statistics).
+-- default_share_token_id: FK to share_tokens (table added in API migration
+--   for issue #xx — share_tokens table is not in this migration batch).
+--   Column is present here as int8 nullable; FK constraint will be added by
+--   the API migration once share_tokens exists. NULL until a share token is
+--   created for the report.
 
 create table if not exists reports (
-  id                 int8        generated always as identity primary key,
-  study_id           int8        not null unique references studies (id) on delete cascade,
-  share_token_hash   text        not null unique,
-  public             boolean     not null default false,
-  expires_at         timestamptz,
-  conv_score         numeric     not null,
-  paired_delta_json  jsonb       not null,
-  ready_at           timestamptz not null default now()
+  id                          int8        generated always as identity primary key,
+  study_id                    int8        not null unique references studies (id) on delete cascade,
+  share_token_hash            text        not null unique,
+  public                      boolean     not null default false,
+  expires_at                  timestamptz,
+  conv_score                  numeric     not null,
+  paired_delta_json           jsonb       not null,
+  clusters_json               jsonb,
+  scores_json                 jsonb,
+  paired_tests_disagreement   boolean,
+  default_share_token_id      int8,
+  ready_at                    timestamptz not null default now()
 );
 
 comment on table reports is 'One report per study (spec §4.1, §5.11). UNIQUE(study_id) is the correctness guarantee.';
@@ -25,3 +43,7 @@ comment on column reports.public is 'Owner opt-in to public listing; still noind
 comment on column reports.expires_at is 'Default 90 days; revoke = set in past + cache purge';
 comment on column reports.conv_score is 'Conversion-weighted score (spec §5.7, amendment A1)';
 comment on column reports.paired_delta_json is 'Per-backstory paired-δ + paired-t + Wilcoxon + McNemar payload (spec §5.7)';
+comment on column reports.clusters_json is 'Pre-computed HDBSCAN cluster blobs for §5.18 theme board; NULL until aggregator writes report';
+comment on column reports.scores_json is 'Pre-computed per-variant and per-backstory scores for §5.18 histogram + Sankey; NULL until aggregated';
+comment on column reports.paired_tests_disagreement is 'true when paired-t and Wilcoxon disagree in direction (spec §2 #19 banner); NULL for single-URL studies';
+comment on column reports.default_share_token_id is 'FK to share_tokens.id (share_tokens added via API migration for issue #xx); NULL until first share token created';

--- a/infra/migrations/0009_reports.sql
+++ b/infra/migrations/0009_reports.sql
@@ -1,0 +1,27 @@
+-- 0009_reports.sql — reports (spec §4.1, §5.18, §5.11).
+--
+-- One report per study. UNIQUE(study_id) is the integrity constraint that
+-- guarantees "exactly one report per study" — spec §5.11 explicitly notes
+-- the aggregator's single-writer lock is an optimization, not the
+-- correctness guarantee. UNIQUE(share_token_hash) backs token lookup.
+-- public/expires_at gate visibility on /r/<slug>; raw token never stored
+-- (only its hash). conv_score and paired_delta_json are the headline
+-- numbers per spec §5.7 + §5.18.
+
+create table if not exists reports (
+  id                 int8        generated always as identity primary key,
+  study_id           int8        not null unique references studies (id) on delete cascade,
+  share_token_hash   text        not null unique,
+  public             boolean     not null default false,
+  expires_at         timestamptz,
+  conv_score         numeric     not null,
+  paired_delta_json  jsonb       not null,
+  ready_at           timestamptz not null default now()
+);
+
+comment on table reports is 'One report per study (spec §4.1, §5.11). UNIQUE(study_id) is the correctness guarantee.';
+comment on column reports.share_token_hash is 'SHA-256 of the share token; raw token only on URL query string at first access (spec §2 #20)';
+comment on column reports.public is 'Owner opt-in to public listing; still noindex (spec §2 #20)';
+comment on column reports.expires_at is 'Default 90 days; revoke = set in past + cache purge';
+comment on column reports.conv_score is 'Conversion-weighted score (spec §5.7, amendment A1)';
+comment on column reports.paired_delta_json is 'Per-backstory paired-δ + paired-t + Wilcoxon + McNemar payload (spec §5.7)';

--- a/infra/migrations/0010_late_arrivals.sql
+++ b/infra/migrations/0010_late_arrivals.sql
@@ -1,0 +1,19 @@
+-- 0010_late_arrivals.sql — late_arrivals (spec §5.11).
+--
+-- Late visits that complete after a study has transitioned to ready/failed
+-- write here instead of mutating the report. Used for forensic audit and
+-- spend reconciliation; never folded back into the report. Visit lease
+-- expiry past the 3-min aggregate timeout (§5.11) is the typical source.
+
+create table if not exists late_arrivals (
+  id           int8        generated always as identity primary key,
+  study_id     int8        not null references studies (id) on delete cascade,
+  visit_id     int8        not null references visits (id) on delete cascade,
+  arrived_at   timestamptz not null default now(),
+  payload_key  text
+);
+
+comment on table late_arrivals is 'Visits that completed after study terminal — never fold back into the report (spec §5.11)';
+comment on column late_arrivals.payload_key is 'Object-storage key for the late visit payload; same retention as raw_storage_key (§2 #33)';
+
+create index if not exists idx_late_arrivals_study_id on late_arrivals (study_id);

--- a/infra/migrations/0011_global_inflight.sql
+++ b/infra/migrations/0011_global_inflight.sql
@@ -1,0 +1,43 @@
+-- 0011_global_inflight.sql — global backpressure tables (spec §5.14).
+--
+-- global_inflight: per-kind in-flight counter. The API server bumps this
+-- counter under SKIP LOCKED + conditional update (spec §5.14) before
+-- admitting a study/visit/probe; bumps it back down on terminal. Caps per
+-- spec §2 #30: visit ≤ 100, capture ≤ 30, probe ≤ 20.
+-- provider_circuit_state: one row per provider; state ∈ {closed, open,
+-- half_open}. 5 consecutive 5xx in 60 s → open for 60 s; half-open probes
+-- a single request; closed on success (spec §5.14).
+-- rate_tokens: per-provider token-bucket bounded at 0.8× the provider's
+-- published rate (spec §5.14). Refilled by a cron-like worker; drained
+-- conditionally by every provider call.
+
+create table if not exists global_inflight (
+  kind        text        primary key,
+  count       int4        not null default 0,
+  updated_at  timestamptz not null default now()
+);
+
+comment on table global_inflight is 'Per-kind in-flight counter for global concurrency caps (spec §5.14, §2 #30)';
+comment on column global_inflight.kind is 'visit | capture | probe — caller-defined; caps live in app config, not DB';
+
+create table if not exists provider_circuit_state (
+  provider     text        primary key,
+  state        text        not null default 'closed'
+    check (state in ('closed', 'open', 'half_open')),
+  opened_at    timestamptz,
+  last_5xx_at  timestamptz
+);
+
+comment on table provider_circuit_state is 'Per-provider circuit breaker state (spec §5.14)';
+comment on column provider_circuit_state.state is 'closed = healthy; open = fail fast; half_open = single probe in flight';
+comment on column provider_circuit_state.opened_at is 'Set when transitioning to open; cleared on closed';
+comment on column provider_circuit_state.last_5xx_at is 'Most recent 5xx; used by the 5-in-60-s rule';
+
+create table if not exists rate_tokens (
+  provider     text        primary key,
+  tokens       int4        not null default 0,
+  refilled_at  timestamptz not null default now()
+);
+
+comment on table rate_tokens is 'Per-provider token bucket bounded at 0.8× published rate (spec §5.14)';
+comment on column rate_tokens.tokens is 'Current available tokens; drained on every provider call, refilled periodically';

--- a/infra/migrations/0011_global_inflight.sql
+++ b/infra/migrations/0011_global_inflight.sql
@@ -29,6 +29,7 @@ create table if not exists provider_circuit_state (
 );
 
 comment on table provider_circuit_state is 'Per-provider circuit breaker state (spec §5.14)';
+comment on column provider_circuit_state.provider is 'Provider identifier (e.g. anthropic); PK — one row per provider (spec §5.14)';
 comment on column provider_circuit_state.state is 'closed = healthy; open = fail fast; half_open = single probe in flight';
 comment on column provider_circuit_state.opened_at is 'Set when transitioning to open; cleared on closed';
 comment on column provider_circuit_state.last_5xx_at is 'Most recent 5xx; used by the 5-in-60-s rule';
@@ -40,4 +41,5 @@ create table if not exists rate_tokens (
 );
 
 comment on table rate_tokens is 'Per-provider token bucket bounded at 0.8× published rate (spec §5.14)';
+comment on column rate_tokens.provider is 'Provider identifier (e.g. anthropic); PK — one token bucket per provider (spec §5.14)';
 comment on column rate_tokens.tokens is 'Current available tokens; drained on every provider call, refilled periodically';

--- a/tests/migrations.schema.test.ts
+++ b/tests/migrations.schema.test.ts
@@ -236,11 +236,10 @@ describeIfDocker('migrations schema (issue #26)', () => {
 
   describe('enum constraint enforcement (forbidden value rejected)', () => {
     it('studies.kind rejects unknown value', () => {
-      // Use a fresh account+study insert path; rely on enum check.
+      psql(pg.container, `insert into accounts (owner_email) values ('enum1@example.com');`);
       expectSqlError(
         pg.container,
-        `insert into accounts (owner_email) values ('enum1@example.com') returning id \\gset
-         insert into studies (account_id, kind, status) select id, 'triple', 'pending' from accounts where owner_email='enum1@example.com';`,
+        `insert into studies (account_id, kind, status) select id, 'triple', 'pending' from accounts where owner_email='enum1@example.com';`,
         /invalid input value|violates check constraint|invalid kind/i,
         'studies.kind enum',
       );

--- a/tests/migrations.schema.test.ts
+++ b/tests/migrations.schema.test.ts
@@ -977,4 +977,71 @@ describeIfDocker('migrations schema (issue #26)', () => {
       expect(out).toBe('1');
     });
   });
+
+  describe('PR-46 B2 (partial) — credit_ledger CHECK: commit/refund require provider_attempt_id NOT NULL (spec §5.4)', () => {
+    it('inserting kind=commit with provider_attempt_id=NULL is rejected (CHECK violation)', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('b2check-commit@example.com');`);
+      expectSqlError(
+        pg.container,
+        `insert into credit_ledger (account_id, provider_attempt_id, kind, cents, idempotency_key)
+           select id, null, 'commit', -5, 'b2check-commit-1' from accounts where owner_email='b2check-commit@example.com';`,
+        /violates check constraint/i,
+        'commit with NULL provider_attempt_id must be rejected',
+      );
+    });
+
+    it('inserting kind=refund with provider_attempt_id=NULL is rejected (CHECK violation)', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('b2check-refund@example.com');`);
+      expectSqlError(
+        pg.container,
+        `insert into credit_ledger (account_id, provider_attempt_id, kind, cents, idempotency_key)
+           select id, null, 'refund', 50, 'b2check-refund-1' from accounts where owner_email='b2check-refund@example.com';`,
+        /violates check constraint/i,
+        'refund with NULL provider_attempt_id must be rejected',
+      );
+    });
+
+    it('inserting kind=reserve with provider_attempt_id=NULL succeeds (reserve precedes any attempt)', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('b2check-reserve@example.com');`);
+      const r = psql(
+        pg.container,
+        `insert into credit_ledger (account_id, provider_attempt_id, kind, cents, idempotency_key)
+           select id, null, 'reserve', -100, 'b2check-reserve-1' from accounts where owner_email='b2check-reserve@example.com';`,
+      );
+      expect(r.code, `reserve with NULL provider_attempt_id should be accepted: ${r.stderr}`).toBe(0);
+    });
+
+    it('inserting kind=top_up with provider_attempt_id=NULL succeeds (Stripe webhook — no provider attempt)', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('b2check-topup@example.com');`);
+      const r = psql(
+        pg.container,
+        `insert into credit_ledger (account_id, provider_attempt_id, kind, cents, idempotency_key)
+           select id, null, 'top_up', 1000, 'b2check-topup-1' from accounts where owner_email='b2check-topup@example.com';`,
+      );
+      expect(r.code, `top_up with NULL provider_attempt_id should be accepted: ${r.stderr}`).toBe(0);
+    });
+
+    it('inserting kind=commit with a valid provider_attempt_id succeeds', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('b2check-ok@example.com');`);
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'single', 'pending' from accounts where owner_email='b2check-ok@example.com';`,
+      );
+      psql(
+        pg.container,
+        `insert into provider_attempts (account_id, study_id, kind, logical_request_key, provider, model, transport_attempts, status, cost_cents, started_at)
+           select a.id, s.id, 'visit', 'b2check-ok-lk', 'anthropic', 'claude-haiku-4-5', 0, 'ended', 50, now()
+           from accounts a join studies s on s.account_id = a.id where a.owner_email='b2check-ok@example.com';`,
+      );
+      const r = psql(
+        pg.container,
+        `insert into credit_ledger (account_id, provider_attempt_id, kind, cents, idempotency_key)
+           select a.id, pa.id, 'commit', -50, 'b2check-ok-commit-1'
+           from accounts a
+           join provider_attempts pa on pa.account_id = a.id
+           where a.owner_email='b2check-ok@example.com';`,
+      );
+      expect(r.code, `commit with valid provider_attempt_id should be accepted: ${r.stderr}`).toBe(0);
+    });
+  });
 });

--- a/tests/migrations.schema.test.ts
+++ b/tests/migrations.schema.test.ts
@@ -1,0 +1,685 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+/*
+ * Schema migration assertions for issue #26.
+ *
+ * Spec refs: §4.1 (canonical table list), §5.5 (atomic spend reservation),
+ * §5.11 (single-writer finalize + late_arrivals), §5.13 (page_captures shape),
+ * §5.14 (global_inflight + provider_circuit_state + rate_tokens),
+ * §5.15 (provider_attempts logical_request_key), §2 #16 (unified provider-attempt ledger).
+ *
+ * Each test exercises one acceptance criterion from issue #26 against an
+ * ephemeral postgres container provisioned via the existing migrations
+ * runner from PR #38. Tests are skipped when docker is unavailable so the
+ * suite still passes on hosts without docker.
+ */
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const migrateScript = resolve(repoRoot, 'scripts/migrate.sh');
+const realMigrationsDir = resolve(repoRoot, 'infra/migrations');
+
+const dockerCheck = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+  encoding: 'utf8',
+});
+const dockerAvailable = dockerCheck.status === 0;
+const describeIfDocker = dockerAvailable ? describe : describe.skip;
+
+const PG_IMAGE = 'postgres:16-alpine';
+const PG_PASSWORD = 'willbuy_test_pw';
+const CONTAINER_PREFIX = 'willbuy-schema-test-';
+
+function uid(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+function dockerRun(args: string[]): { code: number; stdout: string; stderr: string } {
+  const r = spawnSync('docker', args, { encoding: 'utf8' });
+  return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function findFreePort(): number {
+  return 30000 + Math.floor(Math.random() * 30000);
+}
+
+async function startPostgres(): Promise<{ container: string; port: number; url: string }> {
+  const container = CONTAINER_PREFIX + uid();
+  let port = findFreePort();
+  let attempts = 0;
+  let started = false;
+  let lastErr = '';
+  while (attempts < 3 && !started) {
+    const r = dockerRun([
+      'run',
+      '-d',
+      '--rm',
+      '--name',
+      container,
+      '-e',
+      `POSTGRES_PASSWORD=${PG_PASSWORD}`,
+      '-p',
+      `${port}:5432`,
+      PG_IMAGE,
+    ]);
+    if (r.code === 0) {
+      started = true;
+    } else {
+      lastErr = r.stderr;
+      port = findFreePort();
+      attempts += 1;
+    }
+  }
+  if (!started) {
+    throw new Error(`failed to start postgres container: ${lastErr}`);
+  }
+
+  const deadline = Date.now() + 30_000;
+  while (Date.now() < deadline) {
+    const r = dockerRun(['exec', container, 'pg_isready', '-U', 'postgres']);
+    if (r.code === 0) {
+      const url = `postgres://postgres:${PG_PASSWORD}@127.0.0.1:${port}/postgres`;
+      return { container, port, url };
+    }
+    await new Promise((res) => setTimeout(res, 500));
+  }
+  dockerRun(['rm', '-f', container]);
+  throw new Error('postgres container did not become ready in 30s');
+}
+
+function stopPostgres(container: string): void {
+  dockerRun(['rm', '-f', container]);
+}
+
+function runMigrate(databaseUrl: string): { code: number; stdout: string; stderr: string } {
+  const r = spawnSync('bash', [migrateScript], {
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      DATABASE_URL: databaseUrl,
+      MIGRATIONS_DIR: realMigrationsDir,
+    },
+  });
+  return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function psql(container: string, sql: string): { code: number; stdout: string; stderr: string } {
+  const r = spawnSync(
+    'docker',
+    ['exec', '-i', container, 'psql', '-U', 'postgres', '-d', 'postgres', '-tAc', sql],
+    { encoding: 'utf8' },
+  );
+  return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
+}
+
+function expectSqlError(
+  container: string,
+  sql: string,
+  matcher: RegExp,
+  hint: string,
+): void {
+  const r = psql(container, sql);
+  expect(r.code, `${hint}: expected non-zero exit, got stdout=${r.stdout}`).not.toBe(0);
+  expect(r.stderr, `${hint}: stderr did not match ${matcher}`).toMatch(matcher);
+}
+
+function expectSqlOk(container: string, sql: string, hint: string): string {
+  const r = psql(container, sql);
+  expect(r.code, `${hint}: stderr=${r.stderr}`).toBe(0);
+  return r.stdout.trim();
+}
+
+describeIfDocker('migrations schema (issue #26)', () => {
+  let pg: { container: string; port: number; url: string };
+
+  beforeAll(async () => {
+    pg = await startPostgres();
+    const r = runMigrate(pg.url);
+    expect(r.code, `migrate stdout=${r.stdout}\nstderr=${r.stderr}`).toBe(0);
+  }, 120_000);
+
+  afterAll(() => {
+    if (pg) stopPostgres(pg.container);
+  });
+
+  describe('table existence + column types', () => {
+    const expectedTables = [
+      'accounts',
+      'api_keys',
+      'studies',
+      'page_captures',
+      'backstories',
+      'backstory_leases',
+      'visits',
+      'provider_attempts',
+      'credit_ledger',
+      'llm_spend_daily',
+      'cap_warnings',
+      'reports',
+      'late_arrivals',
+      'global_inflight',
+      'provider_circuit_state',
+      'rate_tokens',
+    ];
+
+    for (const t of expectedTables) {
+      it(`table ${t} exists in public schema`, () => {
+        const out = expectSqlOk(
+          pg.container,
+          `select count(*) from information_schema.tables where table_schema = 'public' and table_name = '${t}';`,
+          `table ${t}`,
+        );
+        expect(out).toBe('1');
+      });
+    }
+
+    it('accounts.id is int8 identity', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type, is_identity from information_schema.columns where table_name='accounts' and column_name='id';`,
+        'accounts.id',
+      );
+      expect(out).toBe('bigint|YES');
+    });
+
+    it('studies has timestamptz created_at and finalized_at', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select column_name || ':' || data_type from information_schema.columns
+         where table_name='studies' and column_name in ('created_at','finalized_at')
+         order by column_name;`,
+        'studies timestamptz columns',
+      );
+      expect(out).toBe(
+        ['created_at:timestamp with time zone', 'finalized_at:timestamp with time zone'].join('\n'),
+      );
+    });
+
+    it('visits.parsed is jsonb', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='visits' and column_name='parsed';`,
+        'visits.parsed',
+      );
+      expect(out).toBe('jsonb');
+    });
+
+    it('account_balance view exists', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select count(*) from information_schema.views where table_schema='public' and table_name='account_balance';`,
+        'account_balance view',
+      );
+      expect(out).toBe('1');
+    });
+  });
+
+  describe('idempotent re-apply', () => {
+    it('second migrate run is a no-op (table count unchanged)', () => {
+      const before = expectSqlOk(
+        pg.container,
+        `select count(*) from information_schema.tables where table_schema='public';`,
+        'pre-rerun count',
+      );
+      const r2 = runMigrate(pg.url);
+      expect(r2.code, `r2 stderr=${r2.stderr}`).toBe(0);
+      const after = expectSqlOk(
+        pg.container,
+        `select count(*) from information_schema.tables where table_schema='public';`,
+        'post-rerun count',
+      );
+      expect(after).toBe(before);
+    });
+  });
+
+  describe('enum constraint enforcement (forbidden value rejected)', () => {
+    it('studies.kind rejects unknown value', () => {
+      // Use a fresh account+study insert path; rely on enum check.
+      expectSqlError(
+        pg.container,
+        `insert into accounts (owner_email) values ('enum1@example.com') returning id \\gset
+         insert into studies (account_id, kind, status) select id, 'triple', 'pending' from accounts where owner_email='enum1@example.com';`,
+        /invalid input value|violates check constraint|invalid kind/i,
+        'studies.kind enum',
+      );
+    });
+
+    it('studies.status rejects unknown value', () => {
+      expectSqlError(
+        pg.container,
+        `insert into accounts (owner_email) values ('enum2@example.com');
+         insert into studies (account_id, kind, status) select id, 'single', 'galactic' from accounts where owner_email='enum2@example.com';`,
+        /invalid input value|violates check constraint/i,
+        'studies.status enum',
+      );
+    });
+
+    it('page_captures.status rejects unknown value', () => {
+      expectSqlError(
+        pg.container,
+        `insert into accounts (owner_email) values ('enum3@example.com');
+         insert into studies (account_id, kind, status) select id, 'single', 'pending' from accounts where owner_email='enum3@example.com';
+         insert into page_captures (study_id, side, url_hash, a11y_storage_key, host_count, status)
+           select id, null, repeat('a',64), 'k/x', 1, 'partial' from studies
+           where account_id = (select id from accounts where owner_email='enum3@example.com');`,
+        /invalid input value|violates check constraint/i,
+        'page_captures.status enum',
+      );
+    });
+
+    it('visits.status rejects unknown value', () => {
+      expectSqlError(
+        pg.container,
+        `insert into accounts (owner_email) values ('enum4@example.com');
+         insert into studies (account_id, kind, status) select id, 'single', 'pending' from accounts where owner_email='enum4@example.com';
+         insert into backstories (study_id, idx, payload) select id, 0, '{}'::jsonb from studies
+           where account_id = (select id from accounts where owner_email='enum4@example.com');
+         insert into visits (backstory_id, side, status, repair_generation, transport_attempts, started_at)
+           select id, 'A', 'unknown_terminal', 0, 0, now() from backstories
+           where study_id = (select id from studies where account_id = (select id from accounts where owner_email='enum4@example.com'));`,
+        /invalid input value|violates check constraint/i,
+        'visits.status enum',
+      );
+    });
+
+    it('provider_attempts.kind rejects unknown value', () => {
+      expectSqlError(
+        pg.container,
+        `insert into accounts (owner_email) values ('enum5@example.com');
+         insert into studies (account_id, kind, status) select id, 'single', 'pending' from accounts where owner_email='enum5@example.com';
+         insert into provider_attempts (account_id, study_id, kind, logical_request_key, provider, model, transport_attempts, status, cost_cents, started_at)
+           select a.id, s.id, 'unknown_kind', 'lk-x-1', 'anthropic', 'claude-haiku-4-5', 0, 'started', 0, now()
+           from accounts a join studies s on s.account_id = a.id where a.owner_email='enum5@example.com';`,
+        /invalid input value|violates check constraint/i,
+        'provider_attempts.kind enum',
+      );
+    });
+
+    it('credit_ledger.kind rejects unknown value', () => {
+      expectSqlError(
+        pg.container,
+        `insert into accounts (owner_email) values ('enum6@example.com');
+         insert into credit_ledger (account_id, kind, cents, idempotency_key)
+           select id, 'embezzle', 100, 'idem-enum6' from accounts where owner_email='enum6@example.com';`,
+        /invalid input value|violates check constraint/i,
+        'credit_ledger.kind enum',
+      );
+    });
+
+    it('provider_circuit_state.state rejects unknown value', () => {
+      expectSqlError(
+        pg.container,
+        `insert into provider_circuit_state (provider, state) values ('anthropic', 'broken');`,
+        /invalid input value|violates check constraint/i,
+        'provider_circuit_state.state enum',
+      );
+    });
+  });
+
+  describe('foreign-key enforcement (orphan rejected)', () => {
+    it('api_keys.account_id rejects missing parent', () => {
+      expectSqlError(
+        pg.container,
+        `insert into api_keys (account_id, key_hash, prefix) values (999999, 'h', 'sk_live_x');`,
+        /violates foreign key constraint/i,
+        'api_keys FK',
+      );
+    });
+
+    it('studies.account_id rejects missing parent', () => {
+      expectSqlError(
+        pg.container,
+        `insert into studies (account_id, kind, status) values (999999, 'single', 'pending');`,
+        /violates foreign key constraint/i,
+        'studies FK',
+      );
+    });
+
+    it('page_captures.study_id rejects missing parent', () => {
+      expectSqlError(
+        pg.container,
+        `insert into page_captures (study_id, side, url_hash, a11y_storage_key, host_count, status)
+           values (999999, null, repeat('b',64), 'k/y', 1, 'ok');`,
+        /violates foreign key constraint/i,
+        'page_captures FK',
+      );
+    });
+
+    it('backstories.study_id rejects missing parent', () => {
+      expectSqlError(
+        pg.container,
+        `insert into backstories (study_id, idx, payload) values (999999, 0, '{}'::jsonb);`,
+        /violates foreign key constraint/i,
+        'backstories FK',
+      );
+    });
+
+    it('visits.backstory_id rejects missing parent', () => {
+      expectSqlError(
+        pg.container,
+        `insert into visits (backstory_id, side, status, repair_generation, transport_attempts, started_at)
+           values (999999, 'A', 'started', 0, 0, now());`,
+        /violates foreign key constraint/i,
+        'visits FK',
+      );
+    });
+
+    it('reports.study_id rejects missing parent', () => {
+      expectSqlError(
+        pg.container,
+        `insert into reports (study_id, share_token_hash, conv_score, paired_delta_json, ready_at)
+           values (999999, 'tokhash-fk', 0, '{}'::jsonb, now());`,
+        /violates foreign key constraint/i,
+        'reports FK',
+      );
+    });
+
+    it('credit_ledger.account_id rejects missing parent', () => {
+      expectSqlError(
+        pg.container,
+        `insert into credit_ledger (account_id, kind, cents, idempotency_key)
+           values (999999, 'top_up', 100, 'idem-fk-1');`,
+        /violates foreign key constraint/i,
+        'credit_ledger FK',
+      );
+    });
+  });
+
+  describe('UNIQUE enforcement (duplicate rejected)', () => {
+    it('api_keys.key_hash unique', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('uniq1@example.com');`);
+      const ok = psql(
+        pg.container,
+        `insert into api_keys (account_id, key_hash, prefix)
+           select id, 'dup-hash', 'sk_live_a' from accounts where owner_email='uniq1@example.com';`,
+      );
+      expect(ok.code, `seed: ${ok.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into api_keys (account_id, key_hash, prefix)
+           select id, 'dup-hash', 'sk_live_b' from accounts where owner_email='uniq1@example.com';`,
+        /duplicate key value violates unique/i,
+        'api_keys.key_hash unique',
+      );
+    });
+
+    it('page_captures (study_id, side) unique', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('uniq2@example.com');`);
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'paired', 'pending' from accounts where owner_email='uniq2@example.com';`,
+      );
+      const seed = psql(
+        pg.container,
+        `insert into page_captures (study_id, side, url_hash, a11y_storage_key, host_count, status)
+           select id, 'A', repeat('c',64), 'k/c', 1, 'ok' from studies
+           where account_id = (select id from accounts where owner_email='uniq2@example.com');`,
+      );
+      expect(seed.code, `seed: ${seed.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into page_captures (study_id, side, url_hash, a11y_storage_key, host_count, status)
+           select id, 'A', repeat('d',64), 'k/d', 1, 'ok' from studies
+           where account_id = (select id from accounts where owner_email='uniq2@example.com');`,
+        /duplicate key value violates unique/i,
+        'page_captures (study_id, side) unique',
+      );
+    });
+
+    it('backstories (study_id, idx) unique', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('uniq3@example.com');`);
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'single', 'pending' from accounts where owner_email='uniq3@example.com';`,
+      );
+      const seed = psql(
+        pg.container,
+        `insert into backstories (study_id, idx, payload)
+           select id, 0, '{}'::jsonb from studies
+           where account_id = (select id from accounts where owner_email='uniq3@example.com');`,
+      );
+      expect(seed.code, `seed: ${seed.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into backstories (study_id, idx, payload)
+           select id, 0, '{}'::jsonb from studies
+           where account_id = (select id from accounts where owner_email='uniq3@example.com');`,
+        /duplicate key value violates unique/i,
+        'backstories (study_id, idx) unique',
+      );
+    });
+
+    it('visits (backstory_id, side) unique', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('uniq4@example.com');`);
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'paired', 'pending' from accounts where owner_email='uniq4@example.com';`,
+      );
+      psql(
+        pg.container,
+        `insert into backstories (study_id, idx, payload)
+           select id, 0, '{}'::jsonb from studies
+           where account_id = (select id from accounts where owner_email='uniq4@example.com');`,
+      );
+      const seed = psql(
+        pg.container,
+        `insert into visits (backstory_id, side, status, repair_generation, transport_attempts, started_at)
+           select id, 'A', 'started', 0, 0, now() from backstories
+           where study_id = (select id from studies where account_id = (select id from accounts where owner_email='uniq4@example.com'));`,
+      );
+      expect(seed.code, `seed: ${seed.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into visits (backstory_id, side, status, repair_generation, transport_attempts, started_at)
+           select id, 'A', 'started', 0, 0, now() from backstories
+           where study_id = (select id from studies where account_id = (select id from accounts where owner_email='uniq4@example.com'));`,
+        /duplicate key value violates unique/i,
+        'visits (backstory_id, side) unique',
+      );
+    });
+
+    it('provider_attempts.logical_request_key unique', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('uniq5@example.com');`);
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'single', 'pending' from accounts where owner_email='uniq5@example.com';`,
+      );
+      const seed = psql(
+        pg.container,
+        `insert into provider_attempts (account_id, study_id, kind, logical_request_key, provider, model, transport_attempts, status, cost_cents, started_at)
+           select a.id, s.id, 'visit', 'lk-uniq5', 'anthropic', 'claude-haiku-4-5', 0, 'started', 0, now()
+           from accounts a join studies s on s.account_id = a.id where a.owner_email='uniq5@example.com';`,
+      );
+      expect(seed.code, `seed: ${seed.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into provider_attempts (account_id, study_id, kind, logical_request_key, provider, model, transport_attempts, status, cost_cents, started_at)
+           select a.id, s.id, 'visit', 'lk-uniq5', 'anthropic', 'claude-haiku-4-5', 0, 'started', 0, now()
+           from accounts a join studies s on s.account_id = a.id where a.owner_email='uniq5@example.com';`,
+        /duplicate key value violates unique/i,
+        'provider_attempts.logical_request_key unique',
+      );
+    });
+
+    it('credit_ledger.idempotency_key unique', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('uniq6@example.com');`);
+      const seed = psql(
+        pg.container,
+        `insert into credit_ledger (account_id, kind, cents, idempotency_key)
+           select id, 'top_up', 1000, 'idem-uniq6' from accounts where owner_email='uniq6@example.com';`,
+      );
+      expect(seed.code, `seed: ${seed.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into credit_ledger (account_id, kind, cents, idempotency_key)
+           select id, 'top_up', 1000, 'idem-uniq6' from accounts where owner_email='uniq6@example.com';`,
+        /duplicate key value violates unique/i,
+        'credit_ledger.idempotency_key unique',
+      );
+    });
+
+    it('reports.study_id unique', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('uniq7@example.com');`);
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'single', 'aggregating' from accounts where owner_email='uniq7@example.com';`,
+      );
+      const seed = psql(
+        pg.container,
+        `insert into reports (study_id, share_token_hash, conv_score, paired_delta_json, ready_at)
+           select id, 'tok-uniq7-a', 0.5, '{}'::jsonb, now() from studies
+           where account_id = (select id from accounts where owner_email='uniq7@example.com');`,
+      );
+      expect(seed.code, `seed: ${seed.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into reports (study_id, share_token_hash, conv_score, paired_delta_json, ready_at)
+           select id, 'tok-uniq7-b', 0.7, '{}'::jsonb, now() from studies
+           where account_id = (select id from accounts where owner_email='uniq7@example.com');`,
+        /duplicate key value violates unique/i,
+        'reports.study_id unique',
+      );
+    });
+
+    it('reports.share_token_hash unique', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('uniq8@example.com');`);
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'single', 'aggregating' from accounts where owner_email='uniq8@example.com';`,
+      );
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'single', 'aggregating' from accounts where owner_email='uniq8@example.com';`,
+      );
+      const seed = psql(
+        pg.container,
+        `insert into reports (study_id, share_token_hash, conv_score, paired_delta_json, ready_at)
+           select id, 'shared-tok', 0.5, '{}'::jsonb, now() from studies
+           where account_id = (select id from accounts where owner_email='uniq8@example.com')
+           order by id asc limit 1;`,
+      );
+      expect(seed.code, `seed: ${seed.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into reports (study_id, share_token_hash, conv_score, paired_delta_json, ready_at)
+           select id, 'shared-tok', 0.5, '{}'::jsonb, now() from studies
+           where account_id = (select id from accounts where owner_email='uniq8@example.com')
+           order by id desc limit 1;`,
+        /duplicate key value violates unique/i,
+        'reports.share_token_hash unique',
+      );
+    });
+
+    it('llm_spend_daily PK (account_id, date, kind) unique', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('uniq9@example.com');`);
+      const seed = psql(
+        pg.container,
+        `insert into llm_spend_daily (account_id, date, kind, cents)
+           select id, current_date, 'visit', 5 from accounts where owner_email='uniq9@example.com';`,
+      );
+      expect(seed.code, `seed: ${seed.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into llm_spend_daily (account_id, date, kind, cents)
+           select id, current_date, 'visit', 5 from accounts where owner_email='uniq9@example.com';`,
+        /duplicate key value violates unique/i,
+        'llm_spend_daily PK',
+      );
+    });
+
+    it('global_inflight PK (kind) unique', () => {
+      const seed = psql(
+        pg.container,
+        `insert into global_inflight (kind, count) values ('visit', 0);`,
+      );
+      expect(seed.code, `seed: ${seed.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into global_inflight (kind, count) values ('visit', 0);`,
+        /duplicate key value violates unique/i,
+        'global_inflight PK',
+      );
+    });
+  });
+
+  describe('domain rules', () => {
+    it('accounts: at most 2 active api_keys per account', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('cap@example.com');`);
+      const a = psql(
+        pg.container,
+        `insert into api_keys (account_id, key_hash, prefix)
+           select id, 'cap-h-1', 'sk_live_1' from accounts where owner_email='cap@example.com';`,
+      );
+      const b = psql(
+        pg.container,
+        `insert into api_keys (account_id, key_hash, prefix)
+           select id, 'cap-h-2', 'sk_live_2' from accounts where owner_email='cap@example.com';`,
+      );
+      expect(a.code, `seed1: ${a.stderr}`).toBe(0);
+      expect(b.code, `seed2: ${b.stderr}`).toBe(0);
+      expectSqlError(
+        pg.container,
+        `insert into api_keys (account_id, key_hash, prefix)
+           select id, 'cap-h-3', 'sk_live_3' from accounts where owner_email='cap@example.com';`,
+        /more than 2 active|too many active|active key|api_keys/i,
+        'api_keys ≤2 active per account',
+      );
+    });
+
+    it('credit_ledger.kind accepts the v0.1 set', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('cl-kind@example.com');`);
+      const kinds = ['top_up', 'reserve', 'commit', 'refund', 'partial_finalize'];
+      for (let i = 0; i < kinds.length; i++) {
+        const r = psql(
+          pg.container,
+          `insert into credit_ledger (account_id, kind, cents, idempotency_key)
+             select id, '${kinds[i]}', 100, 'cl-kind-${i}' from accounts where owner_email='cl-kind@example.com';`,
+        );
+        expect(r.code, `kind ${kinds[i]}: ${r.stderr}`).toBe(0);
+      }
+    });
+
+    it('provider_attempts.status accepts the v0.1 set', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('pa-status@example.com');`);
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'single', 'pending' from accounts where owner_email='pa-status@example.com';`,
+      );
+      const statuses = ['started', 'ended', 'indeterminate', 'indeterminate_refunded'];
+      for (let i = 0; i < statuses.length; i++) {
+        const r = psql(
+          pg.container,
+          `insert into provider_attempts (account_id, study_id, kind, logical_request_key, provider, model, transport_attempts, status, cost_cents, started_at)
+             select a.id, s.id, 'visit', 'pa-status-${i}', 'anthropic', 'claude-haiku-4-5', 0, '${statuses[i]}', 0, now()
+             from accounts a join studies s on s.account_id = a.id where a.owner_email='pa-status@example.com';`,
+        );
+        expect(r.code, `status ${statuses[i]}: ${r.stderr}`).toBe(0);
+      }
+    });
+
+    it('account_balance view sums signed ledger entries', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('bal@example.com');`);
+      const ops = [
+        { kind: 'top_up', cents: 1000 },
+        { kind: 'reserve', cents: -200 },
+        { kind: 'refund', cents: 50 },
+      ];
+      for (let i = 0; i < ops.length; i++) {
+        const r = psql(
+          pg.container,
+          `insert into credit_ledger (account_id, kind, cents, idempotency_key)
+             select id, '${ops[i]!.kind}', ${ops[i]!.cents}, 'bal-${i}' from accounts where owner_email='bal@example.com';`,
+        );
+        expect(r.code, r.stderr).toBe(0);
+      }
+      const balance = expectSqlOk(
+        pg.container,
+        `select balance_cents from account_balance where account_id = (select id from accounts where owner_email='bal@example.com');`,
+        'account_balance',
+      );
+      expect(balance).toBe('850');
+    });
+  });
+});

--- a/tests/migrations.schema.test.ts
+++ b/tests/migrations.schema.test.ts
@@ -632,14 +632,38 @@ describeIfDocker('migrations schema (issue #26)', () => {
 
     it('credit_ledger.kind accepts the v0.1 set', () => {
       psql(pg.container, `insert into accounts (owner_email) values ('cl-kind@example.com');`);
-      const kinds = ['top_up', 'reserve', 'commit', 'refund', 'partial_finalize'];
-      for (let i = 0; i < kinds.length; i++) {
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'single', 'pending' from accounts where owner_email='cl-kind@example.com';`,
+      );
+      // Seed one provider_attempt so that commit/refund rows satisfy the NOT NULL CHECK (spec §5.4).
+      psql(
+        pg.container,
+        `insert into provider_attempts (account_id, study_id, kind, logical_request_key, provider, model, transport_attempts, status, cost_cents, started_at)
+           select a.id, s.id, 'visit', 'cl-kind-pa', 'anthropic', 'claude-haiku-4-5', 0, 'ended', 50, now()
+           from accounts a join studies s on s.account_id = a.id where a.owner_email='cl-kind@example.com';`,
+      );
+      // top_up, reserve, partial_finalize: provider_attempt_id may be NULL.
+      const nullKinds = ['top_up', 'reserve', 'partial_finalize'];
+      for (let i = 0; i < nullKinds.length; i++) {
         const r = psql(
           pg.container,
           `insert into credit_ledger (account_id, kind, cents, idempotency_key)
-             select id, '${kinds[i]}', 100, 'cl-kind-${i}' from accounts where owner_email='cl-kind@example.com';`,
+             select id, '${nullKinds[i]}', 100, 'cl-kind-${i}' from accounts where owner_email='cl-kind@example.com';`,
         );
-        expect(r.code, `kind ${kinds[i]}: ${r.stderr}`).toBe(0);
+        expect(r.code, `kind ${nullKinds[i]}: ${r.stderr}`).toBe(0);
+      }
+      // commit/refund: provider_attempt_id IS NOT NULL required (spec §5.4 CHECK).
+      const paKinds = ['commit', 'refund'];
+      for (let i = 0; i < paKinds.length; i++) {
+        const r = psql(
+          pg.container,
+          `insert into credit_ledger (account_id, provider_attempt_id, kind, cents, idempotency_key)
+             select a.id, pa.id, '${paKinds[i]}', 100, 'cl-kind-pa-${i}'
+             from accounts a join provider_attempts pa on pa.account_id = a.id
+             where a.owner_email='cl-kind@example.com';`,
+        );
+        expect(r.code, `kind ${paKinds[i]}: ${r.stderr}`).toBe(0);
       }
     });
 
@@ -663,19 +687,39 @@ describeIfDocker('migrations schema (issue #26)', () => {
 
     it('account_balance view sums signed ledger entries', () => {
       psql(pg.container, `insert into accounts (owner_email) values ('bal@example.com');`);
-      const ops = [
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'single', 'pending' from accounts where owner_email='bal@example.com';`,
+      );
+      // Seed a provider_attempt so that the refund row satisfies the NOT NULL CHECK (spec §5.4).
+      psql(
+        pg.container,
+        `insert into provider_attempts (account_id, study_id, kind, logical_request_key, provider, model, transport_attempts, status, cost_cents, started_at)
+           select a.id, s.id, 'visit', 'bal-pa', 'anthropic', 'claude-haiku-4-5', 0, 'ended', 200, now()
+           from accounts a join studies s on s.account_id = a.id where a.owner_email='bal@example.com';`,
+      );
+      // top_up and reserve may have NULL provider_attempt_id.
+      const nullOps = [
         { kind: 'top_up', cents: 1000 },
         { kind: 'reserve', cents: -200 },
-        { kind: 'refund', cents: 50 },
       ];
-      for (let i = 0; i < ops.length; i++) {
+      for (let i = 0; i < nullOps.length; i++) {
         const r = psql(
           pg.container,
           `insert into credit_ledger (account_id, kind, cents, idempotency_key)
-             select id, '${ops[i]!.kind}', ${ops[i]!.cents}, 'bal-${i}' from accounts where owner_email='bal@example.com';`,
+             select id, '${nullOps[i]!.kind}', ${nullOps[i]!.cents}, 'bal-${i}' from accounts where owner_email='bal@example.com';`,
         );
         expect(r.code, r.stderr).toBe(0);
       }
+      // refund requires a non-NULL provider_attempt_id (spec §5.4 CHECK).
+      const refundR = psql(
+        pg.container,
+        `insert into credit_ledger (account_id, provider_attempt_id, kind, cents, idempotency_key)
+           select a.id, pa.id, 'refund', 50, 'bal-2'
+           from accounts a join provider_attempts pa on pa.account_id = a.id
+           where a.owner_email='bal@example.com';`,
+      );
+      expect(refundR.code, refundR.stderr).toBe(0);
       const balance = expectSqlOk(
         pg.container,
         `select balance_cents from account_balance where account_id = (select id from accounts where owner_email='bal@example.com');`,

--- a/tests/migrations.schema.test.ts
+++ b/tests/migrations.schema.test.ts
@@ -681,4 +681,297 @@ describeIfDocker('migrations schema (issue #26)', () => {
       expect(balance).toBe('850');
     });
   });
+
+  // ── PR #46 review findings ─────────────────────────────────────────────────
+  // Tests added RED (before migration fixes) per TDD red→green discipline.
+  // Blocking: B1 visits columns, B2 credit_ledger.provider_attempt_id,
+  //           B3 reports columns, B4 backstory_leases.holder_visit_id.
+  // Non-blocking: NB5 studies comment, NB6 provider column comments.
+  // Spec refs: §4.3, §5.4, §5.18, §2 #19.
+
+  describe('PR-46 B1 — visits extended columns (spec §4.3)', () => {
+    it('visits has study_id int8 column', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='visits' and column_name='study_id';`,
+        'visits.study_id type',
+      );
+      expect(out).toBe('bigint');
+    });
+
+    it('visits has capture_id int8 column (FK to page_captures)', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='visits' and column_name='capture_id';`,
+        'visits.capture_id type',
+      );
+      expect(out).toBe('bigint');
+    });
+
+    it('visits has variant_idx int4 column (replaces side for spec §4.3 UNIQUE)', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='visits' and column_name='variant_idx';`,
+        'visits.variant_idx type',
+      );
+      expect(out).toBe('integer');
+    });
+
+    it('visits has provider text column', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='visits' and column_name='provider';`,
+        'visits.provider type',
+      );
+      expect(out).toBe('text');
+    });
+
+    it('visits has model text column', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='visits' and column_name='model';`,
+        'visits.model type',
+      );
+      expect(out).toBe('text');
+    });
+
+    it('visits has cost_cents int4 column', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='visits' and column_name='cost_cents';`,
+        'visits.cost_cents type',
+      );
+      expect(out).toBe('integer');
+    });
+
+    it('visits has terminal_reason text column', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='visits' and column_name='terminal_reason';`,
+        'visits.terminal_reason type',
+      );
+      expect(out).toBe('text');
+    });
+
+    it('visits has latency_ms int4 column', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='visits' and column_name='latency_ms';`,
+        'visits.latency_ms type',
+      );
+      expect(out).toBe('integer');
+    });
+
+    it('visits UNIQUE is (study_id, backstory_id, variant_idx) — spec §4.3', () => {
+      // Confirm the new triple-key unique exists by querying pg_indexes.
+      const out = expectSqlOk(
+        pg.container,
+        `select count(*) from pg_indexes
+         where tablename='visits'
+           and indexdef like '%study_id%backstory_id%variant_idx%';`,
+        'visits UNIQUE(study_id, backstory_id, variant_idx)',
+      );
+      expect(out).toBe('1');
+    });
+
+    it('visits.capture_id FK rejects missing parent', () => {
+      expectSqlError(
+        pg.container,
+        `insert into accounts (owner_email) values ('b1fk@example.com');
+         insert into studies (account_id, kind, status)
+           select id, 'single', 'pending' from accounts where owner_email='b1fk@example.com';
+         insert into backstories (study_id, idx, payload)
+           select id, 0, '{}'::jsonb from studies
+           where account_id=(select id from accounts where owner_email='b1fk@example.com');
+         insert into visits (study_id, backstory_id, variant_idx, capture_id, provider, model, status, repair_generation, transport_attempts, started_at)
+           select s.id, b.id, 0, 999999, 'anthropic', 'claude-haiku-4-5', 'started', 0, 0, now()
+           from backstories b
+           join studies s on s.id = b.study_id
+           where s.account_id=(select id from accounts where owner_email='b1fk@example.com');`,
+        /violates foreign key constraint/i,
+        'visits.capture_id FK',
+      );
+    });
+
+    it('visits.study_id FK rejects missing parent', () => {
+      expectSqlError(
+        pg.container,
+        `insert into accounts (owner_email) values ('b1sfk@example.com');
+         insert into studies (account_id, kind, status)
+           select id, 'single', 'pending' from accounts where owner_email='b1sfk@example.com';
+         insert into backstories (study_id, idx, payload)
+           select id, 0, '{}'::jsonb from studies
+           where account_id=(select id from accounts where owner_email='b1sfk@example.com');
+         insert into visits (study_id, backstory_id, variant_idx, provider, model, status, repair_generation, transport_attempts, started_at)
+           select 999999, b.id, 0, 'anthropic', 'claude-haiku-4-5', 'started', 0, 0, now()
+           from backstories b
+           join studies s on s.id = b.study_id
+           where s.account_id=(select id from accounts where owner_email='b1sfk@example.com');`,
+        /violates foreign key constraint/i,
+        'visits.study_id FK',
+      );
+    });
+  });
+
+  describe('PR-46 B2 — credit_ledger.provider_attempt_id FK (spec §4.3/§5.4)', () => {
+    it('credit_ledger has provider_attempt_id int8 column', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='credit_ledger' and column_name='provider_attempt_id';`,
+        'credit_ledger.provider_attempt_id type',
+      );
+      expect(out).toBe('bigint');
+    });
+
+    it('credit_ledger.provider_attempt_id FK rejects missing parent', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('b2fk@example.com');`);
+      expectSqlError(
+        pg.container,
+        `insert into credit_ledger (account_id, provider_attempt_id, kind, cents, idempotency_key)
+           select id, 999999, 'commit', -5, 'b2fk-commit-1' from accounts where owner_email='b2fk@example.com';`,
+        /violates foreign key constraint/i,
+        'credit_ledger.provider_attempt_id FK',
+      );
+    });
+
+    it('credit_ledger.provider_attempt_id accepts NULL (reserve rows have no attempt yet)', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('b2null@example.com');`);
+      const r = psql(
+        pg.container,
+        `insert into credit_ledger (account_id, provider_attempt_id, kind, cents, idempotency_key)
+           select id, null, 'reserve', -100, 'b2null-reserve-1' from accounts where owner_email='b2null@example.com';`,
+      );
+      expect(r.code, `NULL provider_attempt_id rejected: ${r.stderr}`).toBe(0);
+    });
+  });
+
+  describe('PR-46 B3 — reports extended columns (spec §4.3, §5.18, §2 #19)', () => {
+    it('reports has clusters_json jsonb column', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='reports' and column_name='clusters_json';`,
+        'reports.clusters_json type',
+      );
+      expect(out).toBe('jsonb');
+    });
+
+    it('reports has scores_json jsonb column', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='reports' and column_name='scores_json';`,
+        'reports.scores_json type',
+      );
+      expect(out).toBe('jsonb');
+    });
+
+    it('reports has paired_tests_disagreement boolean column (spec §2 #19 banner)', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='reports' and column_name='paired_tests_disagreement';`,
+        'reports.paired_tests_disagreement type',
+      );
+      expect(out).toBe('boolean');
+    });
+
+    it('reports has default_share_token_id int8 column (FK to future share_tokens)', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='reports' and column_name='default_share_token_id';`,
+        'reports.default_share_token_id type',
+      );
+      expect(out).toBe('bigint');
+    });
+
+    it('reports.paired_tests_disagreement accepts true/false (typed boolean)', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('b3bool@example.com');`);
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'paired', 'aggregating' from accounts where owner_email='b3bool@example.com';`,
+      );
+      const r = psql(
+        pg.container,
+        `insert into reports (study_id, share_token_hash, conv_score, paired_delta_json, paired_tests_disagreement, ready_at)
+           select id, 'tok-b3bool', 0.5, '{}'::jsonb, true, now() from studies
+           where account_id=(select id from accounts where owner_email='b3bool@example.com');`,
+      );
+      expect(r.code, `boolean insert: ${r.stderr}`).toBe(0);
+      const out = expectSqlOk(
+        pg.container,
+        `select paired_tests_disagreement from reports
+           where study_id=(select id from studies where account_id=(select id from accounts where owner_email='b3bool@example.com'));`,
+        'reports.paired_tests_disagreement value',
+      );
+      expect(out).toBe('t');
+    });
+  });
+
+  describe('PR-46 B4 — backstory_leases.holder_visit_id typed FK (spec §4.3)', () => {
+    it('backstory_leases has holder_visit_id int8 column (not text lease_owner)', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select data_type from information_schema.columns where table_name='backstory_leases' and column_name='holder_visit_id';`,
+        'backstory_leases.holder_visit_id type',
+      );
+      expect(out).toBe('bigint');
+    });
+
+    it('backstory_leases.holder_visit_id FK rejects missing parent', () => {
+      psql(pg.container, `insert into accounts (owner_email) values ('b4fk@example.com');`);
+      psql(
+        pg.container,
+        `insert into studies (account_id, kind, status) select id, 'paired', 'visiting' from accounts where owner_email='b4fk@example.com';`,
+      );
+      psql(
+        pg.container,
+        `insert into backstories (study_id, idx, payload) select id, 0, '{}'::jsonb from studies where account_id=(select id from accounts where owner_email='b4fk@example.com');`,
+      );
+      expectSqlError(
+        pg.container,
+        `insert into backstory_leases (backstory_id, study_id, holder_visit_id, lease_until, heartbeat_at)
+           select b.id, s.id, 999999, now()+interval '120s', now()
+           from backstories b join studies s on s.id=b.study_id
+           where s.account_id=(select id from accounts where owner_email='b4fk@example.com');`,
+        /violates foreign key constraint/i,
+        'backstory_leases.holder_visit_id FK',
+      );
+    });
+
+    it('backstory_leases no longer has lease_owner text column', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select count(*) from information_schema.columns where table_name='backstory_leases' and column_name='lease_owner';`,
+        'lease_owner should be absent',
+      );
+      // lease_owner was the old text column — should be gone after B4 fix
+      expect(out).toBe('0');
+    });
+  });
+
+  describe('PR-46 NB6 — comment on column for provider_circuit_state.provider and rate_tokens.provider', () => {
+    it('provider_circuit_state.provider has a column comment', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select count(*) from pg_description d
+           join pg_attribute a on a.attrelid = d.objoid and a.attnum = d.objsubid
+           join pg_class c on c.oid = a.attrelid
+           where c.relname = 'provider_circuit_state' and a.attname = 'provider'
+             and d.description is not null;`,
+        'provider_circuit_state.provider comment',
+      );
+      expect(out).toBe('1');
+    });
+
+    it('rate_tokens.provider has a column comment', () => {
+      const out = expectSqlOk(
+        pg.container,
+        `select count(*) from pg_description d
+           join pg_attribute a on a.attrelid = d.objoid and a.attnum = d.objsubid
+           join pg_class c on c.oid = a.attrelid
+           where c.relname = 'rate_tokens' and a.attname = 'provider'
+             and d.description is not null;`,
+        'rate_tokens.provider comment',
+      );
+      expect(out).toBe('1');
+    });
+  });
 });

--- a/tests/migrations.schema.test.ts
+++ b/tests/migrations.schema.test.ts
@@ -275,9 +275,10 @@ describeIfDocker('migrations schema (issue #26)', () => {
          insert into studies (account_id, kind, status) select id, 'single', 'pending' from accounts where owner_email='enum4@example.com';
          insert into backstories (study_id, idx, payload) select id, 0, '{}'::jsonb from studies
            where account_id = (select id from accounts where owner_email='enum4@example.com');
-         insert into visits (backstory_id, side, status, repair_generation, transport_attempts, started_at)
-           select id, 'A', 'unknown_terminal', 0, 0, now() from backstories
-           where study_id = (select id from studies where account_id = (select id from accounts where owner_email='enum4@example.com'));`,
+         insert into visits (study_id, backstory_id, variant_idx, status, repair_generation, transport_attempts, started_at)
+           select s.id, b.id, 0, 'unknown_terminal', 0, 0, now()
+           from backstories b join studies s on s.id = b.study_id
+           where s.account_id = (select id from accounts where owner_email='enum4@example.com');`,
         /invalid input value|violates check constraint/i,
         'visits.status enum',
       );
@@ -358,8 +359,8 @@ describeIfDocker('migrations schema (issue #26)', () => {
     it('visits.backstory_id rejects missing parent', () => {
       expectSqlError(
         pg.container,
-        `insert into visits (backstory_id, side, status, repair_generation, transport_attempts, started_at)
-           values (999999, 'A', 'started', 0, 0, now());`,
+        `insert into visits (study_id, backstory_id, variant_idx, status, repair_generation, transport_attempts, started_at)
+           values (999999, 999999, 0, 'started', 0, 0, now());`,
         /violates foreign key constraint/i,
         'visits FK',
       );
@@ -450,7 +451,7 @@ describeIfDocker('migrations schema (issue #26)', () => {
       );
     });
 
-    it('visits (backstory_id, side) unique', () => {
+    it('visits (study_id, backstory_id, variant_idx) unique', () => {
       psql(pg.container, `insert into accounts (owner_email) values ('uniq4@example.com');`);
       psql(
         pg.container,
@@ -464,18 +465,20 @@ describeIfDocker('migrations schema (issue #26)', () => {
       );
       const seed = psql(
         pg.container,
-        `insert into visits (backstory_id, side, status, repair_generation, transport_attempts, started_at)
-           select id, 'A', 'started', 0, 0, now() from backstories
-           where study_id = (select id from studies where account_id = (select id from accounts where owner_email='uniq4@example.com'));`,
+        `insert into visits (study_id, backstory_id, variant_idx, status, repair_generation, transport_attempts, started_at)
+           select s.id, b.id, 0, 'started', 0, 0, now()
+           from backstories b join studies s on s.id = b.study_id
+           where s.account_id = (select id from accounts where owner_email='uniq4@example.com');`,
       );
       expect(seed.code, `seed: ${seed.stderr}`).toBe(0);
       expectSqlError(
         pg.container,
-        `insert into visits (backstory_id, side, status, repair_generation, transport_attempts, started_at)
-           select id, 'A', 'started', 0, 0, now() from backstories
-           where study_id = (select id from studies where account_id = (select id from accounts where owner_email='uniq4@example.com'));`,
+        `insert into visits (study_id, backstory_id, variant_idx, status, repair_generation, transport_attempts, started_at)
+           select s.id, b.id, 0, 'started', 0, 0, now()
+           from backstories b join studies s on s.id = b.study_id
+           where s.account_id = (select id from accounts where owner_email='uniq4@example.com');`,
         /duplicate key value violates unique/i,
-        'visits (backstory_id, side) unique',
+        'visits (study_id, backstory_id, variant_idx) unique',
       );
     });
 

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -129,7 +129,7 @@ describeIfDocker('migrations runner', () => {
     if (workDir) rmSync(workDir, { recursive: true, force: true });
   });
 
-  it('applies the placeholder migration on a fresh DB', () => {
+  it('applies every migration on a fresh DB', () => {
     const dir = mkdtempSync(join(workDir, 'fresh-'));
     copyRealMigrationsTo(dir);
 
@@ -143,12 +143,14 @@ describeIfDocker('migrations runner', () => {
     expect(tableCheck.code).toBe(0);
     expect(tableCheck.stdout.trim()).toBe('1');
 
+    // _migrations row count must equal the .sql file count in real migrations dir.
+    const onDisk = readdirSync(realMigrationsDir).filter((f) => f.endsWith('.sql')).sort();
     const rowCount = psql(pg.container, 'SELECT COUNT(*) FROM _migrations;');
     expect(rowCount.code).toBe(0);
-    expect(rowCount.stdout.trim()).toBe('1');
+    expect(rowCount.stdout.trim()).toBe(String(onDisk.length));
 
-    const filename = psql(pg.container, 'SELECT filename FROM _migrations ORDER BY filename;');
-    expect(filename.stdout.trim()).toBe('0000_init.sql');
+    const filenames = psql(pg.container, 'SELECT filename FROM _migrations ORDER BY filename;');
+    expect(filenames.stdout.trim().split('\n').sort()).toEqual(onDisk);
   });
 
   it('is a no-op on second run', () => {


### PR DESCRIPTION
## Summary

Lands the 11 migration files split per issue #26. Every migration applies cleanly under \`pnpm migrate\` against the existing runner from PR #38; re-runs are idempotent.

- 0001 \`accounts\` + \`api_keys\` (≤ 2 active keys per account, trigger-enforced)
- 0002 \`studies\` (state machine: \`pending → capturing → visiting → aggregating → ready | failed\`)
- 0003 \`page_captures\` (one per \`(study, side)\`; \`side\` NULL for single, A/B for paired)
- 0004 \`backstories\` + \`backstory_leases\` (per-backstory lease — §2 #12, §5.11)
- 0005 \`visits\` (\`parsed jsonb\`, \`repair_generation\`, \`transport_attempts\`, status enum)
- 0006 \`provider_attempts\` (\`logical_request_key UNIQUE\` — §5.15)
- 0007 \`credit_ledger\` + \`account_balance\` view (§5.4)
- 0008 \`llm_spend_daily\` PK \`(account_id, date, kind)\` + \`cap_warnings\` (§5.5)
- 0009 \`reports\` (UNIQUE \`study_id\`, UNIQUE \`share_token_hash\`; §5.11)
- 0010 \`late_arrivals\` (§5.11)
- 0011 \`global_inflight\` + \`provider_circuit_state\` + \`rate_tokens\` (§5.14)

Implements spec §4.1 + §5.5 + §5.11 + §5.13 + §5.14 + §5.15 + §2 #16.

## Notes

- The \`next_action\` enum from amendment A1 lives in zod at the API/worker boundary, not in the DB. \`visits.parsed\` is \`jsonb\` so amendment churn doesn't require migrations — DB enums would force a migration on every rubric tweak.
- Style follows postgres-ai/rules SQL style guide: lowercase keywords, \`snake_case\`, plural table names, \`int8 generated always as identity\` for surrogate PKs, \`timestamptz\` (never \`timestamp\`), \`text\` (never \`varchar\`), \`comment on table\` / \`comment on column\` for every table + key column.
- The \`≤ 2 active api_keys per account\` rule is a trigger because a partial unique index ("≤ 2 NULL revoked_at rows per account_id") is not expressible as a plain index predicate.
- The unique-per-\`(study_id, side)\` constraint on \`page_captures\` uses \`coalesce(side, '')\` so it covers the single-URL case where \`side\` is NULL.
- \`tests/migrations.test.ts\` updated so the row-count assertion derives the expected count from the on-disk file list rather than the constant 1 from the placeholder era.

## Schema dump (after \`pnpm migrate\` against \`postgres:16-alpine\`)

\`\`\`text
                 List of relations
 Schema |          Name          | Type
--------+------------------------+------
 public | _migrations            | table
 public | accounts               | table
 public | api_keys               | table
 public | backstories            | table
 public | backstory_leases       | table
 public | cap_warnings           | table
 public | credit_ledger          | table
 public | global_inflight        | table
 public | late_arrivals          | table
 public | llm_spend_daily        | table
 public | page_captures          | table
 public | provider_attempts      | table
 public | provider_circuit_state | table
 public | rate_tokens            | table
 public | reports                | table
 public | studies                | table
 public | visits                 | table
(17 rows)

             List of relations
 Schema |      Name       | Type
--------+-----------------+------
 public | account_balance | view
(1 row)
\`\`\`

## TDD

- Red: 92e6394 (\`tests/migrations.schema.test.ts\` — 49 acceptance tests fail against an empty schema)
- Green: 07d96e2 (the 11 migration files; all 49 schema tests + the 3 runner tests pass)

## Test evidence

\`\`\`
$ pnpm test
…
 Test Files  26 passed | 1 skipped (27)
      Tests  144 passed | 1 skipped (145)

$ pnpm lint   # clean
$ pnpm typecheck  # clean
\`\`\`

The 49-test schema suite covers, per acceptance criteria in #26:

1. Each of 16 expected tables exists with correct columns/types — 16 tests
2. Idempotent re-apply (table count unchanged after second \`pnpm migrate\`)
3. Forbidden enum value rejected: \`studies.kind\`, \`studies.status\`, \`page_captures.status\`, \`visits.status\`, \`provider_attempts.kind\`, \`credit_ledger.kind\`, \`provider_circuit_state.state\` — 7 tests
4. FK orphan rejected: \`api_keys\`, \`studies\`, \`page_captures\`, \`backstories\`, \`visits\`, \`reports\`, \`credit_ledger\` — 7 tests
5. UNIQUE duplicate rejected: \`api_keys.key_hash\`, \`page_captures(study_id, side)\`, \`backstories(study_id, idx)\`, \`visits(backstory_id, side)\`, \`provider_attempts.logical_request_key\`, \`credit_ledger.idempotency_key\`, \`reports.study_id\`, \`reports.share_token_hash\`, \`llm_spend_daily\` PK, \`global_inflight\` PK — 10 tests
6. Domain rules: ≤ 2 active api_keys per account, \`credit_ledger.kind\` accepts the v0.1 set, \`provider_attempts.status\` accepts the v0.1 set, \`account_balance\` view sums signed entries — 4 tests

Plus 1 column-type spot-check (\`visits.parsed\` is \`jsonb\`), 1 view-existence check, 1 \`accounts.id\` identity check, 1 \`studies\` timestamptz check.

## Public-repo audit

No secrets, IPs, or secret-sauce leaks; verified by re-grep before pushing. The schema dump above has no hostnames or credentials.

## Spec link

Implements spec §4.1 + §5.4 + §5.5 + §5.11 + §5.13 + §5.14 + §5.15 + §2 #16.

Closes #26