### PR TITLE
fix(api,web): Stripe try/catch + BuyCredits visit-estimate copy (#73)

### DIFF
--- a/apps/api/src/routes/checkout.ts
+++ b/apps/api/src/routes/checkout.ts
@@ -6,10 +6,12 @@
  * so the webhook can reconcile the payment back to the account.
  *
  * Spec refs: §4.1 (Stripe Checkout), §5.6 (pack tiers).
+ * Fix #73: wrap stripe.checkout.sessions.create in try/catch; map to 502
+ * without leaking Stripe internals to the client.
  */
 
 import { z } from 'zod';
-import type Stripe from 'stripe';
+import Stripe from 'stripe';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
 
@@ -43,22 +45,33 @@ export async function registerCheckoutRoutes(
       const packId: PackId = bodyResult.data.pack_id;
       const pack = PACKS[packId];
 
-      const session = await stripe.checkout.sessions.create({
-        mode: 'payment',
-        payment_method_types: ['card'],
-        line_items: [
-          {
-            price: pack.price_id,
-            quantity: 1,
-          },
-        ],
-        client_reference_id: String(account.id),
-        metadata: { pack_id: packId },
-        // success_url and cancel_url are required by Stripe; use env if set,
-        // otherwise use fallback placeholders (adequate for test mode).
-        success_url: env.STRIPE_SUCCESS_URL ?? 'https://willbuy.dev/credits?success=1',
-        cancel_url: env.STRIPE_CANCEL_URL ?? 'https://willbuy.dev/credits?cancelled=1',
-      });
+      let session: Awaited<ReturnType<typeof stripe.checkout.sessions.create>>;
+      try {
+        session = await stripe.checkout.sessions.create({
+          mode: 'payment',
+          payment_method_types: ['card'],
+          line_items: [
+            {
+              price: pack.price_id,
+              quantity: 1,
+            },
+          ],
+          client_reference_id: String(account.id),
+          metadata: { pack_id: packId },
+          // success_url and cancel_url are required by Stripe; use env if set,
+          // otherwise use fallback placeholders (adequate for test mode).
+          success_url: env.STRIPE_SUCCESS_URL ?? 'https://willbuy.dev/credits?success=1',
+          cancel_url: env.STRIPE_CANCEL_URL ?? 'https://willbuy.dev/credits?cancelled=1',
+        });
+      } catch (err) {
+        // Log with Fastify's logger (Fastify logger pattern: req.log.error).
+        // Do NOT forward Stripe error details to the client — they may contain
+        // internal API messages, price-ID hints, or other sensitive internals.
+        req.log.error(err, 'stripe-checkout-create-failed');
+        return reply
+          .code(502)
+          .send({ error: 'payment provider unavailable, try again' });
+      }
 
       return reply.code(200).send({ url: session.url });
     },

--- a/apps/api/test/stripe.test.ts
+++ b/apps/api/test/stripe.test.ts
@@ -10,7 +10,7 @@
  * Spec refs: §5.6, §16, §4.1.
  */
 
-import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { createHash, createHmac } from 'node:crypto';
 import { readdirSync, readFileSync } from 'node:fs';

--- a/apps/api/test/stripe.test.ts
+++ b/apps/api/test/stripe.test.ts
@@ -1,7 +1,8 @@
 /**
- * stripe.test.ts — TDD acceptance suite for issue #36.
+ * stripe.test.ts — TDD acceptance suite for issues #36 and #73.
  *
  * Tests §5.6 credit-pack tiers, §16 idempotent webhook, §4.1 Stripe Checkout.
+ * Issue #73 adds: Stripe try/catch hardening (502 on StripeAPIError).
  *
  * Real-DB integration via startPostgres helper.
  * Stripe API calls are stubbed — no real Stripe API calls in CI.
@@ -9,7 +10,7 @@
  * Spec refs: §5.6, §16, §4.1.
  */
 
-import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { afterAll, beforeAll, describe, expect, it, vi } from 'vitest';
 import { spawnSync } from 'node:child_process';
 import { createHash, createHmac } from 'node:crypto';
 import { readdirSync, readFileSync } from 'node:fs';
@@ -17,7 +18,7 @@ import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
 import type { FastifyInstance } from 'fastify';
 import { Client } from 'pg';
-import type Stripe from 'stripe';
+import Stripe from 'stripe';
 
 import { startPostgres, stopPostgres } from '../../../tests/helpers/start-postgres.js';
 import { buildServer } from '../src/server.js';
@@ -380,4 +381,110 @@ describeIfDocker('Stripe Checkout + webhook (issue #36, real DB)', () => {
       await client.end();
     }
   });
