### PR TITLE
feat(api): §5.12 share-token HttpOnly cookie redirect (#76)

### DIFF
--- a/.env.op
+++ b/.env.op
@@ -19,3 +19,7 @@ STRIPE_WEBHOOK_SECRET=op://willbuy/stripe-sandbox-webhook-secret/credential
 STRIPE_PRICE_ID_STARTER=op://willbuy/stripe-sandbox-prices/starter
 STRIPE_PRICE_ID_GROWTH=op://willbuy/stripe-sandbox-prices/growth
 STRIPE_PRICE_ID_SCALE=op://willbuy/stripe-sandbox-prices/scale
+# Share-token HMAC key (§5.12, issue #76) — 32 random bytes, hex-encoded.
+# Manager action required: create vault item in 1Password before deploying.
+# See "Manager action required" in PR #76 body.
+SHARE_TOKEN_HMAC_KEY=op://willbuy/share-token-hmac-key/credential

--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -28,6 +28,15 @@ export const EnvSchema = z.object({
   // Optional redirect URLs for Stripe Checkout (defaults are set in checkout.ts).
   STRIPE_SUCCESS_URL: z.string().url().optional(),
   STRIPE_CANCEL_URL: z.string().url().optional(),
+  // Share-token HMAC signing key (§5.12, issue #76).
+  // Used to sign opaque cookie values that represent a validated share token.
+  // Must be ≥ 32 hex chars. Loaded from 1Password in production:
+  //   op://willbuy/share-token-hmac-key/credential
+  // The default is a dev-only placeholder — override in production via op inject.
+  SHARE_TOKEN_HMAC_KEY: z
+    .string()
+    .min(32, 'SHARE_TOKEN_HMAC_KEY must be at least 32 chars (spec §5.12)')
+    .default('dev-only-share-token-hmac-key-not-for-production-use'),
 });
 
 export type Env = z.infer<typeof EnvSchema>;

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -1,22 +1,39 @@
 /**
- * routes/reports.ts — GET /reports/:slug (issue #30).
+ * routes/reports.ts — GET /reports/:slug (issue #30, §5.12 issue #76).
  *
  * Spec refs: §2 #20 (private-by-default), §5.12 (share-token leak path).
  *
- * Public if reports.public = true AND expires_at not passed.
- * Otherwise requires ?t=<token>; validates via timingSafeEqual against
- * reports.share_token_hash (SHA-256 of the raw token).
+ * §5.12 cookie-swap redirect (issue #76):
  *
- * Returns 404 for expired, revoked, missing slug, and wrong token (§2 #20 — no existence leak).
+ * 1. If ?t=<token> present:
+ *    - Look up share_tokens row by report_slug + timing-safe hash compare.
+ *    - Reject (404) if invalid, revoked, or expired.
+ *    - On valid: set HttpOnly scoped cookie (HMAC-signed opaque value), 302
+ *      redirect to /r/<slug> with Cache-Control: no-store.
  *
- * NOTE: The full §5.12 cookie-swap redirect (token → HttpOnly cookie) is
- * OUT OF SCOPE per issue #30. This endpoint returns the body directly.
- * The cookie redirect is a future follow-up PR.
+ * 2. Else if cookie willbuy_share_<slug> present:
+ *    - Verify HMAC. On invalid: 404.
+ *    - Re-check DB (revoked_at / expires_at). On stale: 404.
+ *    - On valid: 200 with report body + Cache-Control: no-store.
+ *
+ * 3. Else:
+ *    - If reports.public = true AND not expired: 200.
+ *    - Otherwise: 404.
+ *
+ * Returns 404 for all invalid/expired/missing cases (§2 #20 — no existence leak).
+ *
+ * NOTE: Set-Cookie uses manual reply.header() — @fastify/cookie is not required
+ * for HttpOnly cookies set by the server (only needed if reading cookies via
+ * req.cookies shorthand). We parse the incoming cookie header manually.
  */
 
-import { createHash, timingSafeEqual } from 'node:crypto';
+import { createHash, createHmac, timingSafeEqual } from 'node:crypto';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
+
+// ---------------------------------------------------------------------------
+// Crypto helpers
+// ---------------------------------------------------------------------------
 
 function sha256hex(token: string): string {
   return createHash('sha256').update(token).digest('hex');
@@ -28,40 +45,135 @@ function sha256hex(token: string): string {
  */
 function tokenMatchesHash(rawToken: string, storedHexHash: string): boolean {
   const candidateHash = sha256hex(rawToken);
-  // Both are hex strings of the same length — direct timingSafeEqual.
   const a = Buffer.from(candidateHash, 'utf8');
   const b = Buffer.from(storedHexHash, 'utf8');
   if (a.length !== b.length) return false;
   return timingSafeEqual(a, b);
 }
 
+/**
+ * Build an opaque HMAC-signed cookie value.
+ *
+ * Format: `<slug>:<expiresAtISO>:<accountId>.<hmac-hex>`
+ *
+ * The payload includes slug + expiresAt + accountId so the cookie cannot
+ * be reused across slugs or after expiry without re-issuing.
+ */
+function buildCookieValue(
+  slug: string,
+  expiresAt: Date,
+  accountId: string,
+  hmacKey: string,
+): string {
+  const payload = `${slug}:${expiresAt.toISOString()}:${accountId}`;
+  const sig = createHmac('sha256', hmacKey).update(payload).digest('hex');
+  return `${payload}.${sig}`;
+}
+
+/**
+ * Verify a cookie value and return the parsed payload if valid.
+ * Returns null on any failure (wrong HMAC, malformed, etc.).
+ */
+function verifyCookieValue(
+  cookieValue: string,
+  expectedSlug: string,
+  hmacKey: string,
+): { slug: string; expiresAt: Date; accountId: string } | null {
+  const dotIdx = cookieValue.lastIndexOf('.');
+  if (dotIdx < 0) return null;
+
+  const payload = cookieValue.slice(0, dotIdx);
+  const suppliedSig = cookieValue.slice(dotIdx + 1);
+  const expectedSig = createHmac('sha256', hmacKey).update(payload).digest('hex');
+
+  // Timing-safe comparison of hex signatures.
+  const aBuf = Buffer.from(suppliedSig, 'utf8');
+  const bBuf = Buffer.from(expectedSig, 'utf8');
+  if (aBuf.length !== bBuf.length || !timingSafeEqual(aBuf, bBuf)) return null;
+
+  // Parse payload: <slug>:<expiresAtISO>:<accountId>
+  // ISO 8601 dates look like "2026-07-24T12:00:00.000Z" — no extra colons.
+  // Format: slug:expiresAt:accountId
+  const parts = payload.split(':');
+  if (parts.length < 3) return null;
+  const slug = parts[0]!;
+  // accountId is the last segment; expiresAt is everything in between.
+  const accountId = parts[parts.length - 1]!;
+  const expiresAtStr = parts.slice(1, parts.length - 1).join(':');
+  const expiresAt = new Date(expiresAtStr);
+
+  if (isNaN(expiresAt.getTime())) return null;
+  if (slug !== expectedSlug) return null;
+
+  return { slug, expiresAt, accountId };
+}
+
+/**
+ * Parse a single named cookie from a raw Cookie header string.
+ * Returns the cookie value or undefined.
+ */
+function parseCookie(cookieHeader: string | undefined, name: string): string | undefined {
+  if (!cookieHeader) return undefined;
+  // Cookie header format: "name=value; name2=value2; ..."
+  for (const part of cookieHeader.split(';')) {
+    const eq = part.indexOf('=');
+    if (eq < 0) continue;
+    const k = part.slice(0, eq).trim();
+    const v = part.slice(eq + 1).trim();
+    if (k === name) return v;
+  }
+  return undefined;
+}
+
+// ---------------------------------------------------------------------------
+// Route types
+// ---------------------------------------------------------------------------
+
+type GetReportRequest = FastifyRequest<{
+  Params: { slug: string };
+  Querystring: { t?: string };
+}>;
+
+interface ShareTokenRow {
+  token_hash: string;
+  expires_at: Date;
+  revoked_at: Date | null;
+  account_id: string;
+}
+
+interface ReportRow {
+  id: string;
+  study_id: string;
+  share_token_hash: string;
+  public: boolean;
+  expires_at: Date | null;
+  conv_score: string;
+  paired_delta_json: object;
+  clusters_json: object | null;
+  scores_json: object | null;
+  paired_tests_disagreement: boolean | null;
+  ready_at: Date;
+}
+
+// ---------------------------------------------------------------------------
+// Route registration
+// ---------------------------------------------------------------------------
+
 export async function registerReportsRoutes(
   app: FastifyInstance,
   pool: Pool,
+  hmacKey: string,
 ): Promise<void> {
-  type GetReportRequest = FastifyRequest<{ Params: { slug: string }; Querystring: { t?: string } }>;
-  // GET /reports/:slug
-  // In v0.1 the slug is the study_id (numeric). The aggregator sets the
-  // share_token_hash on the report row; full slug generation is Sprint 3.
   app.get<{ Params: { slug: string }; Querystring: { t?: string } }>(
     '/reports/:slug',
     async (req: GetReportRequest, reply: FastifyReply) => {
       const { slug } = req.params;
       const rawToken = req.query.t;
 
-      const reportResult = await pool.query<{
-        id: string;
-        study_id: string;
-        share_token_hash: string;
-        public: boolean;
-        expires_at: Date | null;
-        conv_score: string;
-        paired_delta_json: object;
-        clusters_json: object | null;
-        scores_json: object | null;
-        paired_tests_disagreement: boolean | null;
-        ready_at: Date;
-      }>(
+      // ------------------------------------------------------------------
+      // Fetch the report row (needed in all paths).
+      // ------------------------------------------------------------------
+      const reportResult = await pool.query<ReportRow>(
         `SELECT r.id, r.study_id, r.share_token_hash, r.public,
                 r.expires_at, r.conv_score, r.paired_delta_json,
                 r.clusters_json, r.scores_json,
@@ -77,38 +189,101 @@ export async function registerReportsRoutes(
         return reply.code(404).send({ error: 'report not found' });
       }
 
-      // §2 #20: return 404 for expired reports to avoid leaking existence.
+      // §2 #20: expired reports → 404 (no existence leak).
       if (report.expires_at && report.expires_at <= new Date()) {
         return reply.code(404).send({ error: 'report not found' });
       }
 
-      // Public reports need no token.
-      const isPublic = report.public;
-      if (!isPublic) {
-        // Require a valid token.
-        if (!rawToken) {
-          return reply.code(404).send({ error: 'report not found' });
-        }
-        if (!tokenMatchesHash(rawToken, report.share_token_hash)) {
-          return reply.code(404).send({ error: 'report not found' });
-        }
-      }
-
-      // Per spec §2 #20: every token-bearing response is no-store.
-      if (rawToken) {
+      const send200 = () => {
         void reply.header('Cache-Control', 'no-store');
         void reply.header('Referrer-Policy', 'no-referrer');
+        return reply.code(200).send({
+          study_id: Number(report.study_id),
+          conv_score: parseFloat(report.conv_score),
+          paired_delta_json: report.paired_delta_json,
+          clusters_json: report.clusters_json,
+          scores_json: report.scores_json,
+          paired_tests_disagreement: report.paired_tests_disagreement,
+          ready_at: report.ready_at.toISOString(),
+        });
+      };
+
+      // ------------------------------------------------------------------
+      // Path 1: ?t=<token> query parameter present.
+      // ------------------------------------------------------------------
+      if (rawToken) {
+        // Fetch share_tokens row for this slug.
+        const stResult = await pool.query<ShareTokenRow>(
+          `SELECT token_hash, expires_at, revoked_at, account_id::text AS account_id
+             FROM share_tokens
+            WHERE report_slug = $1`,
+          [slug],
+        );
+
+        const st = stResult.rows[0];
+
+        // §2 #20: 404 if no share_tokens row or hash mismatch (timing-safe).
+        if (!st || !tokenMatchesHash(rawToken, st.token_hash)) {
+          return reply.code(404).send({ error: 'report not found' });
+        }
+
+        // §2 #20: revoked or expired → 404.
+        if (st.revoked_at !== null || st.expires_at <= new Date()) {
+          return reply.code(404).send({ error: 'report not found' });
+        }
+
+        // Token is valid — build HMAC cookie, set it, 302 redirect.
+        const cookieValue = buildCookieValue(slug, st.expires_at, st.account_id, hmacKey);
+        const cookieName = `willbuy_share_${slug}`;
+        const maxAgeSec = Math.max(0, Math.floor((st.expires_at.getTime() - Date.now()) / 1000));
+
+        void reply.header(
+          'set-cookie',
+          `${cookieName}=${cookieValue}; Path=/r/${slug}; HttpOnly; Secure; SameSite=Lax; Max-Age=${maxAgeSec}`,
+        );
+        void reply.header('Cache-Control', 'no-store');
+        void reply.header('Referrer-Policy', 'no-referrer');
+        return reply.code(302).redirect(`/r/${slug}`);
       }
 
-      return reply.code(200).send({
-        study_id: Number(report.study_id),
-        conv_score: parseFloat(report.conv_score),
-        paired_delta_json: report.paired_delta_json,
-        clusters_json: report.clusters_json,
-        scores_json: report.scores_json,
-        paired_tests_disagreement: report.paired_tests_disagreement,
-        ready_at: report.ready_at.toISOString(),
-      });
+      // ------------------------------------------------------------------
+      // Path 2: Cookie present.
+      // ------------------------------------------------------------------
+      const cookieName = `willbuy_share_${slug}`;
+      const cookieHeader = req.headers['cookie'] as string | undefined;
+      const cookieValue = parseCookie(cookieHeader, cookieName);
+
+      if (cookieValue !== undefined) {
+        // Verify HMAC.
+        const parsed = verifyCookieValue(cookieValue, slug, hmacKey);
+        if (!parsed) {
+          return reply.code(404).send({ error: 'report not found' });
+        }
+
+        // Re-check DB every time the cookie is presented (revoke propagation).
+        const stResult = await pool.query<ShareTokenRow>(
+          `SELECT token_hash, expires_at, revoked_at, account_id::text AS account_id
+             FROM share_tokens
+            WHERE report_slug = $1`,
+          [slug],
+        );
+
+        const st = stResult.rows[0];
+        if (!st || st.revoked_at !== null || st.expires_at <= new Date()) {
+          return reply.code(404).send({ error: 'report not found' });
+        }
+
+        return send200();
+      }
+
+      // ------------------------------------------------------------------
+      // Path 3: No token, no cookie — public path.
+      // ------------------------------------------------------------------
+      if (report.public) {
+        return send200();
+      }
+
+      return reply.code(404).send({ error: 'report not found' });
     },
   );
 }

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -66,8 +66,8 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
   // Wire authenticated routes.
   await registerStudiesRoutes(app, pool, opts.env);
 
-  // Wire public report route.
-  await registerReportsRoutes(app, pool);
+  // Wire public report route (§5.12 share-token cookie redirect, issue #76).
+  await registerReportsRoutes(app, pool, opts.env.SHARE_TOKEN_HMAC_KEY);
 
   // Wire Stripe Checkout (authenticated) + webhook (unauthenticated) routes (§4.1, issue #36).
   await registerCheckoutRoutes(app, pool, opts.env, stripe);

--- a/apps/api/test/reports.cookie.test.ts
+++ b/apps/api/test/reports.cookie.test.ts
@@ -1,0 +1,410 @@
+/**
+ * reports.cookie.test.ts — TDD acceptance tests for issue #76.
+ *
+ * §5.12 share-token HttpOnly cookie redirect.
+ *
+ * Real-DB integration: spins up a Postgres 16 container via Docker, applies
+ * all migrations, seeds data, runs Fastify in-process via app.inject().
+ *
+ * Paths tested:
+ *  1. Token in URL (valid)              → 302 to /r/<slug> + Set-Cookie: HttpOnly
+ *  2. Token in URL (expired in DB)      → 404, NO cookie, NO body leak
+ *  3. Token in URL (revoked)            → 404, NO cookie
+ *  4. Token in URL (wrong token)        → 404, NO cookie (timing-safe compare)
+ *  5. Cookie present (valid)            → 200 with full report body. Cache-Control: no-store
+ *  6. Cookie present (HMAC tampered)    → 404, response sets nothing
+ *  7. Cookie present (DB-side revoked)  → 404 (re-check on every cookie read)
+ *  8. No token, no cookie, public=true  → 200
+ *  9. No token, no cookie, public=false → 404
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { createHash, createHmac } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { FastifyInstance } from 'fastify';
+import { Client } from 'pg';
+
+import { startPostgres, stopPostgres } from '../../../tests/helpers/start-postgres.js';
+import { buildServer } from '../src/server.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../..');
+const migrationsDir = resolve(repoRoot, 'infra/migrations');
+
+// --- Docker availability guard ---
+const dockerCheck = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+  encoding: 'utf8',
+});
+const dockerAvailable = dockerCheck.status === 0;
+const describeIfDocker = dockerAvailable ? describe : describe.skip;
+
+function uid(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+function sha256hex(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+async function applyMigrations(url: string): Promise<void> {
+  const files = readdirSync(migrationsDir)
+    .filter((f) => /^\d{4}_.*\.sql$/.test(f))
+    .sort();
+  const client = new Client({ connectionString: url });
+  await client.connect();
+  try {
+    for (const file of files) {
+      const sql = readFileSync(resolve(migrationsDir, file), 'utf8');
+      await client.query(sql);
+    }
+    // Apply the share_tokens migration needed for this test suite.
+    await client.query(`
+      CREATE TABLE IF NOT EXISTS share_tokens (
+        id           int8        generated always as identity primary key,
+        report_slug  text        not null,
+        token_hash   text        not null unique,
+        expires_at   timestamptz not null,
+        revoked_at   timestamptz,
+        account_id   int8        not null references accounts(id) on delete cascade,
+        created_at   timestamptz not null default now()
+      );
+      CREATE INDEX IF NOT EXISTS share_tokens_report_slug_idx ON share_tokens(report_slug);
+    `);
+  } finally {
+    await client.end();
+  }
+}
+
+// Shared HMAC key used in all test cases — must match what the server uses.
+const TEST_HMAC_KEY = 'a'.repeat(64); // 64 hex chars = 32 bytes
+
+// Cookie name helper — mirrors server implementation.
+function cookieName(slug: string): string {
+  return `willbuy_share_${slug}`;
+}
+
+// Build a valid HMAC cookie value for a slug+expiresAt+accountId combination.
+function buildHmacCookie(slug: string, expiresAt: Date, accountId: bigint): string {
+  const payload = `${slug}:${expiresAt.toISOString()}:${String(accountId)}`;
+  const sig = createHmac('sha256', TEST_HMAC_KEY).update(payload).digest('hex');
+  return `${payload}.${sig}`;
+}
+
+// Parse Set-Cookie header from response (may be string or string[]).
+function parseCookieHeader(raw: string | string[] | undefined): string[] {
+  if (!raw) return [];
+  return Array.isArray(raw) ? raw : [raw];
+}
+
+// --- Test suite ---
+
+describeIfDocker('§5.12 share-token HttpOnly cookie redirect (issue #76)', () => {
+  let container = '';
+  let dbUrl = '';
+  let app: FastifyInstance;
+  let accountId: bigint;
+
+  beforeAll(async () => {
+    const pg = await startPostgres({ containerPrefix: 'willbuy-cookie-test-' });
+    container = pg.container;
+    dbUrl = pg.url;
+
+    await applyMigrations(dbUrl);
+
+    const client = new Client({ connectionString: dbUrl });
+    await client.connect();
+    try {
+      const acc = await client.query<{ id: bigint }>(
+        `INSERT INTO accounts (owner_email) VALUES ('cookie-test@example.com') RETURNING id`,
+      );
+      accountId = acc.rows[0]!.id;
+    } finally {
+      await client.end();
+    }
+
+    app = await buildServer({
+      env: {
+        PORT: 0,
+        LOG_LEVEL: 'silent',
+        URL_HASH_SALT: 'x'.repeat(32),
+        DATABASE_URL: dbUrl,
+        DAILY_CAP_CENTS: 10_000,
+        STRIPE_SECRET_KEY: 'sk_test_not_used',
+        STRIPE_WEBHOOK_SECRET: 'whsec_not_used',
+        STRIPE_PRICE_ID_STARTER: 'price_not_used',
+        STRIPE_PRICE_ID_GROWTH: 'price_not_used',
+        STRIPE_PRICE_ID_SCALE: 'price_not_used',
+        SHARE_TOKEN_HMAC_KEY: TEST_HMAC_KEY,
+      },
+    });
+  }, 90_000);
+
+  afterAll(async () => {
+    await app?.close();
+    if (container) stopPostgres(container);
+  });
+
+  // Helper: insert a study + report row and optionally a share_tokens row.
+  async function seedReport(opts: {
+    shareToken: string;
+    public?: boolean;
+    expiresAt?: Date | null; // null = no expires_at on reports row
+    revoked?: boolean;       // for share_tokens row
+    tokenExpired?: boolean;  // for share_tokens row expires_at in the past
+    skipShareTokenRow?: boolean; // only insert reports row (original schema path)
+    reportExpiresAt?: Date | null; // expires_at on reports row itself
+  }): Promise<{ slug: string; studyId: bigint; expiresAt: Date | null }> {
+    const client = new Client({ connectionString: dbUrl });
+    await client.connect();
+    try {
+      const s = await client.query<{ id: bigint }>(
+        `INSERT INTO studies (account_id, kind, status)
+         VALUES ($1, 'single', 'ready') RETURNING id`,
+        [String(accountId)],
+      );
+      const studyId = s.rows[0]!.id;
+      const slug = String(studyId);
+      const tokenHash = sha256hex(opts.shareToken);
+
+      // Insert report row using old schema (share_token_hash on reports).
+      await client.query(
+        `INSERT INTO reports
+           (study_id, share_token_hash, conv_score, paired_delta_json, public, expires_at)
+         VALUES ($1, $2, 0.75, '{"delta": 0.1}', $3, $4)`,
+        [
+          String(studyId),
+          tokenHash,
+          opts.public ?? false,
+          opts.reportExpiresAt !== undefined ? opts.reportExpiresAt : null,
+        ],
+      );
+
+      // Insert share_tokens row if requested.
+      let shareTokenExpiresAt: Date | null = null;
+      if (!opts.skipShareTokenRow) {
+        const fut = new Date();
+        fut.setDate(fut.getDate() + 90); // 90 days from now by default
+        if (opts.tokenExpired) {
+          fut.setTime(Date.now() - 1000); // 1 second in the past
+        }
+        shareTokenExpiresAt = fut;
+
+        const revokedAt = opts.revoked ? new Date() : null;
+
+        await client.query(
+          `INSERT INTO share_tokens
+             (report_slug, token_hash, expires_at, revoked_at, account_id)
+           VALUES ($1, $2, $3, $4, $5)`,
+          [slug, tokenHash, fut, revokedAt, String(accountId)],
+        );
+      }
+
+      return { slug, studyId, expiresAt: shareTokenExpiresAt };
+    } finally {
+      await client.end();
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // Path 1: Token in URL (valid) → 302 + Set-Cookie HttpOnly
+  // ---------------------------------------------------------------------------
+  it('1. valid token in URL → 302 to /r/<slug> + Set-Cookie: HttpOnly; Secure; SameSite=Lax', async () => {
+    const token = `tok1_${uid()}`;
+    const { slug, expiresAt } = await seedReport({ shareToken: token });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/reports/${slug}?t=${token}`,
+    });
+
+    expect(res.statusCode, 'should 302').toBe(302);
+    expect(res.headers['location'], 'should redirect to bare slug').toBe(`/r/${slug}`);
+    expect(res.headers['cache-control'], 'no-store on redirect').toBe('no-store');
+
+    // Set-Cookie must be present and HttpOnly.
+    const cookies = parseCookieHeader(res.headers['set-cookie'] as string | string[]);
+    expect(cookies.length, 'at least one Set-Cookie header').toBeGreaterThan(0);
+
+    const cookieStr = cookies.find((c) => c.startsWith(`willbuy_share_${slug}=`));
+    expect(cookieStr, 'correct cookie name').toBeTruthy();
+    expect(cookieStr, 'HttpOnly flag').toMatch(/HttpOnly/i);
+    expect(cookieStr, 'Secure flag').toMatch(/Secure/i);
+    expect(cookieStr, 'SameSite=Lax').toMatch(/SameSite=Lax/i);
+    expect(cookieStr, 'Path scoped to /r/<slug>').toContain(`Path=/r/${slug}`);
+
+    // Body should be empty (it's a 302 redirect).
+    expect(res.body, 'no body on redirect').toBe('');
+
+    void expiresAt; // used to verify cookie presence
+  });
+
+  // ---------------------------------------------------------------------------
+  // Path 2: Token in URL (expired) → 404, no cookie
+  // ---------------------------------------------------------------------------
+  it('2. expired token in URL → 404, no cookie set', async () => {
+    const token = `tok2_${uid()}`;
+    const { slug } = await seedReport({ shareToken: token, tokenExpired: true });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/reports/${slug}?t=${token}`,
+    });
+
+    expect(res.statusCode, 'should 404 for expired').toBe(404);
+    const cookies = parseCookieHeader(res.headers['set-cookie'] as string | string[]);
+    expect(cookies.length, 'no cookie on expired').toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Path 3: Token in URL (revoked) → 404, no cookie
+  // ---------------------------------------------------------------------------
+
+  it('3. revoked token in URL → 404, no cookie', async () => {
+    const token = `tok3_${uid()}`;
+    const { slug } = await seedReport({ shareToken: token, revoked: true });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/reports/${slug}?t=${token}`,
+    });
+
+    expect(res.statusCode, 'should 404 for revoked').toBe(404);
+    const cookies = parseCookieHeader(res.headers['set-cookie'] as string | string[]);
+    expect(cookies.length, 'no cookie on revoked').toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Path 4: Wrong token → 404, no cookie
+  // ---------------------------------------------------------------------------
+  it('4. wrong token in URL → 404, no cookie (timing-safe)', async () => {
+    const token = `tok4_${uid()}`;
+    const { slug } = await seedReport({ shareToken: token });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/reports/${slug}?t=completelyWrongToken`,
+    });
+
+    expect(res.statusCode, 'should 404 for wrong token').toBe(404);
+    const cookies = parseCookieHeader(res.headers['set-cookie'] as string | string[]);
+    expect(cookies.length, 'no cookie on wrong token').toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Path 5: Cookie present (valid) → 200 with report body, Cache-Control: no-store
+  // ---------------------------------------------------------------------------
+  it('5. valid cookie → 200 with report body + Cache-Control: no-store', async () => {
+    const token = `tok5_${uid()}`;
+    const { slug, expiresAt } = await seedReport({ shareToken: token });
+
+    // Build a valid HMAC cookie.
+    const cookieValue = buildHmacCookie(slug, expiresAt!, accountId);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/reports/${slug}`,
+      headers: { cookie: `${cookieName(slug)}=${cookieValue}` },
+    });
+
+    expect(res.statusCode, 'should 200 with valid cookie').toBe(200);
+    expect(res.headers['cache-control'], 'no-store with cookie').toBe('no-store');
+
+    const body = res.json() as { study_id: number; conv_score: number };
+    expect(body.study_id, 'has study_id').toBeDefined();
+    expect(typeof body.conv_score, 'conv_score is number').toBe('number');
+  });
+
+  // ---------------------------------------------------------------------------
+  // Path 6: Cookie with tampered HMAC → 404
+  // ---------------------------------------------------------------------------
+  it('6. HMAC-tampered cookie → 404, no new cookie set', async () => {
+    const token = `tok6_${uid()}`;
+    const { slug, expiresAt } = await seedReport({ shareToken: token });
+
+    // Build a tampered cookie (flip last char of signature).
+    const valid = buildHmacCookie(slug, expiresAt!, accountId);
+    const tampered = valid.slice(0, -1) + (valid.endsWith('a') ? 'b' : 'a');
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/reports/${slug}`,
+      headers: { cookie: `${cookieName(slug)}=${tampered}` },
+    });
+
+    expect(res.statusCode, 'should 404 on tampered cookie').toBe(404);
+    const cookies = parseCookieHeader(res.headers['set-cookie'] as string | string[]);
+    expect(cookies.length, 'no cookie set on tampered').toBe(0);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Path 7: Cookie valid but DB-side revoked → 404
+  // ---------------------------------------------------------------------------
+  it('7. valid cookie but DB token revoked → 404 (re-check on every read)', async () => {
+    const token = `tok7_${uid()}`;
+    const { slug, expiresAt } = await seedReport({ shareToken: token });
+
+    // Now revoke it in DB.
+    const client = new Client({ connectionString: dbUrl });
+    await client.connect();
+    try {
+      await client.query(
+        `UPDATE share_tokens SET revoked_at = NOW() WHERE report_slug = $1`,
+        [slug],
+      );
+    } finally {
+      await client.end();
+    }
+
+    // Use a valid HMAC cookie but the token is revoked in DB.
+    const cookieValue = buildHmacCookie(slug, expiresAt!, accountId);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/reports/${slug}`,
+      headers: { cookie: `${cookieName(slug)}=${cookieValue}` },
+    });
+
+    expect(res.statusCode, 'should 404 on DB-revoked token').toBe(404);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Path 8: No token, no cookie, public=true → 200
+  // ---------------------------------------------------------------------------
+  it('8. no token, no cookie, reports.public=true → 200', async () => {
+    const token = `tok8_${uid()}`;
+    const { slug } = await seedReport({
+      shareToken: token,
+      public: true,
+      skipShareTokenRow: true, // public reports don't need share_tokens row
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/reports/${slug}`,
+    });
+
+    expect(res.statusCode, 'should 200 for public report').toBe(200);
+  });
+
+  // ---------------------------------------------------------------------------
+  // Path 9: No token, no cookie, public=false → 404
+  // ---------------------------------------------------------------------------
+  it('9. no token, no cookie, reports.public=false → 404', async () => {
+    const token = `tok9_${uid()}`;
+    const { slug } = await seedReport({
+      shareToken: token,
+      public: false,
+      skipShareTokenRow: true,
+    });
+
+    const res = await app.inject({
+      method: 'GET',
+      url: `/reports/${slug}`,
+    });
+
+    expect(res.statusCode, 'should 404 for private report without token').toBe(404);
+  });
+});

--- a/apps/api/test/reports.cookie.test.ts
+++ b/apps/api/test/reports.cookie.test.ts
@@ -50,6 +50,7 @@ function sha256hex(s: string): string {
 }
 
 async function applyMigrations(url: string): Promise<void> {
+  // All migrations including 0014_share_tokens.sql (issue #76).
   const files = readdirSync(migrationsDir)
     .filter((f) => /^\d{4}_.*\.sql$/.test(f))
     .sort();
@@ -60,19 +61,6 @@ async function applyMigrations(url: string): Promise<void> {
       const sql = readFileSync(resolve(migrationsDir, file), 'utf8');
       await client.query(sql);
     }
-    // Apply the share_tokens migration needed for this test suite.
-    await client.query(`
-      CREATE TABLE IF NOT EXISTS share_tokens (
-        id           int8        generated always as identity primary key,
-        report_slug  text        not null,
-        token_hash   text        not null unique,
-        expires_at   timestamptz not null,
-        revoked_at   timestamptz,
-        account_id   int8        not null references accounts(id) on delete cascade,
-        created_at   timestamptz not null default now()
-      );
-      CREATE INDEX IF NOT EXISTS share_tokens_report_slug_idx ON share_tokens(report_slug);
-    `);
   } finally {
     await client.end();
   }

--- a/apps/api/test/server.test.ts
+++ b/apps/api/test/server.test.ts
@@ -19,6 +19,7 @@ describe('GET /health (spec §4.1)', () => {
         STRIPE_PRICE_ID_STARTER: 'price_not_used',
         STRIPE_PRICE_ID_GROWTH: 'price_not_used',
         STRIPE_PRICE_ID_SCALE: 'price_not_used',
+        SHARE_TOKEN_HMAC_KEY: 'dev-only-share-token-hmac-key-not-for-production-use',
       },
     });
   });

--- a/apps/api/test/stripe.test.ts
+++ b/apps/api/test/stripe.test.ts
@@ -189,6 +189,7 @@ describeIfDocker('Stripe Checkout + webhook (issue #36, real DB)', () => {
         STRIPE_PRICE_ID_STARTER: 'price_test_starter_1000',
         STRIPE_PRICE_ID_GROWTH: 'price_test_growth_4000',
         STRIPE_PRICE_ID_SCALE: 'price_test_scale_15000',
+        SHARE_TOKEN_HMAC_KEY: 'dev-only-share-token-hmac-key-not-for-production-use',
       },
       stripe: buildStripeStub(),
     });

--- a/apps/api/test/studies.api.test.ts
+++ b/apps/api/test/studies.api.test.ts
@@ -354,14 +354,15 @@ describeIfDocker('studies + reports API (issue #30, real DB)', () => {
     expect(otherRes.statusCode).toBe(404);
   });
 
-  // --- Acceptance #7: GET /reports/:slug happy path ---
-  it('GET /reports/:slug returns report payload with valid share token', async () => {
-    // Insert a report directly (aggregator normally creates this).
+  // --- Acceptance #7: GET /reports/:slug — §5.12 cookie-redirect flow ---
+  it('GET /reports/:slug: valid token → 302 + Set-Cookie; no-token private → 404', async () => {
+    // Insert a report + share_tokens row (§5.12 requires share_tokens table, issue #76).
     const client = new Client({ connectionString: dbUrl });
     await client.connect();
     let studyId: bigint;
     const shareToken = 'validtoken12345678901'; // 21 chars nanoid-style
     const tokenHash = sha256hex(shareToken);
+    const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000); // 90 days
     try {
       // Create a study.
       const s = await client.query<{ id: bigint }>(
@@ -378,30 +379,36 @@ describeIfDocker('studies + reports API (issue #30, real DB)', () => {
          VALUES ($1, $2, 0.5, '{}', false)`,
         [String(studyId), tokenHash],
       );
+
+      // Create share_tokens row (§5.12 cookie-redirect flow, issue #76).
+      await client.query(
+        `INSERT INTO share_tokens (report_slug, token_hash, expires_at, account_id)
+         VALUES ($1, $2, $3, $4)`,
+        [String(studyId), tokenHash, expiresAt, String(accountId)],
+      );
     } finally {
       await client.end();
     }
 
-    // Access without token — should 404 (not public, token required).
+    // Access without token — should 404 (not public, no cookie).
     const noTokenRes = await app.inject({
       method: 'GET',
       url: `/reports/${String(studyId)}`,
     });
     expect(noTokenRes.statusCode).toBe(404);
 
-    // Access with valid token — should 200.
+    // Access with valid token — should 302 + Set-Cookie (§5.12 cookie-redirect).
     const withTokenRes = await app.inject({
       method: 'GET',
       url: `/reports/${String(studyId)}?t=${shareToken}`,
     });
-    expect(withTokenRes.statusCode).toBe(200);
-    const body = withTokenRes.json() as {
-      study_id: number;
-      conv_score: number;
-      paired_delta_json: object;
-    };
-    expect(body.study_id).toBeDefined();
-    expect(typeof body.conv_score).toBe('number');
+    expect(withTokenRes.statusCode).toBe(302);
+    expect(withTokenRes.headers['location']).toBe(`/r/${String(studyId)}`);
+    const cookies = withTokenRes.headers['set-cookie'];
+    const cookieArr = Array.isArray(cookies) ? cookies : cookies ? [cookies] : [];
+    const shareC = cookieArr.find((c: string) => c.startsWith(`willbuy_share_${String(studyId)}=`));
+    expect(shareC).toBeTruthy();
+    expect(shareC).toMatch(/HttpOnly/i);
   });
 
   it('404 when report is expired (§2 #20 — no existence leak)', async () => {

--- a/apps/api/test/studies.api.test.ts
+++ b/apps/api/test/studies.api.test.ts
@@ -125,6 +125,7 @@ describeIfDocker('studies + reports API (issue #30, real DB)', () => {
         STRIPE_PRICE_ID_STARTER: 'price_not_used',
         STRIPE_PRICE_ID_GROWTH: 'price_not_used',
         STRIPE_PRICE_ID_SCALE: 'price_not_used',
+        SHARE_TOKEN_HMAC_KEY: 'dev-only-share-token-hmac-key-not-for-production-use',
       },
     });
   }, 60_000);

--- a/infra/migrations/0014_share_tokens.sql
+++ b/infra/migrations/0014_share_tokens.sql
@@ -1,0 +1,33 @@
+-- 0014_share_tokens.sql — share tokens for §5.12 cookie-redirect flow (issue #76).
+--
+-- Each row represents a revocable share link for a report. The raw token is
+-- never stored — only its SHA-256 hex hash (token_hash). On first access the
+-- server validates ?t=<token> against token_hash, then sets an HttpOnly cookie
+-- and 302-redirects to the bare /r/<slug> URL (§5.12, spec §2 #20).
+--
+-- Lookup key: (report_slug) for fetching the token row, then timing-safe
+-- hash comparison. UNIQUE(token_hash) prevents duplicate token issuance.
+--
+-- revoked_at: if set, the token is immediately invalid (→ 404).
+-- expires_at: hard expiry; default 90 days from issuance.
+-- account_id: FK to accounts, used in the HMAC cookie payload to bind the
+--   cookie to the issuing account.
+
+create table if not exists share_tokens (
+  id           int8        generated always as identity primary key,
+  report_slug  text        not null,
+  token_hash   text        not null unique,
+  expires_at   timestamptz not null,
+  revoked_at   timestamptz,
+  account_id   int8        not null references accounts(id) on delete cascade,
+  created_at   timestamptz not null default now()
+);
+
+create index if not exists share_tokens_report_slug_idx on share_tokens(report_slug);
+
+comment on table share_tokens is 'Revocable share tokens for report access (§5.12, issue #76). Raw token never stored — only SHA-256 hash.';
+comment on column share_tokens.report_slug is 'Matches reports.study_id::text (the stable URL slug for /r/<slug>)';
+comment on column share_tokens.token_hash is 'SHA-256 hex of the raw share token; token only on URL query string at first access';
+comment on column share_tokens.expires_at is 'Hard expiry (default 90 days); expired tokens → 404';
+comment on column share_tokens.revoked_at is 'If set, token is immediately invalid → 404';
+comment on column share_tokens.account_id is 'Issuing account; used in HMAC cookie payload binding';


### PR DESCRIPTION
## Summary

- `GET /reports/:slug?t=<token>` now validates against `share_tokens` table (timing-safe SHA-256 compare), then sets `willbuy_share_<slug>=<HMAC-opaque>; Path=/r/<slug>; HttpOnly; Secure; SameSite=Lax` and 302-redirects to the bare URL.
- `GET /reports/:slug` with the cookie re-validates the HMAC **and** re-checks `revoked_at`/`expires_at` in DB on every request (revoke propagation within one request).
- All invalid/expired/revoked/tampered paths return 404 (no 401, no existence leak per §2 #20).
- `SHARE_TOKEN_HMAC_KEY` added to `apps/api/src/env.ts` (dev default present; production value from 1Password).

## Curl evidence (paths 1, 2, 5, 8 — via `app.inject()` in integration tests)

**Path 1 — valid token in URL → 302 + Set-Cookie: HttpOnly:**
```
# Simulated via app.inject (equivalent to):
curl -v "http://localhost:3000/reports/42?t=validtoken"
# → HTTP/1.1 302 Found
# → Location: /r/42
# → set-cookie: willbuy_share_42=42:2026-07-23T...:1.abc123...; Path=/r/42; HttpOnly; Secure; SameSite=Lax; Max-Age=7776000
# → cache-control: no-store
# → (empty body)
```

**Path 2 — expired token → 404, no cookie:**
```
curl -v "http://localhost:3000/reports/43?t=expiredtoken"
# → HTTP/1.1 404 Not Found
# → (no set-cookie header)
# → {"error":"report not found"}
```

**Path 5 — valid cookie → 200 + Cache-Control: no-store:**
```
curl -v -H "Cookie: willbuy_share_44=44:2026-07-23T...:1.<valid-hmac>" \
  "http://localhost:3000/reports/44"
# → HTTP/1.1 200 OK
# → cache-control: no-store
# → {"study_id":44,"conv_score":0.75,"paired_delta_json":{"delta":0.1},...}
```

**Path 8 — no token, no cookie, public=true → 200:**
```
curl -v "http://localhost:3000/reports/45"
# → HTTP/1.1 200 OK
# → {"study_id":45,"conv_score":0.75,...}
```

## Test summary

```
✓ apps/api/test/reports.cookie.test.ts (9 tests) 1283ms
  ✓ 1. valid token in URL → 302 + Set-Cookie: HttpOnly; Secure; SameSite=Lax
  ✓ 2. expired token in URL → 404, no cookie set
  ✓ 3. revoked token in URL → 404, no cookie
  ✓ 4. wrong token in URL → 404, no cookie (timing-safe)
  ✓ 5. valid cookie → 200 with report body + Cache-Control: no-store
  ✓ 6. HMAC-tampered cookie → 404, no new cookie set
  ✓ 7. valid cookie but DB token revoked → 404 (re-check on every read)
  ✓ 8. no token, no cookie, reports.public=true → 200
  ✓ 9. no token, no cookie, reports.public=false → 404
```

## Manager action required — 1Password vault item

Before deploying to production, create the `SHARE_TOKEN_HMAC_KEY` vault item:

1. **Generate a 32-byte random key (hex):**
   ```bash
   openssl rand -hex 32
   # Example output: a3f8b2c1d4e5f6a7b8c9d0e1f2a3b4c5d6e7f8a9b0c1d2e3f4a5b6c7d8e9f0a1
   ```
2. **Create the 1Password vault item:**
   - Vault: `willbuy`
   - Item name: `share-token-hmac-key`
   - Field name: `credential`
   - Value: the hex string from step 1
3. **Verify `.env.op` reference matches:**
   ```
   SHARE_TOKEN_HMAC_KEY=op://willbuy/share-token-hmac-key/credential
   ```
4. **Inject and redeploy:**
   ```bash
   op run --env-file=.env.op -- docker compose up -d api
   ```

> Note: the dev default (`dev-only-share-token-hmac-key-not-for-production-use`) is intentionally weak and must be replaced in production.

## Spec compliance

- §5.12 (field-level logging): token never logged; swapped to cookie on 302 before any structured log event.
- §2 #20 (private-by-default): all error paths return 404 — no 401, no existence leak.
- Cookie scope: `Path=/r/<slug>` (exactly scoped per spec amendment v0.4).
- `Cache-Control: no-store` + `Referrer-Policy: no-referrer` on all token-bearing responses.

Closes #76