### PR TITLE
fix(web): Recharts charts render empty on initial paint (#78)

### DIFF
--- a/apps/web/components/report/Histograms.tsx
+++ b/apps/web/components/report/Histograms.tsx
@@ -35,7 +35,7 @@ function HistOne({ row }: { row: ReportT['histograms'][number] }) {
         </span>
       </div>
       <div className="mt-2 h-48 w-full">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height={192}>
           <BarChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="score" tickCount={11} />

--- a/apps/web/components/report/NextActions.tsx
+++ b/apps/web/components/report/NextActions.tsx
@@ -74,7 +74,7 @@ export function NextActions({ rows }: { rows: ReportT['next_actions'] }) {
         8 actions ordered by intent weight (amendment A1). Stacked counts per variant.
       </p>
       <div className="mt-4 h-72 w-full">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height={288}>
           <BarChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="variant" />

--- a/apps/web/components/report/PairedDots.tsx
+++ b/apps/web/components/report/PairedDots.tsx
@@ -100,7 +100,7 @@ export function PairedDots({ rows }: { rows: ReportT['paired_dots'] }) {
         One column per backstory. Red = A higher, green = B higher, gray = tie.
       </p>
       <div className="mt-4 h-64 w-full">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height={256}>
           <ScatterChart margin={{ top: 16, right: 16, bottom: 16, left: 0 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis dataKey="x" type="number" name="Backstory" tick={false} />

--- a/apps/web/components/report/ThemeBoard.tsx
+++ b/apps/web/components/report/ThemeBoard.tsx
@@ -50,7 +50,7 @@ function CategoryChart({
     >
       <h3 className="font-semibold capitalize text-gray-900">{category}</h3>
       <div className="mt-2 h-40 w-full">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height={160}>
           <BarChart layout="vertical" data={data} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis type="number" allowDecimals={false} />

--- a/apps/web/components/report/TierPicked.tsx
+++ b/apps/web/components/report/TierPicked.tsx
@@ -62,7 +62,7 @@ export function TierPicked({ rows }: { rows: ReportT['tier_picked'] }) {
         Horizontal stacked bar across <code>none → enterprise</code>.
       </p>
       <div className="mt-4 h-48 w-full">
-        <ResponsiveContainer width="100%" height="100%">
+        <ResponsiveContainer width="100%" height={192}>
           <BarChart layout="vertical" data={data} margin={{ top: 8, right: 8, bottom: 8, left: 8 }}>
             <CartesianGrid strokeDasharray="3 3" />
             <XAxis type="number" allowDecimals={false} />

--- a/apps/web/test/report-viz.test.tsx
+++ b/apps/web/test/report-viz.test.tsx
@@ -161,6 +161,88 @@ describe('§5.18 — report visualization', () => {
     expect(banner.textContent).toMatch(/low.power/i);
   });
 
+  it('F2 — charts render SVG content even when parent getBoundingClientRect returns 0 height (issue #78)', () => {
+    // Regression guard for the "empty chart on initial paint" bug (#78).
+    //
+    // Root cause: ResponsiveContainer with height="100%" measures its parent
+    // via ResizeObserver/getBoundingClientRect. On first paint in a Next.js
+    // SSR context the CSS hasn't applied yet, so the measured height is 0 —
+    // Recharts emits an SVG with height=0 and nothing is visible.
+    //
+    // The fix is to pass explicit pixel heights instead of "100%". This test
+    // verifies the fix by rendering each chart component with a parent whose
+    // getBoundingClientRect returns height=0, then asserting that the SVG
+    // element has a non-zero height attribute (meaning Recharts used the
+    // hard-coded prop, not the measured parent size).
+    //
+    // If any component still uses height="100%", its SVG will render with
+    // height=0 (or Recharts will skip rendering entirely) and this test fails.
+    const origGBCR = HTMLElement.prototype.getBoundingClientRect;
+    Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+      configurable: true,
+      value() {
+        return { width: 800, height: 0, top: 0, left: 0, right: 800, bottom: 0, x: 0, y: 0, toJSON: () => ({}) };
+      },
+    });
+
+    try {
+      // PairedDots — container uses h-64 = 256px
+      {
+        const { container } = render(<PairedDots rows={fixture.paired_dots} />);
+        const svgs = container.querySelectorAll('svg');
+        expect(svgs.length, 'PairedDots: expected at least one SVG element').toBeGreaterThan(0);
+        const svgHeight = Number(svgs[0]?.getAttribute('height') ?? 0);
+        expect(svgHeight, 'PairedDots: SVG height must be > 0 (not measured from zero-height parent)').toBeGreaterThan(0);
+        cleanup();
+      }
+
+      // Histograms — container uses h-48 = 192px per histogram
+      {
+        const { container } = render(<ReportView report={fixture} mode="public" />);
+        const histA = container.querySelector('[data-testid="histogram-A"] svg');
+        const histB = container.querySelector('[data-testid="histogram-B"] svg');
+        expect(histA, 'Histograms: histogram-A SVG must exist').toBeTruthy();
+        expect(histB, 'Histograms: histogram-B SVG must exist').toBeTruthy();
+        expect(
+          Number(histA?.getAttribute('height') ?? 0),
+          'Histograms: histogram-A SVG height must be > 0',
+        ).toBeGreaterThan(0);
+        expect(
+          Number(histB?.getAttribute('height') ?? 0),
+          'Histograms: histogram-B SVG height must be > 0',
+        ).toBeGreaterThan(0);
+        // NextActions — h-72 = 288px
+        const nextActions = container.querySelector('[data-testid="next-actions"] svg');
+        expect(nextActions, 'NextActions: SVG must exist').toBeTruthy();
+        expect(
+          Number(nextActions?.getAttribute('height') ?? 0),
+          'NextActions: SVG height must be > 0',
+        ).toBeGreaterThan(0);
+        // TierPicked — h-48 = 192px
+        const tierPicked = container.querySelector('[data-testid="tier-picked"] svg');
+        expect(tierPicked, 'TierPicked: SVG must exist').toBeTruthy();
+        expect(
+          Number(tierPicked?.getAttribute('height') ?? 0),
+          'TierPicked: SVG height must be > 0',
+        ).toBeGreaterThan(0);
+        // ThemeBoard — h-40 = 160px per category chart
+        const themeBlockers = container.querySelector('[data-testid="theme-blockers"] svg');
+        expect(themeBlockers, 'ThemeBoard/blockers: SVG must exist').toBeTruthy();
+        expect(
+          Number(themeBlockers?.getAttribute('height') ?? 0),
+          'ThemeBoard/blockers: SVG height must be > 0',
+        ).toBeGreaterThan(0);
+        cleanup();
+      }
+    } finally {
+      // Restore original getBoundingClientRect so subsequent tests are unaffected.
+      Object.defineProperty(HTMLElement.prototype, 'getBoundingClientRect', {
+        configurable: true,
+        value: origGBCR,
+      });
+    }
+  });
+
   it('F1 — paired-dot plot renders one SVG <line> connector per backstory (§5.18 #2)', () => {
     // Spec §5.18 #2: "Per-visitor dots showing A-score vs B-score with a
     // thin connecting segment." The connector is the entire point of the


### PR DESCRIPTION
## Root cause

`ResponsiveContainer` with `height="100%"` measures its parent div via `ResizeObserver`/`getBoundingClientRect` on mount. In the Next.js SSR + hydration cycle on `/r/[slug]`, the CSS for the flex/block container hasn't been applied yet at the moment of first paint, so the measured height is **0 px**. Recharts emits an SVG with `height=0` — visually an empty white space. Headline, persona cards, and section headers (plain HTML, no Recharts) render fine.

## Fix applied

**Candidate #1 — explicit pixel heights.** Replaced `height="100%"` with the pixel value matching each component's Tailwind container class:

| Component | Tailwind class | Old prop | New prop |
|---|---|---|---|
| `PairedDots` | `h-64` | `height="100%"` | `height={256}` |
| `Histograms` | `h-48` | `height="100%"` | `height={192}` |
| `NextActions` | `h-72` | `height="100%"` | `height={288}` |
| `TierPicked` | `h-48` | `height="100%"` | `height={192}` |
| `ThemeBoard` | `h-40` | `height="100%"` | `height={160}` |

With a hard-coded number, Recharts skips the DOM measurement entirely and renders the full SVG tree on first paint. The outer `h-{N}` Tailwind class on the wrapping div still constrains visual overflow correctly — the explicit height just removes the 0px-on-first-measure problem.

## Test evidence

**RED commit** (`f2643e5`): Added test `F2` in `apps/web/test/report-viz.test.tsx` that overrides `getBoundingClientRect` to return `height: 0` (simulating the browser's initial paint), then asserts each chart's SVG element has a non-zero `height` attribute. Fails against `main`:

```
FAIL  test/report-viz.test.tsx > §5.18 — report visualization > F2 — charts render SVG content even when parent getBoundingClientRect returns 0 height (issue #78)
AssertionError: PairedDots: expected at least one SVG element: expected 0 to be greater than 0
```

**GREEN commit** (`81c53ec`): After replacing `height="100%"` → explicit px values, all 9 tests pass:

```
 ✓ test/report-viz.test.tsx (9 tests) 296ms
 Test Files  1 passed (1)
      Tests  9 passed (9)
   Duration  1.10s
```

**Typecheck + lint:** both exit 0 (no output).

## Visual evidence (SSR HTML)

The server-rendered HTML from `WILLBUY_REPORT_FIXTURE=enabled bun run dev` on the fixed branch shows the `recharts-responsive-container` divs with explicit pixel heights baked in — the chart container size is known at the moment the browser first paints HTML, before any JS runs:

**Before fix** (on `main`):
```html
<div class="recharts-responsive-container" style="width:100%;height:100%;min-width:0"></div>
```
→ browser measures `height: 0` before CSS hydration → empty chart.

**After fix** (this branch):
```html
<!-- PairedDots -->
<div class="recharts-responsive-container" style="width:100%;height:256px;min-width:0"></div>
<!-- Histograms (each) -->
<div class="recharts-responsive-container" style="width:100%;height:192px;min-width:0"></div>
<!-- NextActions -->
<div class="recharts-responsive-container" style="width:100%;height:288px;min-width:0"></div>
<!-- TierPicked -->
<div class="recharts-responsive-container" style="width:100%;height:192px;min-width:0"></div>
<!-- ThemeBoard (each category) -->
<div class="recharts-responsive-container" style="width:100%;height:160px;min-width:0"></div>
```

Height is now a pixel value, not `"100%"`. Recharts renders the full SVG tree without any DOM measurement.

## Spec link

Implements fix for spec §5.18 chart rendering (#2 paired-delta dot plot, #3 histograms, #4 next-action bar, #5 tier-picked, #6 theme board).

## Public-repo audit

No secrets, IPs, or sensitive identifiers in the diff — only `height="100%"` → `height={N}` changes in 5 component files + the new test assertion.

Closes #78