+});
+
+// ---------------------------------------------------------------------------
+// Issue #73 — Stripe try/catch hardening (no Docker required).
+//
+// Verifies that when stripe.checkout.sessions.create throws a StripeAPIError,
+// POST /checkout/sessions returns 502 with a generic user-facing message and
+// does NOT leak internal Stripe error details to the client.
+// ---------------------------------------------------------------------------
+
+describe('Stripe checkout error-handling (issue #73)', () => {
+  let app: FastifyInstance;
+  const apiKey = 'sk_live_stripe_error_test_key_73xx';
+  const sha256hex = (s: string) => createHash('sha256').update(s).digest('hex');
+
+  beforeAll(async () => {
+    // Start a real Postgres via Docker if available; otherwise skip.
+    // This block is guarded by the same dockerAvailable flag used above.
+  });
+
+  // Use a separate describe that is conditionally skipped based on Docker.
+  it.skipIf(!dockerAvailable)(
+    'POST /checkout/sessions returns 502 when stripe.checkout.sessions.create throws StripeAPIError',
+    async () => {
+      // Build a stub Stripe that throws StripeAPIError on checkout creation.
+      const stripeErr = new Stripe.errors.StripeAPIError({
+        message: 'stripe internal details that must not leak',
+        type: 'api_error',
+      });
+
+      const throwingStripe = {
+        checkout: {
+          sessions: {
+            create: async () => {
+              throw stripeErr;
+            },
+          },
+        },
+        webhooks: {
+          constructEvent: () => {
+            throw new Error('not used in this test');
+          },
+        },
+      } as unknown as Stripe;
+
+      // Spin up a fresh server instance for this test.
+      const pg = await startPostgres({ containerPrefix: 'willbuy-stripe-err-test-' });
+      try {
+        // Apply migrations.
+        const migFiles = readdirSync(migrationsDir)
+          .filter((f) => /^\d{4}_.*\.sql$/.test(f))
+          .sort();
+        const pgClient = new Client({ connectionString: pg.url });
+        await pgClient.connect();
+        for (const f of migFiles) {
+          await pgClient.query(readFileSync(resolve(migrationsDir, f), 'utf8'));
+        }
+        await pgClient.end();
+
+        // Seed account + api-key.
+        const seedClient = new Client({ connectionString: pg.url });
+        await seedClient.connect();
+        const acc = await seedClient.query<{ id: string }>(
+          `INSERT INTO accounts (owner_email) VALUES ('err-test@example.com') RETURNING id`,
+        );
+        await seedClient.query(
+          `INSERT INTO api_keys (account_id, key_hash, prefix) VALUES ($1, $2, $3)`,
+          [String(acc.rows[0]!.id), sha256hex(apiKey), 'sk_live_se'],
+        );
+        await seedClient.end();
+
+        app = await buildServer({
+          env: {
+            PORT: 0,
+            LOG_LEVEL: 'silent',
+            URL_HASH_SALT: 'x'.repeat(32),
+            DATABASE_URL: pg.url,
+            DAILY_CAP_CENTS: 10_000,
+            STRIPE_SECRET_KEY: 'sk_test_fake_not_used_because_stub_injected',
+            STRIPE_WEBHOOK_SECRET: 'whsec_not_used',
+            STRIPE_PRICE_ID_STARTER: 'price_test_starter',
+            STRIPE_PRICE_ID_GROWTH: 'price_test_growth',
+            STRIPE_PRICE_ID_SCALE: 'price_test_scale',
+          },
+          stripe: throwingStripe,
+        });
+
+        const res = await app.inject({
+          method: 'POST',
+          url: '/checkout/sessions',
+          headers: { authorization: `Bearer ${apiKey}` },
+          payload: { pack_id: 'starter' },
+        });
+
+        // Must return 502, not 500 and not a Stripe internal message.
+        expect(res.statusCode).toBe(502);
+        const body = res.json() as { error: string };
+        expect(body.error).toBe('payment provider unavailable, try again');
+        // Stripe internal message must NOT appear in the response body.
+        expect(res.body).not.toContain('stripe internal details that must not leak');
+      } finally {
+        await app?.close();
+        stopPostgres(pg.container);
+      }
+    },
+  );
 });

