### PR TITLE
spec: add amendments-precedence callout at top of SPEC.md

### DIFF
--- a/.samo/spec/willbuy/SPEC.md
+++ b/.samo/spec/willbuy/SPEC.md
@@ -1,5 +1,7 @@
 # willbuy.dev — SPEC v0.9
 
+> **Spec amendments take precedence in narrow areas.** This file is the authoritative spec, but a separate **append-only amendments log** lives at [`SPEC.willbuy.amendments.md`](./SPEC.willbuy.amendments.md). When an amendment narrowly contradicts a section here, the amendment wins **for the area it explicitly scopes** — every entry lists the affected sections (`Affects:`), the driver, what changes, what is NOT changed, and any constraints. The amendments file exists so individual deviations discovered during implementation can be recorded and reviewed without forcing a full spec rev for each change; future spec revs roll the amendments back inline. Always read both files together — `SPEC.md` first, then any `A_n` entries whose `Affects:` line touches the section you care about.
+
 ## 0. Persona
 
 Veteran "conversion research & LLM-simulated user testing" expert — someone who has shipped both CRO audit tools and LLM eval harnesses, and knows the trap in this category is producing plausible-sounding slop that doesn't correlate with reality.


### PR DESCRIPTION
## Summary

Adds a short callout at the top of `SPEC.md` (immediately after the v0.9 title) clarifying that `SPEC.willbuy.amendments.md` is the authoritative place for narrow deviations and that amendments win within the scope they explicitly declare via their `Affects:` line.

Without this pointer, the amendments file is discoverable only by accident (git log, repo-tree exploration). That's a real problem now that A1 replaces §2 #15/#18/#19 (next_action enum + weights), A2 documents the HDBSCAN cosine routing, and A3/A4/A5 (just merged in #50) queue the post–Sprint-2 Bun/sqlever/ZFS+DBLab migrations — readers who skip the amendments file will silently diverge from the authoritative spec.

Docs-only — no schema, behavior, or contract changes.

## Test plan
- [x] Renders cleanly at the top of SPEC.md
- [x] Markdown link to `SPEC.willbuy.amendments.md` resolves correctly when viewed in the GitHub UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)