### PR TITLE
fix(llm-adapter): extend FORBIDDEN to 9 identifiers + amendment A6 (#20)

### DIFF
--- a/.samo/spec/willbuy/SPEC.willbuy.amendments.md
+++ b/.samo/spec/willbuy/SPEC.willbuy.amendments.md
@@ -174,3 +174,19 @@ This matrix is passed to HDBSCAN as `metric='precomputed'`. With `metric='precom
 **Constraints.** (a) ZFS dataset properties: `recordsize=8K` (matches Postgres page size), `compression=lz4`, `atime=off`, `logbias=throughput`, `primarycache=metadata` per the postgres-ai standard ZFS-for-Postgres tuning. (b) WAL on a separate dataset with `recordsize=128K` is preferred but not blocking. (c) DBLab is not in the request hot path — it's a developer/CI primitive only; production reads/writes go straight to the primary Postgres instance. (d) Backup story: ZFS snapshots `+` `zfs send` to off-host storage, replacing whatever pg_dump cron we would otherwise run. (e) Capacity sizing on CPX21 (40 GB SSD) is tight for ZFS; the migration may bundle a VM upsize if monitoring shows the ARC + branching headroom is insufficient.
 
 **Tracking.** Issue #49 (PR set on cutover). Spec future rev folds the ZFS + DBLab deployment into §5.6 and adds a §10 amendment around test-time branching.
+
+---
+
+## 2026-04-25 — A6: `packages/adapters` renamed to `packages/llm-adapter`; forbidden identifiers inlined in `eslint-rule.js`
+
+**Affects:** §2 #12 (`packages/adapters/**` AST scope, `packages/adapters/forbidden-keys.ts` location), §6 (`packages/adapters/forbidden-keys.ts` reference).
+
+**Driver:** Sprint 1 implementation simplification — a single workspace with a single `eslint-rule.js` is shorter than a separate `forbidden-keys.ts` module that the rule has to import. Spec was written before the simpler shape was clear.
+
+**Amendment.** Wherever the spec says `packages/adapters/`, read `packages/llm-adapter/`. The forbidden identifier list lives inline in `packages/llm-adapter/eslint-rule.js` (the `FORBIDDEN` Set constant) instead of a separate `forbidden-keys.ts` file. AST lint scope is unchanged: still scans all TS files in `packages/llm-adapter/**` for forbidden identifier usage as keys, properties, parameters, and imports.
+
+**What is NOT changed.** The 9-identifier list itself (now correct after this PR per BD-1 fix: `conversation_id`, `session_id`, `thread_id`, `previous_response_id`, `cached_prompt_id`, `parent_message_id`, `context_id`, `assistant_id`, `run_id`), the AST-vs-grep authoritative ordering, the CI failure semantics on lint hit, the LLMProvider interface contract.
+
+**Constraints.** Adding more provider adapters in the future (e.g. a hypothetical OpenAI HTTP adapter) MUST live in `packages/llm-adapter/` and inherit the same `eslint-rule.js` Set. If a separate provider package is ever needed, the `eslint-rule.js` Set should be extracted to a shared module first.
+
+**Tracking.** PR #N (set on merge), issue #20.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,7 +42,7 @@ PRs that introduce behavior without a test will be sent back. PRs that add a tes
 - **Don't add error handling for impossible cases.** If a caller is internal and a value is guaranteed non-null by upstream code, don't add `if (x == null) throw` defensively.
 - **Don't add features the issue didn't ask for.** Bug fixes don't need surrounding cleanup. One-shot operations don't need helpers. No backwards-compat shims when you can just change the caller.
 - **No `--no-sandbox` for Chromium.** Ever. There's a CI grep-lint enforcing this.
-- **No reserved identifiers at LLM adapter call sites or in adapter type definitions.** Spec §2 #15 lists them; an AST lint enforces. If your code grep-matches `conversation_id|session_id|thread_id|previous_response_id|cached_prompt_id|parent_message_id|run_id` near an LLM call, you'll fail CI — by design, to preserve the fresh-context guarantee.
+- **No reserved identifiers at LLM adapter call sites or in adapter type definitions.** Spec §2 #12 lists them; an AST lint enforces. If your code grep-matches `conversation_id|session_id|thread_id|previous_response_id|cached_prompt_id|parent_message_id|context_id|assistant_id|run_id` near an LLM call, you'll fail CI — by design, to preserve the fresh-context guarantee.
 - **All LLM calls go through `LLMProvider` (chat) — only.** No direct subprocess to a CLI from worker code; no direct HTTP to a provider. The adapter is the seam where capability flags, idempotency keys, prompt-caching prefix isolation, and spend ledger writes happen. Bypassing the adapter breaks every guarantee in the spec at once.
 - **Embeddings are local in-process** via `fastembed` (`BAAI/bge-small-en-v1.5`). No external embedding provider, no API key, no adapter. Spec §17.
 

--- a/packages/llm-adapter/eslint-rule.js
+++ b/packages/llm-adapter/eslint-rule.js
@@ -1,9 +1,9 @@
 /**
  * Custom ESLint rule: bans the reserved continuation identifiers from
- * spec §2 #15 (`conversation_id`, `session_id`, `thread_id`,
+ * spec §2 #12 (`conversation_id`, `session_id`, `thread_id`,
  * `previous_response_id`, `cached_prompt_id`, `parent_message_id`,
- * `run_id`) ANYWHERE in the repo, with a single allow-list line for the
- * rule definition itself.
+ * `context_id`, `assistant_id`, `run_id`) ANYWHERE in the repo, with a
+ * single allow-list line for the rule definition itself.
  *
  * The rule walks the AST (typescript-eslint extends ESLint's AST so we
  * can intercept TS-only nodes the same way we intercept regular ones),
@@ -23,7 +23,7 @@
  * Issue #5 acceptance #6.
  */
 
-// Spec §2 #15. Keep the list narrow — it is the authoritative set the rule
+// Spec §2 #12. Keep the list narrow — it is the authoritative set the rule
 // blocks. The amendments file may add provider-specific aliases later;
 // when that happens, add them here, NOT in a separate config knob (the
 // rule is the single source of truth and reviewers grep for this list).
@@ -34,6 +34,8 @@ const FORBIDDEN = new Set([
   'previous_response_id',
   'cached_prompt_id',
   'parent_message_id',
+  'context_id',
+  'assistant_id',
   'run_id',
 ]);
 
@@ -64,12 +66,12 @@ const rule = {
     type: 'problem',
     docs: {
       description:
-        'Disallow reserved LLM continuation identifiers (spec §2 #15) anywhere in source — fresh-context guarantee.',
+        'Disallow reserved LLM continuation identifiers (spec §2 #12) anywhere in source — fresh-context guarantee.',
     },
     schema: [],
     messages: {
       banned:
-        "Reserved LLM continuation identifier '{{name}}' is forbidden anywhere in the repo (spec §2 #15 fresh-context guarantee). Use logical_request_key + transport_attempts instead.",
+        "Reserved LLM continuation identifier '{{name}}' is forbidden anywhere in the repo (spec §2 #12 fresh-context guarantee). Use logical_request_key + transport_attempts instead.",
     },
   },
   create(context) {

--- a/packages/llm-adapter/lint-fixtures/forbidden-assistant-id.ts
+++ b/packages/llm-adapter/lint-fixtures/forbidden-assistant-id.ts
@@ -1,0 +1,8 @@
+// Lint fixture: `assistant_id` as a TypeScript interface property signature.
+// Spec §2 #12 lists `assistant_id` in the 9-identifier forbidden set.
+// The willbuy/no-reserved-llm-identifiers rule MUST flag this file.
+
+export interface BadShape {
+  assistant_id: string;
+  ok: number;
+}

--- a/packages/llm-adapter/lint-fixtures/forbidden-context-id.ts
+++ b/packages/llm-adapter/lint-fixtures/forbidden-context-id.ts
@@ -1,0 +1,7 @@
+// Lint fixture: `context_id` as an object-literal property key.
+// Spec §2 #12 lists `context_id` in the 9-identifier forbidden set.
+// The willbuy/no-reserved-llm-identifiers rule MUST flag this file.
+
+export const payload = {
+  context_id: 'should-be-flagged',
+};

--- a/packages/llm-adapter/test/lint-rule.test.ts
+++ b/packages/llm-adapter/test/lint-rule.test.ts
@@ -73,6 +73,22 @@ describe('willbuy/no-reserved-llm-identifiers — forbidden fixtures', () => {
     expect(out.stdout + out.stderr).toMatch(/no-reserved-llm-identifiers/);
     expect(out.stdout + out.stderr).toMatch(/run_id/);
   });
+
+  // Issue #20: `context_id` and `assistant_id` were missing from the FORBIDDEN
+  // Set (spec §2 #12 lists 9 identifiers; implementation had only 7).
+  it('flags `context_id` as an object-literal property key (issue #20)', () => {
+    const out = lintFile('packages/llm-adapter/lint-fixtures/forbidden-context-id.ts');
+    expect(out.code, `expected non-zero; got ${out.code}\n${out.stdout}\n${out.stderr}`).not.toBe(0);
+    expect(out.stdout + out.stderr).toMatch(/no-reserved-llm-identifiers/);
+    expect(out.stdout + out.stderr).toMatch(/context_id/);
+  });
+
+  it('flags `assistant_id` as a TS interface property signature (issue #20)', () => {
+    const out = lintFile('packages/llm-adapter/lint-fixtures/forbidden-assistant-id.ts');
+    expect(out.code, `expected non-zero; got ${out.code}\n${out.stdout}\n${out.stderr}`).not.toBe(0);
+    expect(out.stdout + out.stderr).toMatch(/no-reserved-llm-identifiers/);
+    expect(out.stdout + out.stderr).toMatch(/assistant_id/);
+  });
 });
 
 describe('willbuy/no-reserved-llm-identifiers — clean fixture', () => {


### PR DESCRIPTION
## Root cause

Sprint 1 alignment audit found `context_id` and `assistant_id` missing from §2 #12 enforcement. The `FORBIDDEN` Set in `packages/llm-adapter/eslint-rule.js` had only 7 identifiers; spec §2 #12 authoritatively lists 9.

## Changes

**BD-1 — Code fix (TDD red→green):**
- `packages/llm-adapter/eslint-rule.js`: added `context_id` and `assistant_id` to the `FORBIDDEN` Set (now 9 entries); updated doc-comment and lint message to reference §2 #12 (not #15)
- `packages/llm-adapter/lint-fixtures/forbidden-context-id.ts`: RED fixture — `context_id` as object-literal property key
- `packages/llm-adapter/lint-fixtures/forbidden-assistant-id.ts`: RED fixture — `assistant_id` as TS interface property signature
- `packages/llm-adapter/test/lint-rule.test.ts`: two new test cases for the above fixtures
- `CLAUDE.md` line 45: updated grep-pattern and spec ref to include all 9 identifiers (§2 #12)

**A6 — Spec amendment:**
- `.samo/spec/willbuy/SPEC.willbuy.amendments.md`: appended A6 recording that `packages/adapters/` was renamed to `packages/llm-adapter/` and the forbidden list lives inline in `eslint-rule.js` instead of `forbidden-keys.ts`

## Test evidence — lint-rule (all 9 identifiers, 8/8 passing)

```
 RUN  v2.1.9 /Users/nik/github/willbuy-wt-20-forbidden-keys

 ✓ packages/llm-adapter/test/lint-rule.test.ts (8 tests) 60333ms
   ✓ willbuy/no-reserved-llm-identifiers — forbidden fixtures > flags a top-level `const session_id = …` declaration 9125ms
   ✓ willbuy/no-reserved-llm-identifiers — forbidden fixtures > flags `conversation_id` in a TS interface property 5687ms
   ✓ willbuy/no-reserved-llm-identifiers — forbidden fixtures > flags `thread_id` as an object-literal property 9218ms
   ✓ willbuy/no-reserved-llm-identifiers — forbidden fixtures > flags `previous_response_id` as a function parameter 5820ms
   ✓ willbuy/no-reserved-llm-identifiers — forbidden fixtures > flags `run_id` inside an object destructure 8506ms
   ✓ willbuy/no-reserved-llm-identifiers — forbidden fixtures > flags `context_id` as an object-literal property key (issue #20) 6861ms
   ✓ willbuy/no-reserved-llm-identifiers — forbidden fixtures > flags `assistant_id` as a TS interface property signature (issue #20) 10047ms
   ✓ willbuy/no-reserved-llm-identifiers — clean fixture > accepts a module with visit_id / logical_request_key / transport_attempts 5027ms

 Test Files  1 passed (1)
      Tests  8 passed (8)
```

## Spec link

Implements spec §2 #12. Records package-rename deviation in amendment A6.

## Public-repo audit

No secrets, IPs, tokens, or secret-sauce in the diff. The fixtures contain only forbidden identifier names (which are spec-defined, not proprietary). The amendment is prose only.

## Pre-existing test failures (not introduced by this PR)

- `captureGolden.test.ts` / `captureHostCount.test.ts`: browser timeout — pre-existing in local env (no Chromium available), also fails on main
- `migrations.test.ts` / `migrations.schema.test.ts`: Docker not available in worktree env
- `boot.test.ts` one case: `.npmrc` NPM_TOKEN interpolation noise in worktree env

All pass on main in the full CI environment.

Closes #20