--- a/apps/web/components/credits/BuyCredits.tsx
+++ b/apps/web/components/credits/BuyCredits.tsx
@@ -3,11 +3,12 @@
 /**
  * BuyCredits — credit-pack selection + Stripe Checkout redirect.
  *
- * Spec §5.6: starter=$29/1000c, growth=$99/4000c, scale=$299/15000c.
+ * Spec §5.6: starter=$29/2900¢, growth=$99/9900¢, scale=$299/29900¢.
+ * Visit estimate derived from pack.cents / 5 (spec §5.5 per-visit cost ceiling).
  * POSTs to /checkout/sessions with the selected pack_id.
  * Redirects to the Stripe Checkout URL returned by the API.
  *
- * Issue #36.
+ * Issue #36. Fix #73: correct visit-estimate derivation.
  */
 
 import { useState } from 'react';
@@ -18,8 +19,15 @@ interface Pack {
   id: PackId;
   label: string;
   usd: number;
+  /** Pack price in USD cents; visit estimate = cents / 5 (spec §5.5). */
+  cents: number;
   credits: number;
-  description: string;
+}
+
+/** Derive visit-estimate description from pack cents (spec §5.5: 5¢/visit ceiling). */
+function visitEstimate(cents: number): string {
+  const visits = Math.floor(cents / 5);
+  return `≈ ${visits.toLocaleString()} visits`;
 }
 
 const PACKS: Pack[] = [
@@ -27,22 +35,22 @@ const PACKS: Pack[] = [
     id: 'starter',
     label: 'Starter',
     usd: 29,
+    cents: 2900,
     credits: 1000,
-    description: '≈ 285 visits',
   },
   {
     id: 'growth',
     label: 'Growth',
     usd: 99,
+    cents: 9900,
     credits: 4000,
-    description: '≈ 1,140 visits',
   },
   {
     id: 'scale',
     label: 'Scale',
     usd: 299,
+    cents: 29900,
     credits: 15000,
-    description: '≈ 4,280 visits',
   },
 ];
 
@@ -106,7 +114,7 @@ export function BuyCredits({ apiKey, apiBaseUrl }: BuyCreditsProps) {
             <span className="text-sm text-gray-600">
               {pack.credits.toLocaleString()} credits
             </span>
-            <span className="text-xs text-gray-500">{pack.description}</span>
+            <span className="text-xs text-gray-500">{visitEstimate(pack.cents)}</span>
           </button>
         ))}
       </div>

--- a/apps/web/test/buy-credits.test.tsx
+++ b/apps/web/test/buy-credits.test.tsx
@@ -1,0 +1,43 @@
+/**
+ * buy-credits.test.tsx — TDD acceptance for issue #73.
+ *
+ * Asserts that BuyCredits renders the correct visit-estimate copy derived
+ * from pack.cents / 5 (spec §5.5 per-visit cost ceiling).
+ *
+ * Expected:
+ *   Starter:  2900¢ / 5¢ = 580 visits
+ *   Growth:   9900¢ / 5¢ = 1980 visits
+ *   Scale:   29900¢ / 5¢ = 5980 visits
+ */
+
+// @vitest-environment jsdom
+
+import { describe, expect, it } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import { BuyCredits } from '../components/credits/BuyCredits';
+
+describe('BuyCredits visit-estimate copy (issue #73)', () => {
+  function renderComponent() {
+    render(
+      <BuyCredits
+        apiKey="sk_test_fake"
+        apiBaseUrl="https://api.example.com"
+      />,
+    );
+  }
+
+  it('starter pack shows "580 visits"', () => {
+    renderComponent();
+    expect(screen.getByText(/580 visits/i)).toBeTruthy();
+  });
+
+  it('growth pack shows "1980 visits"', () => {
+    renderComponent();
+    expect(screen.getByText(/1,?980 visits/i)).toBeTruthy();
+  });
+
+  it('scale pack shows "5980 visits"', () => {
+    renderComponent();
+    expect(screen.getByText(/5,?980 visits/i)).toBeTruthy();
+  });
+});

--- a/apps/web/test/buy-credits.test.tsx
+++ b/apps/web/test/buy-credits.test.tsx
@@ -12,9 +12,13 @@
 
 // @vitest-environment jsdom
 
-import { describe, expect, it } from 'vitest';
-import { render, screen } from '@testing-library/react';
+import { afterEach, describe, expect, it } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
 import { BuyCredits } from '../components/credits/BuyCredits';
+
+afterEach(() => {
+  cleanup();
+});
 
 describe('BuyCredits visit-estimate copy (issue #73)', () => {
   function renderComponent() {
@@ -28,16 +32,17 @@ describe('BuyCredits visit-estimate copy (issue #73)', () => {
 
   it('starter pack shows "580 visits"', () => {
     renderComponent();
-    expect(screen.getByText(/580 visits/i)).toBeTruthy();
+    // Use getAllByText to handle locale-formatted numbers; assert at least one match.
+    expect(screen.getAllByText(/580 visits/i).length).toBeGreaterThan(0);
   });
 
   it('growth pack shows "1980 visits"', () => {
     renderComponent();
-    expect(screen.getByText(/1,?980 visits/i)).toBeTruthy();
+    expect(screen.getAllByText(/1[,.]?980 visits/i).length).toBeGreaterThan(0);
   });
 
   it('scale pack shows "5980 visits"', () => {
     renderComponent();
-    expect(screen.getByText(/5,?980 visits/i)).toBeTruthy();
+    expect(screen.getAllByText(/5[,.]?980 visits/i).length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Root causes

**Fix 1 — BuyCredits visit-estimate copy** (`apps/web/components/credits/BuyCredits.tsx`):
The visit-count descriptions (≈ 285/1,140/4,280) were derived from `credits / 3.5`, which is a stale ratio unrelated to spec §5.5. The correct derivation is `pack.cents / 5` (5¢ per-visit cost ceiling per spec §5.5), yielding 580/1,980/5,980. The `Pack` interface now carries a `cents` field and a `visitEstimate(cents)` helper replaces the hardcoded `description` strings.

**Fix 2 — Stripe try/catch hardening** (`apps/api/src/routes/checkout.ts`):
`stripe.checkout.sessions.create` had no error handling; any `StripeError` (network failure, invalid key, rate limit, etc.) propagated as an unhandled 500. Wrapped in an explicit try/catch: logs the raw error via `req.log.error(err, 'stripe-checkout-create-failed')` (Fastify logger pattern) and returns a generic 502 without forwarding Stripe internals to the client.

## Test summary

| File | Tests | Result |
|---|---|---|
| `apps/web/test/buy-credits.test.tsx` (new) | 3 | ✅ all green |
| `apps/api/test/stripe.test.ts` (extended) | 8 (+1) | ✅ all green |

- Web: asserts rendered copy contains "580 visits", "1,980 visits", "5,980 visits".
- API: stubs `stripe.checkout.sessions.create` to throw `Stripe.errors.StripeAPIError`; asserts 502 + `{error: 'payment provider unavailable, try again'}`; asserts Stripe internal message is not leaked.

Closes #73