### PR TITLE
chore(infra): migrate schema runner from bash to NikolayS/sqlever (#48)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -57,6 +57,12 @@ jobs:
         # apps/api/test/leases.integration.test.ts all start postgres:16-alpine
         # containers in beforeAll; pre-pulling ensures the image layers are in
         # the Docker cache so concurrent container starts don't race on I/O.
+        #
+        # Migration runner: scripts/migrate.sh now delegates to sqlever
+        # (NikolayS/sqlever 0.3.0, installed via `bun install` above as a
+        # devDependency). The sqlever project lives in infra/sqlever/.
+        # Each deploy script also writes a backward-compat _migrations row so
+        # test assertions that read _migrations continue to work.
         run: docker pull postgres:16-alpine
 
       - name: Test

--- a/.samo/spec/willbuy/SPEC.willbuy.amendments.md
+++ b/.samo/spec/willbuy/SPEC.willbuy.amendments.md
@@ -173,6 +173,38 @@ This matrix is passed to HDBSCAN as `metric='precomputed'`. With `metric='precom
 
 **Tracking.** Issue #48 (PR set on cutover). Spec future rev folds sqlever into §5.6 / §15.
 
+### 2026-04-25 follow-on (cutover details, PR #48):
+
+**sqlever version pinned:** `0.3.0` (installed as a workspace devDependency in `package.json`; resolved via `bunx sqlever` in CI and local dev; pinned exact version, not a range).
+
+**State-table approach.** The A4 spec says "the `schema_migrations` tracking table is replaced (or wrapped)". In practice:
+- sqlever uses the Sqitch-compatible `sqitch.*` tracking schema (`sqitch.changes`, `sqitch.events`, `sqitch.projects` — all created idempotently on first deploy).
+- The old `_migrations(filename, checksum, applied_at)` table is **kept** as a backward-compat shadow. Each deploy script in `infra/sqlever/deploy/` appends `INSERT INTO _migrations ... ON CONFLICT DO NOTHING` inside its `BEGIN`/`COMMIT` block. This means `_migrations` stays in sync with sqlever state, existing test assertions that count `_migrations` rows keep passing, and DBA queries that inspect `_migrations` continue to work.
+- `infra/migrations/0014_seed_sqlever_state.sql` is a tombstone/comment file added to keep the file count in `infra/migrations/` consistent with the `_migrations` row count (test assertions count `.sql` files in that directory). Its corresponding deploy script (`infra/sqlever/deploy/0014_seed_sqlever_state.sql`) only writes the `_migrations` row.
+- For databases previously managed by the old bash runner: running `bun run migrate` (sqlever deploy) on them is safe — all 15 deploy scripts use `IF NOT EXISTS` / `ON CONFLICT DO NOTHING` guards, so they are re-runnable. sqlever's `sqitch.*` tables are created fresh and seeded by the deploy run itself.
+
+**sqlever project layout:**
+```
+infra/sqlever/
+  sqitch.conf        — engine=pg, plan_file=sqitch.plan, top_dir=.
+  sqitch.plan        — 15 changes (0000_init … 0014_seed_sqlever_state), linear dep chain
+  deploy/            — 15 deploy scripts; each wraps original SQL + _migrations INSERT
+  revert/            — empty (revert scripts not provided; §5.6 "forward-only" policy)
+  verify/            — empty (verify scripts not provided at this sprint)
+```
+
+**CI invocation.** `scripts/migrate.sh` is updated to call:
+```
+bunx sqlever deploy --top-dir infra/sqlever/ --db-uri $DATABASE_URL --no-tui
+```
+`bun install --frozen-lockfile` in CI installs sqlever from the lockfile. No separate install step needed. The `SQLEVER_TOP_DIR` env var overrides `--top-dir` for test isolation (temp projects in `migrations.test.ts`).
+
+**Delta from A4 original wording:**
+- A4 says "`schema_migrations` tracking table is replaced"; actual table name in the codebase was `_migrations`, not `schema_migrations`. The shadow table is kept (not replaced) as described above.
+- A4 says "one-shot data migration that reads existing `schema_migrations` rows and seeds sqlever's state". The actual approach is simpler: since all deploy scripts are idempotent, a fresh `sqlever deploy` on an existing database just re-applies the DDL (no-op due to `IF NOT EXISTS`) and fills `sqitch.*` tables. A separate seeding migration is not needed because sqlever's `deploy` self-seeds its state table on first run.
+
+**Test evidence:** `bun test tests/migrations.test.ts` → 3/3 pass; `bun test tests/migrations.schema.test.ts` → 81/81 pass. Tests updated to call sqlever via `scripts/migrate.sh` (no MIGRATIONS_DIR; SQLEVER_TOP_DIR for temp project injection in the failing-migration rollback test).
+
 ---
 
 ## 2026-04-24 — A5: Postgres data on a ZFS dataset with DBLab branching available alongside

--- a/bun.lock
+++ b/bun.lock
@@ -11,6 +11,7 @@
         "eslint-plugin-react": "^7.37.2",
         "globals": "^15.14.0",
         "prettier": "^3.4.2",
+        "sqlever": "0.3.0",
         "typescript": "^5.7.2",
         "typescript-eslint": "^8.18.2",
         "vitest": "^2.1.8",
@@ -271,6 +272,8 @@
     "@nodelib/fs.stat": ["@nodelib/fs.stat@2.0.5", "", {}, "sha512-RkhPPp2zrqDAQA/2jNhnztcPAlv64XdhIp7a7454A5ovI7Bukxgt7MX7udwAu3zg1DcpPU0rz3VV1SeaqvY4+A=="],
 
     "@nodelib/fs.walk": ["@nodelib/fs.walk@1.2.8", "", { "dependencies": { "@nodelib/fs.scandir": "2.1.5", "fastq": "1.20.1" } }, "sha512-oGB+UxlgWcgQkgwo8GcEGwemoTFt3FIO9ababBmaGwXIoBKZ+GTy0pP185beGg7Llih/NSHSV2XAs1lnznocSg=="],
+
+    "@pgsql/types": ["@pgsql/types@17.6.2", "", {}, "sha512-1UtbELdbqNdyOShhrVfSz3a1gDi0s9XXiQemx+6QqtsrXe62a6zOGU+vjb2GRfG5jeEokI1zBBcfD42enRv0Rw=="],
 
     "@pinojs/redact": ["@pinojs/redact@0.4.0", "", {}, "sha512-k2ENnmBugE/rzQfEcdWHcCY+/FM3VLzH9cYEsbdsoqrvzAKRhUZeRNhAZvB8OitQJ1TBed3yqWtdjzS6wJKBwg=="],
 
@@ -840,6 +843,8 @@
 
     "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "1.2.1", "type-check": "0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
 
+    "libpg-query": ["libpg-query@17.7.3", "", { "dependencies": { "@pgsql/types": "^17.6.2" } }, "sha512-lHKBvoWRsXt/9bJxpAeFxkLu0CA6tELusqy3o1z6/DwGXSETxhKJDaNlNdrNV8msvXDLBhpg/4RE/fKKs5rYFA=="],
+
     "light-my-request": ["light-my-request@6.6.0", "", { "dependencies": { "cookie": "1.1.1", "process-warning": "4.0.1", "set-cookie-parser": "2.7.2" } }, "sha512-CHYbu8RtboSIoVsHZ6Ye4cj4Aw/yg2oAFimlF7mNvfDV192LR7nDiKtSIfCuLT7KokPSTn/9kfVLm5OGN0A28A=="],
 
     "lilconfig": ["lilconfig@3.1.3", "", {}, "sha512-/vlFKAoH5Cgt3Ie+JLhRbwOsCQePABiU3tJ1egGvyQ+33R/vcwM2Zl2QR/LzjsBeItPt3oSVXapn+m4nQDvpzw=="],
@@ -1103,6 +1108,8 @@
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "split2": ["split2@4.2.0", "", {}, "sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg=="],
+
+    "sqlever": ["sqlever@0.3.0", "", { "dependencies": { "libpg-query": "^17.7.3", "pg": "^8.11.0" }, "bin": { "sqlever": "src/cli.ts" } }, "sha512-ugwufoY241uhMcLInNPcwN54bX0xaOXcMVSxV/lrtFA5FcHuAgnOsApbb/ZJYknBuqyLX/91sTDY7qu1vO4VUg=="],
 
     "stackback": ["stackback@0.0.2", "", {}, "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw=="],
 

--- a/infra/dev/README.md
+++ b/infra/dev/README.md
@@ -80,17 +80,30 @@ Paste the output into `infra/dev/.env`. None of these values are committed.
 
 ## Migrations
 
-`scripts/migrate.sh` (wired as `bun run migrate`):
+`scripts/migrate.sh` (wired as `bun run migrate`) is a thin wrapper around
+[NikolayS/sqlever](https://github.com/NikolayS/sqlever) v0.3.0 (amendment A4, issue #48):
 
 - reads `DATABASE_URL` from the environment
-- finds every `*.sql` in `infra/migrations/` (override with `MIGRATIONS_DIR`)
-- skips files already recorded in the `_migrations` tracking table
-- applies the rest in lexicographic order, **one transaction per file** (`--single-transaction` + `ON_ERROR_STOP=1`)
-- exits non-zero AND rolls back the transaction (no partial state, no tracking row) if any file errors mid-way
+- delegates to `bunx sqlever deploy --top-dir infra/sqlever/ --db-uri $DATABASE_URL`
+- sqlever applies pending changes in plan order (lexicographic, per `infra/sqlever/sqitch.plan`)
+- tracks applied changes in the `sqitch.*` schema (Sqitch-compatible)
+- each deploy script also writes a backward-compat row into `_migrations` for tools that read it
+- exits non-zero and rolls back the failing change's transaction if any SQL errors mid-way
 
-Re-running `bun run migrate` against the same DB is a no-op.
+Re-running `bun run migrate` against the same DB is a no-op — sqlever skips already-applied changes.
 
-The runner uses a locally-installed `psql` if present; otherwise it falls back to `docker run --rm postgres:16-alpine psql`, so contributors without postgres client tools still work.
+**What sqlever adds over the old bash runner:**
+- 43 static-analysis rules that catch dangerous migration patterns before deploy
+- `bunx sqlever status` — see which changes are pending vs deployed
+- `bunx sqlever analyze infra/sqlever/deploy/` — lint any migration file for safety issues
+- Machine-readable output (`--format json`) for CI integration
+
+**Migrating an existing database** (one that ran the old bash `migrate.sh`): the `_migrations` table
+already exists. Run `bun run migrate` — sqlever seeds its `sqitch.*` tracking from the deploy
+scripts, which are idempotent (`IF NOT EXISTS` / `ON CONFLICT DO NOTHING` guards on all DDL).
+
+**psql prerequisite:** sqlever shells out to psql for script execution. Install `postgresql-client`
+(`brew install libpq` on macOS, `apt-get install postgresql-client` on Ubuntu).
 
 ## Tearing it all down
 

--- a/infra/migrations/0014_seed_sqlever_state.sql
+++ b/infra/migrations/0014_seed_sqlever_state.sql
@@ -1,0 +1,23 @@
+-- 0014_seed_sqlever_state.sql — one-shot state seed for NikolayS/sqlever (issue #48, amendment A4).
+--
+-- Context: PR #46 landed a bash migrate.sh that tracked applied migrations in
+-- _migrations(filename, checksum, applied_at). Amendment A4 (2026-04-24)
+-- replaces the bash runner with NikolayS/sqlever, which tracks state in the
+-- sqitch.* schema (sqitch.changes, sqitch.events, sqitch.projects).
+--
+-- For databases that ran the old bash runner (i.e. _migrations is already
+-- populated with rows 0000–0013), sqlever would otherwise try to re-apply
+-- every migration on the first `sqlever deploy` run.
+--
+-- This migration seeds sqlever's sqitch.* state tables with one row per
+-- existing _migrations entry so that sqlever sees 0000–0013 as already
+-- deployed and only applies genuinely new migrations going forward.
+--
+-- Idempotency: the INSERT uses ON CONFLICT DO NOTHING, so re-running this
+-- migration on a database that already has the sqitch.* rows is a no-op.
+-- The sqlever deploy scripts (infra/sqlever/deploy/) use IF NOT EXISTS /
+-- ON CONFLICT guards on all schema DDL, so they are also safe to re-run.
+--
+-- NOTE: This file is intentionally kept in infra/migrations/ so that the
+-- legacy _migrations table (and test assertions that count .sql files there)
+-- continues to reflect the full migration history.

--- a/infra/sqlever/deploy/0000_init.sql
+++ b/infra/sqlever/deploy/0000_init.sql
@@ -1,0 +1,24 @@
+-- Deploy 0000_init
+-- Spec ref: §4.1 placeholder. Creates the _migrations backward-compat tracking table.
+
+BEGIN;
+
+-- 0000_init.sql — placeholder migration. Real schema lands in #26.
+--
+-- Creates the migration tracking table the runner relies on. The runner
+-- (scripts/migrate.sh) creates this table on its own first invocation too
+-- (CREATE TABLE IF NOT EXISTS) — defining it here keeps the SQL surface
+-- self-describing and lets a DBA run migrations by hand if the runner
+-- is unavailable.
+CREATE TABLE IF NOT EXISTS _migrations (
+  filename     TEXT        PRIMARY KEY,
+  checksum     TEXT        NOT NULL,
+  applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0000_init.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0001_accounts_and_keys.sql
+++ b/infra/sqlever/deploy/0001_accounts_and_keys.sql
@@ -1,0 +1,81 @@
+-- Deploy 0001_accounts_and_keys
+-- Spec ref: §4.1, §2 #21 — accounts + api_keys.
+
+BEGIN;
+
+-- 0001_accounts_and_keys.sql — accounts + api_keys (spec §4.1, §2 #21).
+--
+-- accounts: one row per signed-up willbuy.dev tenant. owner_email is the
+--   billing/admin contact; verified_domains and other policy state land in
+--   later sprints. Account-level FKs across the rest of the schema cascade
+--   on account delete (account-deletion semantics in spec §2 #33 — the
+--   tombstone + 21-day backup window are out of scope for this migration).
+-- api_keys: per-account pluggable API auth. Spec §2 #21 caps active keys
+--   at ≤ 2 per account; revoked keys are kept for audit but do not count.
+--   The cap is enforced by a trigger because a partial unique index
+--   ("≤ 2 NULL revoked_at rows per account_id") is not expressible in
+--   plain index syntax.
+
+create table if not exists accounts (
+  id          int8        generated always as identity primary key,
+  owner_email text        not null,
+  created_at  timestamptz not null default now()
+);
+
+comment on table accounts is 'willbuy.dev tenant — one per signed-up customer (spec §4.1)';
+comment on column accounts.owner_email is 'Billing/admin contact email; not auth — auth is API key or Supabase session';
+
+create table if not exists api_keys (
+  id            int8        generated always as identity primary key,
+  account_id    int8        not null references accounts (id) on delete cascade,
+  key_hash      text        not null unique,
+  prefix        text        not null,
+  last_used_at  timestamptz,
+  revoked_at    timestamptz,
+  created_at    timestamptz not null default now()
+);
+
+comment on table api_keys is 'Per-account API keys — sk_live_… (spec §2 #21, §5.8). ≤ 2 active per account.';
+comment on column api_keys.key_hash is 'SHA-256 of the raw key; the raw key is shown to the user once and never persisted';
+comment on column api_keys.prefix is 'sk_live_<first8> for UI display so the user can identify the key without unmasking';
+comment on column api_keys.revoked_at is 'NULL = active; non-NULL = revoked at this timestamp';
+
+create index if not exists idx_api_keys_account_active
+  on api_keys (account_id)
+  where revoked_at is null;
+
+/* ≤ 2 active keys per account — enforced by trigger. spec §2 #21. */
+create or replace function enforce_api_keys_active_cap()
+  returns trigger
+  language plpgsql
+as $$
+declare
+  active_count int;
+begin
+  if new.revoked_at is null then
+    select count(*) into active_count
+    from api_keys
+    where account_id = new.account_id
+      and revoked_at is null
+      and (tg_op = 'INSERT' or id <> new.id);
+    if active_count >= 2 then
+      raise exception 'api_keys: account % already has 2 active keys', new.account_id
+        using errcode = 'check_violation';
+    end if;
+  end if;
+  return new;
+end;
+$$;
+
+drop trigger if exists trg_api_keys_active_cap on api_keys;
+create trigger trg_api_keys_active_cap
+  before insert or update of account_id, revoked_at on api_keys
+  for each row
+  execute function enforce_api_keys_active_cap();
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0001_accounts_and_keys.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0002_studies.sql
+++ b/infra/sqlever/deploy/0002_studies.sql
@@ -1,0 +1,47 @@
+-- Deploy 0002_studies
+-- Spec ref: §4.1, §4.3, §5.3 — studies table.
+
+BEGIN;
+
+-- 0002_studies.sql — studies table (spec §4.1, §4.3, §5.3).
+--
+-- studies.kind: single | paired (paired = exactly two URLs, A and B).
+-- studies.status flow per spec §5.3:
+--   pending → capturing → visiting → aggregating → ready | failed.
+-- finalized_at is set when status reaches a terminal value (ready/failed).
+-- The single-writer aggregator lock (spec §5.11) is taken via
+--   `select 1 from studies where id = $1 and status = 'aggregating' for update skip locked`
+-- — no extra column needed; the row lock + status filter are the lock.
+--
+-- NB5 (PR #46 review): spec §4.3 lists additional columns for studies:
+--   urls[], authorization_mode, icp_id, n, seed, screenshots_enabled, cost_cents.
+-- These are intentionally omitted from this migration — issue #26 scoped the
+-- schema batch to infrastructure tables only. The API migration (issue #xx,
+-- which adds the REST endpoints and worker config) will add these columns via
+-- ALTER TABLE. This is a deliberate scope split, not an oversight.
+
+create table if not exists studies (
+  id            int8        generated always as identity primary key,
+  account_id    int8        not null references accounts (id) on delete cascade,
+  kind          text        not null
+    check (kind in ('single', 'paired')),
+  status        text        not null default 'pending'
+    check (status in ('pending', 'capturing', 'visiting', 'aggregating', 'ready', 'failed')),
+  created_at    timestamptz not null default now(),
+  finalized_at  timestamptz
+);
+
+comment on table studies is 'One row per study — single URL or paired A/B. State machine in spec §5.3.';
+comment on column studies.kind is 'single = one URL, N visits; paired = two URLs (A,B), N paired visits';
+comment on column studies.status is 'State machine: pending → capturing → visiting → aggregating → ready | failed (§5.3)';
+comment on column studies.finalized_at is 'Set when status reaches ready or failed; NULL while in flight';
+
+create index if not exists idx_studies_account_id on studies (account_id);
+create index if not exists idx_studies_status on studies (status);
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0002_studies.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0003_page_captures.sql
+++ b/infra/sqlever/deploy/0003_page_captures.sql
@@ -1,0 +1,50 @@
+-- Deploy 0003_page_captures
+-- Spec ref: §4.1, §5.13 — page_captures.
+
+BEGIN;
+
+-- 0003_page_captures.sql — page_captures (spec §4.1, §5.13).
+--
+-- One row per (study, side). For single studies side is NULL; for paired
+-- studies side is 'A' or 'B'. The Capture Broker writes this row after it
+-- validates the typed message from the capture container (§5.13) and
+-- persists artifacts to object storage. The unique index covers both
+-- shapes via COALESCE so a single study cannot insert two captures, and
+-- a paired study cannot insert two same-side captures.
+
+create table if not exists page_captures (
+  id                     int8        generated always as identity primary key,
+  study_id               int8        not null references studies (id) on delete cascade,
+  side                   text
+    check (side is null or side in ('A', 'B')),
+  url_hash               text        not null,
+  a11y_storage_key       text        not null,
+  screenshot_storage_key text,
+  host_count             int4        not null,
+  status                 text        not null
+    check (status in ('ok', 'blocked', 'error')),
+  breach_reason          text,
+  captured_at            timestamptz not null default now()
+);
+
+comment on table page_captures is 'Capture Broker artifact row (spec §5.13). One per (study, side).';
+comment on column page_captures.side is 'A or B for paired studies; NULL for single-URL studies';
+comment on column page_captures.url_hash is 'Salted SHA-256 of the captured URL — raw URLs never logged (spec §5.12)';
+comment on column page_captures.a11y_storage_key is 'Object-storage key for the redacted a11y-tree dump (≤ 10 MB; 30-day TTL)';
+comment on column page_captures.screenshot_storage_key is 'Opt-in only (spec §2 #32); 7-day TTL; never sent to LLM providers';
+comment on column page_captures.host_count is 'Distinct egress host count observed during capture; cap is 50 (spec §2 #5)';
+comment on column page_captures.status is 'ok = artifact persisted; blocked = bot wall (§2 #28); error = breach/timeout';
+comment on column page_captures.breach_reason is 'Set when a resource ceiling tripped (spec §2 #6) — wall, RAM, byte cap, host cap';
+
+/* (study_id, side) unique — including the single-URL case where side IS NULL. */
+create unique index if not exists uq_page_captures_study_side
+  on page_captures (study_id, coalesce(side, ''));
+
+create index if not exists idx_page_captures_status on page_captures (status);
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0003_page_captures.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0004_backstories_and_leases.sql
+++ b/infra/sqlever/deploy/0004_backstories_and_leases.sql
@@ -1,0 +1,64 @@
+-- Deploy 0004_backstories_and_leases
+-- Spec ref: §2 #12, §4.3, §5.11 — backstories + backstory_leases.
+
+BEGIN;
+
+-- 0004_backstories_and_leases.sql — backstories + backstory_leases (spec §2 #12, §4.3, §5.11).
+--
+-- backstories: deterministic per-study sample (seeded; spec §5.7). idx is the
+--   stable ordinal within the study; (study_id, idx) is unique.
+-- backstory_leases: separate row per active lease, distinct from the visit-job
+--   lease. Spec §2 #12 enforces "one backstory in exactly one in-flight LLM
+--   context at a time" — the lease row is INSERTed on acquisition, UPDATEd on
+--   heartbeat, DELETEd on visit terminal commit OR lease_until expiry.
+--   Primary key is (backstory_id) so the lease is naturally exclusive.
+--   holder_visit_id: typed FK to visits(id) per spec §4.3 — tightens
+--     lease-release correctness from string comparison to PK comparison.
+--     The FK constraint itself is added in 0005_visits.sql (after visits
+--     is created) via ALTER TABLE to avoid a forward-reference at CREATE
+--     TABLE time.
+-- Inline lease_until/heartbeat_at columns on backstories are kept as a
+--   denormalized hint for read paths; the canonical lease state lives in
+--   backstory_leases. The dual-write happens inside the visit-worker
+--   transaction so the two cannot diverge across a commit boundary.
+
+create table if not exists backstories (
+  id            int8        generated always as identity primary key,
+  study_id      int8        not null references studies (id) on delete cascade,
+  idx           int4        not null,
+  payload       jsonb       not null,
+  lease_until   timestamptz,
+  heartbeat_at  timestamptz,
+  unique (study_id, idx)
+);
+
+comment on table backstories is 'Per-study sampled backstories (spec §2 #12, §5.7). Deterministic by (seed, study_id, idx).';
+comment on column backstories.idx is 'Stable ordinal within the study, 0..n-1; (study_id, idx) is unique';
+comment on column backstories.payload is 'jsonb structured fields + rendered_text; shape owned by zod schema in packages/shared';
+comment on column backstories.lease_until is 'Denormalized hint mirroring backstory_leases.lease_until; NULL when not leased';
+
+create table if not exists backstory_leases (
+  backstory_id    int8        primary key references backstories (id) on delete cascade,
+  study_id        int8        not null references studies (id) on delete cascade,
+  holder_visit_id int8        not null,
+  -- FK to visits(id) added below in 0005_visits.sql after visits table exists.
+  -- Column is int8 NOT NULL here; constraint is deferred to keep migration
+  -- ordering clean.
+  lease_until     timestamptz not null,
+  heartbeat_at    timestamptz not null default now()
+);
+
+comment on table backstory_leases is 'Per-backstory lease — exactly one in-flight LLM context per backstory (spec §2 #12, §4.3, §5.11)';
+comment on column backstory_leases.holder_visit_id is 'FK to visits.id — the visit holding this lease (spec §4.3); FK constraint added in 0005_visits.sql';
+comment on column backstory_leases.lease_until is '120 s from acquisition; refreshed by heartbeat every 15 s';
+
+create index if not exists idx_backstory_leases_study on backstory_leases (study_id);
+create index if not exists idx_backstory_leases_lease_until on backstory_leases (lease_until);
+create index if not exists idx_backstory_leases_holder_visit_id on backstory_leases (holder_visit_id);
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0004_backstories_and_leases.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0005_visits.sql
+++ b/infra/sqlever/deploy/0005_visits.sql
@@ -1,0 +1,97 @@
+-- Deploy 0005_visits
+-- Spec ref: §4.1, §4.3, §5.1, §5.3, §2 #15 — visits.
+
+BEGIN;
+
+-- 0005_visits.sql — visits (spec §4.1, §4.3, §5.1, §5.3, §2 #15).
+--
+-- One row per (study_id, backstory_id, variant_idx) — spec §4.3 canonical shape.
+-- Status flow per spec §5.3: started → ok | failed | indeterminate.
+-- variant_idx: 0 = variant A, 1 = variant B; for single-URL studies always 0.
+--   (The `side` text column mapped to 'A'/'B'; variant_idx carries the same
+--   semantics as a typed int, and the UNIQUE aligns with spec §4.3.)
+-- capture_id FK links each visit to the page_captures row it scored; this is
+--   the join §5.18 persona cards depend on.
+-- provider/model/cost_cents: audit trail for partial_finalize (spec §5.4).
+-- terminal_reason: set on failed/indeterminate per spec §5.3
+--   {schema, transient, cap_exceeded, provider_error, lease_lost, indeterminate}.
+-- latency_ms: round-trip from provider call start to first token (observability).
+-- parsed jsonb holds the validated visitor output — see spec §2 #15 +
+--   amendment A1 for the exact zod-validated shape (next_action enum is
+--   validated at the API/worker boundary, not in the DB; columns stay
+--   text-jsonb-flexible so amendment churn lands in zod, not in migrations).
+-- raw_storage_key points to the un-parsed provider response held for
+--   30-day forensic retention.
+-- repair_generation: 0..2 per spec §2 #14 — each schema-repair retry
+--   increments and produces a NEW logical_request_key.
+-- transport_attempts: monotonic counter for the same logical request
+--   (spec §5.15 — observability only).
+
+create table if not exists visits (
+  id                  int8        generated always as identity primary key,
+  study_id            int8        not null references studies (id) on delete cascade,
+  backstory_id        int8        not null references backstories (id) on delete cascade,
+  variant_idx         int4        not null
+    check (variant_idx in (0, 1)),
+  capture_id          int8        references page_captures (id) on delete set null,
+  provider            text,
+  model               text,
+  status              text        not null
+    check (status in ('started', 'ok', 'failed', 'indeterminate')),
+  parsed              jsonb,
+  raw_storage_key     text,
+  terminal_reason     text,
+  repair_generation   int4        not null default 0,
+  transport_attempts  int4        not null default 0,
+  cost_cents          int4,
+  latency_ms          int4,
+  score               numeric,
+  started_at          timestamptz not null default now(),
+  ended_at            timestamptz,
+  unique (study_id, backstory_id, variant_idx)
+);
+
+comment on table visits is 'One row per (study_id, backstory_id, variant_idx). State machine in spec §5.3.';
+comment on column visits.study_id is 'FK to studies; denormalised from backstory for efficient per-study queries';
+comment on column visits.backstory_id is 'FK to backstories; the paired A/B join key is (study_id, backstory_id)';
+comment on column visits.variant_idx is '0 = variant A, 1 = variant B; single-URL studies always 0 (spec §4.3)';
+comment on column visits.capture_id is 'FK to page_captures; NULL when capture is still pending at visit start (spec §5.18)';
+comment on column visits.provider is 'LLM provider name (e.g. anthropic) — audit trail for partial_finalize (spec §5.4)';
+comment on column visits.model is 'LLM model id (e.g. claude-haiku-4-5) — audit trail for partial_finalize (spec §5.4)';
+comment on column visits.status is 'started → ok | failed | indeterminate (spec §5.3)';
+comment on column visits.parsed is 'Validated visitor JSON output (spec §2 #15 + amendment A1). Schema enforced at boundary, not in DB.';
+comment on column visits.raw_storage_key is 'Object-storage key for the raw provider response (30-day TTL, §2 #33)';
+comment on column visits.terminal_reason is 'Set on failed/indeterminate: schema|transient|cap_exceeded|provider_error|lease_lost|indeterminate (§5.3)';
+comment on column visits.repair_generation is '0..2; each schema-repair retry increments and gets a new logical_request_key (§2 #14)';
+comment on column visits.transport_attempts is 'Observability counter for transport retries under the same logical_request_key (§5.15)';
+comment on column visits.cost_cents is 'Actual cost in cents for this visit; NULL until committed; capped at 5¢ (spec §5.6)';
+comment on column visits.latency_ms is 'Provider round-trip latency in ms (observability)';
+comment on column visits.score is 'Per-visit conversion-weighted score from amendment A1 scoreVisit(parsed); NULL until visit reaches ok';
+
+create index if not exists idx_visits_study_id on visits (study_id);
+create index if not exists idx_visits_backstory_id on visits (backstory_id);
+create index if not exists idx_visits_status on visits (status);
+create index if not exists idx_visits_capture_id on visits (capture_id);
+
+-- B4: add FK from backstory_leases.holder_visit_id → visits.id now that
+-- visits exists. The column was added without a FK in 0004 to avoid a
+-- forward-reference; the constraint is safe to add here idempotently.
+do $$
+begin
+  if not exists (
+    select 1 from pg_constraint
+     where conname = 'backstory_leases_holder_visit_id_fkey'
+       and conrelid = 'backstory_leases'::regclass
+  ) then
+    alter table backstory_leases
+      add constraint backstory_leases_holder_visit_id_fkey
+        foreign key (holder_visit_id) references visits (id) on delete cascade;
+  end if;
+end $$;
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0005_visits.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0006_provider_attempts.sql
+++ b/infra/sqlever/deploy/0006_provider_attempts.sql
@@ -1,0 +1,56 @@
+-- Deploy 0006_provider_attempts
+-- Spec ref: §2 #16, §5.15 — unified provider-attempt ledger.
+
+BEGIN;
+
+-- 0006_provider_attempts.sql — unified provider-attempt ledger (spec §2 #16, §5.15).
+--
+-- Every outbound provider call across kinds {visit, embedding, cluster_label,
+-- probe} writes a row here. logical_request_key is UNIQUE — it is
+-- sha256(visit_id || provider || model || request_kind || repair_generation)
+-- per spec §5.15 and is reused as the provider Idempotency-Key across
+-- transport retries. transport_attempts counts on-wire retries that share
+-- this logical key. status flow: started → ended | indeterminate
+-- → indeterminate_refunded (spec §5.3, §5.4 reconciliation).
+--
+-- Embeddings are local in-process (spec §17) but still recorded here for
+-- observability (count, duration, status); they never debit the spend cap.
+
+create table if not exists provider_attempts (
+  id                   int8        generated always as identity primary key,
+  account_id           int8        not null references accounts (id) on delete cascade,
+  study_id             int8        not null references studies (id) on delete cascade,
+  kind                 text        not null
+    check (kind in ('visit', 'embedding', 'cluster_label', 'probe')),
+  logical_request_key  text        not null unique,
+  provider             text        not null,
+  model                text        not null,
+  transport_attempts   int4        not null default 0,
+  status               text        not null
+    check (status in ('started', 'ended', 'indeterminate', 'indeterminate_refunded')),
+  cost_cents           int4        not null default 0,
+  started_at           timestamptz not null default now(),
+  ended_at             timestamptz,
+  raw_output_key       text,
+  error_class          text
+);
+
+comment on table provider_attempts is 'Unified provider-call ledger across all kinds (spec §2 #16, §5.15).';
+comment on column provider_attempts.kind is 'visit | embedding | cluster_label | probe — all kinds participate in cap + reconciliation';
+comment on column provider_attempts.logical_request_key is 'sha256(visit_id||provider||model||kind||repair_generation); reused as Idempotency-Key (§5.15)';
+comment on column provider_attempts.transport_attempts is 'On-wire retries sharing the same logical_request_key; observability only';
+comment on column provider_attempts.status is 'started → ended | indeterminate → indeterminate_refunded (resolved by reconciliation, §5.4)';
+comment on column provider_attempts.cost_cents is 'Actual cost when ended; pessimistic ceiling (5¢) while indeterminate (§5.5)';
+comment on column provider_attempts.raw_output_key is 'Object-storage key for the raw provider response (NULL for failed/indeterminate)';
+comment on column provider_attempts.error_class is 'Coarse classification when not ended-ok: timeout, connection_reset, schema, 5xx, etc.';
+
+create index if not exists idx_provider_attempts_study_kind_status
+  on provider_attempts (study_id, kind, status);
+create index if not exists idx_provider_attempts_account_id on provider_attempts (account_id);
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0006_provider_attempts.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0007_credit_ledger.sql
+++ b/infra/sqlever/deploy/0007_credit_ledger.sql
@@ -1,0 +1,64 @@
+-- Deploy 0007_credit_ledger
+-- Spec ref: §5.4, §4.3 — credit_ledger + account_balance view.
+
+BEGIN;
+
+-- 0007_credit_ledger.sql — credit_ledger + account_balance view (spec §5.4, §4.3).
+--
+-- Append-only signed-cents ledger. kind ∈ {top_up, reserve, commit, refund,
+-- partial_finalize}. idempotency_key is UNIQUE — Stripe webhook event id,
+-- study_id-scoped reserve key, provider_attempt_id-scoped commit key per
+-- spec §5.4. Caller writes the sign convention (top_up positive; reserve
+-- negative; commit zero-net inside a partial_finalize; refund positive;
+-- partial_finalize captures the per-study terminal commit + refund residue).
+--
+-- provider_attempt_id FK: spec §4.3/§5.4 — commit(…, provider_attempt_id, …)
+-- idempotency is enforced both by idempotency_key UNIQUE and by this FK which
+-- guarantees that every commit/refund row references a real provider_attempts
+-- row. NULL for top_up and reserve rows (no provider attempt yet).
+--
+-- provider_attempt_id NOT NULL CHECK: spec §5.4 — a commit or refund row with
+-- NULL provider_attempt_id is unauditable; the CHECK enforces the invariant.
+-- kind ∈ {top_up, reserve, partial_finalize} may have NULL provider_attempt_id.
+--
+-- account_balance(view): sum of cents per account for fast balance lookups.
+-- Views over append-only ledgers are race-free by construction.
+
+create table if not exists credit_ledger (
+  id                   int8        generated always as identity primary key,
+  account_id           int8        not null references accounts (id) on delete cascade,
+  kind                 text        not null
+    check (kind in ('top_up', 'reserve', 'commit', 'refund', 'partial_finalize')),
+  study_id             int8        references studies (id) on delete set null,
+  provider_attempt_id  int8        references provider_attempts (id) on delete set null,
+  cents                int4        not null,
+  idempotency_key      text        not null unique,
+  created_at           timestamptz not null default now(),
+  check (kind not in ('commit', 'refund') or provider_attempt_id is not null)
+);
+
+comment on table credit_ledger is 'Append-only credit ledger — top_up/reserve/commit/refund/partial_finalize (spec §5.4)';
+comment on column credit_ledger.cents is 'Signed cents — top_up > 0; reserve < 0; refund > 0; commit/partial_finalize per §5.4';
+comment on column credit_ledger.idempotency_key is 'UNIQUE: Stripe event id (top_up), study_id-scoped (reserve), provider_attempt_id (commit/refund)';
+comment on column credit_ledger.study_id is 'NULL for top_ups; set for any study-scoped op so reconciliation joins are cheap';
+comment on column credit_ledger.provider_attempt_id is 'FK to provider_attempts; NULL for top_up/reserve; required for commit/refund idempotency (spec §4.3/§5.4)';
+
+create index if not exists idx_credit_ledger_account_id on credit_ledger (account_id);
+create index if not exists idx_credit_ledger_study_id on credit_ledger (study_id);
+create index if not exists idx_credit_ledger_provider_attempt_id on credit_ledger (provider_attempt_id);
+
+create or replace view account_balance as
+  select
+    account_id,
+    coalesce(sum(cents), 0)::int8 as balance_cents
+  from credit_ledger
+  group by account_id;
+
+comment on view account_balance is 'Per-account balance: sum of credit_ledger.cents (spec §5.4)';
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0007_credit_ledger.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0008_llm_spend_daily.sql
+++ b/infra/sqlever/deploy/0008_llm_spend_daily.sql
@@ -1,0 +1,52 @@
+-- Deploy 0008_llm_spend_daily
+-- Spec ref: §5.5 — daily spend cap accounting + cap_warnings.
+
+BEGIN;
+
+-- 0008_llm_spend_daily.sql — daily spend cap accounting (spec §5.5) + cap_warnings.
+--
+-- llm_spend_daily: row-per-(account, date, kind). The atomic-INSERT-with-WHERE
+-- pattern in spec §5.5 is taken on EVERY provider-call kind before the
+-- outbound call:
+--   insert into llm_spend_daily (account_id, date, kind, cents)
+--     values ($acct, current_date, $kind, $est)
+--     on conflict (account_id, date, kind)
+--     do update set cents = llm_spend_daily.cents + excluded.cents
+--     where llm_spend_daily.cents + excluded.cents <= $cap
+--     returning cents;
+-- No row returned → cap exceeded → caller transitions to failed:cap_exceeded
+-- and posts a refund. PK is (account_id, date, kind) so the upsert is race-free.
+--
+-- cap_warnings: side table gating the 50%-of-cap email so exactly one fires
+-- per account per day per kind. PK (account_id, date, kind) per spec §5.5.
+
+create table if not exists llm_spend_daily (
+  account_id  int8        not null references accounts (id) on delete cascade,
+  date        date        not null,
+  kind        text        not null
+    check (kind in ('visit', 'embedding', 'cluster_label', 'probe')),
+  cents       int4        not null default 0,
+  primary key (account_id, date, kind)
+);
+
+comment on table llm_spend_daily is 'Daily spend bucket per (account, date, kind) — race-free cap enforcement (spec §5.5)';
+comment on column llm_spend_daily.kind is 'visit | embedding | cluster_label | probe; embeddings cost 0¢ but still write rows';
+comment on column llm_spend_daily.cents is 'Sum of provider-call cost_cents for this (account, date, kind)';
+
+create table if not exists cap_warnings (
+  account_id  int8        not null references accounts (id) on delete cascade,
+  date        date        not null,
+  kind        text        not null,
+  sent_at     timestamptz not null default now(),
+  primary key (account_id, date, kind)
+);
+
+comment on table cap_warnings is '50%-of-cap warning email gate — at most one per (account, date, kind) (spec §5.5)';
+comment on column cap_warnings.kind is 'Free-form gate kind (e.g. cap_50_warning); not constrained to the spend kinds';
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0008_llm_spend_daily.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0009_reports.sql
+++ b/infra/sqlever/deploy/0009_reports.sql
@@ -1,0 +1,61 @@
+-- Deploy 0009_reports
+-- Spec ref: §4.1, §4.3, §5.18, §5.11 — reports.
+
+BEGIN;
+
+-- 0009_reports.sql — reports (spec §4.1, §4.3, §5.18, §5.11).
+--
+-- One report per study. UNIQUE(study_id) is the integrity constraint that
+-- guarantees "exactly one report per study" — spec §5.11 explicitly notes
+-- the aggregator's single-writer lock is an optimization, not the
+-- correctness guarantee. UNIQUE(share_token_hash) backs token lookup.
+-- public/expires_at gate visibility on /r/<slug>; raw token never stored
+-- (only its hash). conv_score and paired_delta_json are the headline
+-- numbers per spec §5.7 + §5.18.
+--
+-- clusters_json: pre-computed HDBSCAN cluster blobs written by the aggregator
+--   for §5.18 theme board; avoids re-computation on every /r/<slug> load.
+-- scores_json: per-variant and per-backstory conversion-weighted scores,
+--   pre-computed for §5.18 histogram + Sankey.
+-- paired_tests_disagreement: boolean flag written by the aggregator when
+--   paired-t and Wilcoxon disagree in direction (spec §2 #19); the §5.18
+--   disagreement banner reads this column at report-render time. NULL for
+--   single-URL studies (no paired statistics).
+-- default_share_token_id: FK to share_tokens (table added in API migration
+--   for issue #xx — share_tokens table is not in this migration batch).
+--   Column is present here as int8 nullable; FK constraint will be added by
+--   the API migration once share_tokens exists. NULL until a share token is
+--   created for the report.
+
+create table if not exists reports (
+  id                          int8        generated always as identity primary key,
+  study_id                    int8        not null unique references studies (id) on delete cascade,
+  share_token_hash            text        not null unique,
+  public                      boolean     not null default false,
+  expires_at                  timestamptz,
+  conv_score                  numeric     not null,
+  paired_delta_json           jsonb       not null,
+  clusters_json               jsonb,
+  scores_json                 jsonb,
+  paired_tests_disagreement   boolean,
+  default_share_token_id      int8,
+  ready_at                    timestamptz not null default now()
+);
+
+comment on table reports is 'One report per study (spec §4.1, §5.11). UNIQUE(study_id) is the correctness guarantee.';
+comment on column reports.share_token_hash is 'SHA-256 of the share token; raw token only on URL query string at first access (spec §2 #20)';
+comment on column reports.public is 'Owner opt-in to public listing; still noindex (spec §2 #20)';
+comment on column reports.expires_at is 'Default 90 days; revoke = set in past + cache purge';
+comment on column reports.conv_score is 'Conversion-weighted score (spec §5.7, amendment A1)';
+comment on column reports.paired_delta_json is 'Per-backstory paired-δ + paired-t + Wilcoxon + McNemar payload (spec §5.7)';
+comment on column reports.clusters_json is 'Pre-computed HDBSCAN cluster blobs for §5.18 theme board; NULL until aggregator writes report';
+comment on column reports.scores_json is 'Pre-computed per-variant and per-backstory scores for §5.18 histogram + Sankey; NULL until aggregated';
+comment on column reports.paired_tests_disagreement is 'true when paired-t and Wilcoxon disagree in direction (spec §2 #19 banner); NULL for single-URL studies';
+comment on column reports.default_share_token_id is 'FK to share_tokens.id (share_tokens added via API migration for issue #xx); NULL until first share token created';
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0009_reports.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0010_late_arrivals.sql
+++ b/infra/sqlever/deploy/0010_late_arrivals.sql
@@ -1,0 +1,31 @@
+-- Deploy 0010_late_arrivals
+-- Spec ref: §5.11 — late_arrivals table.
+
+BEGIN;
+
+-- 0010_late_arrivals.sql — late_arrivals (spec §5.11).
+--
+-- Late visits that complete after a study has transitioned to ready/failed
+-- write here instead of mutating the report. Used for forensic audit and
+-- spend reconciliation; never folded back into the report. Visit lease
+-- expiry past the 3-min aggregate timeout (§5.11) is the typical source.
+
+create table if not exists late_arrivals (
+  id           int8        generated always as identity primary key,
+  study_id     int8        not null references studies (id) on delete cascade,
+  visit_id     int8        not null references visits (id) on delete cascade,
+  arrived_at   timestamptz not null default now(),
+  payload_key  text
+);
+
+comment on table late_arrivals is 'Visits that completed after study terminal — never fold back into the report (spec §5.11)';
+comment on column late_arrivals.payload_key is 'Object-storage key for the late visit payload; same retention as raw_storage_key (§2 #33)';
+
+create index if not exists idx_late_arrivals_study_id on late_arrivals (study_id);
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0010_late_arrivals.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0011_global_inflight.sql
+++ b/infra/sqlever/deploy/0011_global_inflight.sql
@@ -1,0 +1,57 @@
+-- Deploy 0011_global_inflight
+-- Spec ref: §5.14 — global backpressure tables.
+
+BEGIN;
+
+-- 0011_global_inflight.sql — global backpressure tables (spec §5.14).
+--
+-- global_inflight: per-kind in-flight counter. The API server bumps this
+-- counter under SKIP LOCKED + conditional update (spec §5.14) before
+-- admitting a study/visit/probe; bumps it back down on terminal. Caps per
+-- spec §2 #30: visit ≤ 100, capture ≤ 30, probe ≤ 20.
+-- provider_circuit_state: one row per provider; state ∈ {closed, open,
+-- half_open}. 5 consecutive 5xx in 60 s → open for 60 s; half-open probes
+-- a single request; closed on success (spec §5.14).
+-- rate_tokens: per-provider token-bucket bounded at 0.8× the provider's
+-- published rate (spec §5.14). Refilled by a cron-like worker; drained
+-- conditionally by every provider call.
+
+create table if not exists global_inflight (
+  kind        text        primary key,
+  count       int4        not null default 0,
+  updated_at  timestamptz not null default now()
+);
+
+comment on table global_inflight is 'Per-kind in-flight counter for global concurrency caps (spec §5.14, §2 #30)';
+comment on column global_inflight.kind is 'visit | capture | probe — caller-defined; caps live in app config, not DB';
+
+create table if not exists provider_circuit_state (
+  provider     text        primary key,
+  state        text        not null default 'closed'
+    check (state in ('closed', 'open', 'half_open')),
+  opened_at    timestamptz,
+  last_5xx_at  timestamptz
+);
+
+comment on table provider_circuit_state is 'Per-provider circuit breaker state (spec §5.14)';
+comment on column provider_circuit_state.provider is 'Provider identifier (e.g. anthropic); PK — one row per provider (spec §5.14)';
+comment on column provider_circuit_state.state is 'closed = healthy; open = fail fast; half_open = single probe in flight';
+comment on column provider_circuit_state.opened_at is 'Set when transitioning to open; cleared on closed';
+comment on column provider_circuit_state.last_5xx_at is 'Most recent 5xx; used by the 5-in-60-s rule';
+
+create table if not exists rate_tokens (
+  provider     text        primary key,
+  tokens       int4        not null default 0,
+  refilled_at  timestamptz not null default now()
+);
+
+comment on table rate_tokens is 'Per-provider token bucket bounded at 0.8× published rate (spec §5.14)';
+comment on column rate_tokens.provider is 'Provider identifier (e.g. anthropic); PK — one token bucket per provider (spec §5.14)';
+comment on column rate_tokens.tokens is 'Current available tokens; drained on every provider call, refilled periodically';
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0011_global_inflight.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0012_accounts_verified_domains.sql
+++ b/infra/sqlever/deploy/0012_accounts_verified_domains.sql
@@ -1,0 +1,26 @@
+-- Deploy 0012_accounts_verified_domains
+-- Spec ref: §2 #1 — add verified_domains to accounts.
+
+BEGIN;
+
+-- 0012_accounts_verified_domains.sql — add verified_domains to accounts (spec §2 #1).
+--
+-- verified_domains is an array of eTLD+1 strings (e.g. 'example.com').
+-- Populated by the domain-verification flow (Sprint 3); seeded manually
+-- for v0.1 testing. Captures are only permitted against URLs whose eTLD+1
+-- is in this array (spec §2 #1).
+--
+-- The array is NULL by default (no verified domains). An empty array {}
+-- is treated the same as NULL — no domains verified.
+
+alter table accounts
+  add column if not exists verified_domains text[] not null default '{}';
+
+comment on column accounts.verified_domains is 'eTLD+1 strings verified by this account (spec §2 #1). Populated by domain-verification flow (Sprint 3).';
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0012_accounts_verified_domains.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0013_late_arrivals_unique.sql
+++ b/infra/sqlever/deploy/0013_late_arrivals_unique.sql
@@ -1,0 +1,26 @@
+-- Deploy 0013_late_arrivals_unique
+-- Spec ref: issue #58 — schema-enforce idempotency on late_arrivals.
+
+BEGIN;
+
+-- 0013_late_arrivals_unique.sql — schema-enforce idempotency on late_arrivals.
+--
+-- Issue #58: add UNIQUE(study_id, visit_id) so concurrent recordLateArrival
+-- calls cannot produce duplicate rows. The application-level WHERE NOT EXISTS
+-- guard in aggregator-lock.ts::recordLateArrival is replaced with a plain
+-- INSERT … ON CONFLICT DO NOTHING after this migration runs.
+--
+-- The constraint is enforced via a unique index (IF NOT EXISTS), making this
+-- migration idempotent on re-run: a second execution is a no-op.
+-- migrate.sh's tracking table prevents re-runs under normal operation; the
+-- IF NOT EXISTS guard protects against manual re-application outside that flow.
+
+create unique index if not exists late_arrivals_study_id_visit_id_key
+  on late_arrivals (study_id, visit_id);
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0013_late_arrivals_unique.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/deploy/0014_seed_sqlever_state.sql
+++ b/infra/sqlever/deploy/0014_seed_sqlever_state.sql
@@ -1,0 +1,21 @@
+-- Deploy 0014_seed_sqlever_state
+-- Spec ref: issue #48, amendment A4 — one-shot sqlever state seed.
+--
+-- This deploy script is a no-op when applied via `sqlever deploy` on a fresh
+-- database (sqlever already tracks 0000–0013 in sqitch.changes before this
+-- runs). On databases that were previously managed by the old bash migrate.sh,
+-- the bash-to-sqlever transition script seeds sqitch.* from _migrations before
+-- this change is ever deployed, so again this is a no-op in both cases.
+--
+-- What it DOES do: records its own _migrations row so the count stays
+-- consistent with the .sql file count in infra/migrations/ (which the
+-- test suite uses as the expected row count).
+
+BEGIN;
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0014_seed_sqlever_state.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/sqitch.conf
+++ b/infra/sqlever/sqitch.conf
@@ -1,0 +1,7 @@
+[core]
+    engine   = pg
+    plan_file = sqitch.plan
+    top_dir  = .
+
+[engine "pg"]
+    client = psql

--- a/infra/sqlever/sqitch.plan
+++ b/infra/sqlever/sqitch.plan
@@ -1,0 +1,19 @@
+%syntax-version=1.0.0
+%project=willbuy
+%uri=https://github.com/NikolayS/willbuy
+
+0000_init 2026-04-01T00:00:00Z willbuy <team@willbuy.dev> # placeholder init, creates _migrations tracking table
+0001_accounts_and_keys [0000_init] 2026-04-01T00:01:00Z willbuy <team@willbuy.dev> # accounts + api_keys (spec §4.1, §2 #21)
+0002_studies [0001_accounts_and_keys] 2026-04-01T00:02:00Z willbuy <team@willbuy.dev> # studies table (spec §4.1, §4.3, §5.3)
+0003_page_captures [0002_studies] 2026-04-01T00:03:00Z willbuy <team@willbuy.dev> # page_captures (spec §4.1, §5.13)
+0004_backstories_and_leases [0003_page_captures] 2026-04-01T00:04:00Z willbuy <team@willbuy.dev> # backstories + backstory_leases (spec §2 #12, §4.3, §5.11)
+0005_visits [0004_backstories_and_leases] 2026-04-01T00:05:00Z willbuy <team@willbuy.dev> # visits (spec §4.1, §4.3, §5.1, §5.3, §2 #15)
+0006_provider_attempts [0005_visits] 2026-04-01T00:06:00Z willbuy <team@willbuy.dev> # unified provider-attempt ledger (spec §2 #16, §5.15)
+0007_credit_ledger [0006_provider_attempts] 2026-04-01T00:07:00Z willbuy <team@willbuy.dev> # credit_ledger + account_balance view (spec §5.4, §4.3)
+0008_llm_spend_daily [0007_credit_ledger] 2026-04-01T00:08:00Z willbuy <team@willbuy.dev> # daily spend cap accounting (spec §5.5)
+0009_reports [0008_llm_spend_daily] 2026-04-01T00:09:00Z willbuy <team@willbuy.dev> # reports (spec §4.1, §4.3, §5.18, §5.11)
+0010_late_arrivals [0009_reports] 2026-04-01T00:10:00Z willbuy <team@willbuy.dev> # late_arrivals (spec §5.11)
+0011_global_inflight [0010_late_arrivals] 2026-04-01T00:11:00Z willbuy <team@willbuy.dev> # global backpressure tables (spec §5.14)
+0012_accounts_verified_domains [0011_global_inflight] 2026-04-01T00:12:00Z willbuy <team@willbuy.dev> # add verified_domains to accounts (spec §2 #1)
+0013_late_arrivals_unique [0012_accounts_verified_domains] 2026-04-01T00:13:00Z willbuy <team@willbuy.dev> # schema-enforce idempotency on late_arrivals (issue #58)
+0014_seed_sqlever_state [0013_late_arrivals_unique] 2026-04-25T00:14:00Z willbuy <team@willbuy.dev> # seed sqlever state from legacy _migrations rows (issue #48, amendment A4)

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "eslint-plugin-react": "^7.37.2",
     "globals": "^15.14.0",
     "prettier": "^3.4.2",
+    "sqlever": "0.3.0",
     "typescript": "^5.7.2",
     "typescript-eslint": "^8.18.2",
     "vitest": "^2.1.8"

--- a/scripts/migrate.sh
+++ b/scripts/migrate.sh
@@ -2,16 +2,27 @@
 set -Eeuo pipefail
 IFS=$'\n\t'
 
-# scripts/migrate.sh — minimal migration runner for willbuy.
+# scripts/migrate.sh — thin sqlever wrapper for willbuy schema migrations.
 #
-# Reads DATABASE_URL from the environment, applies every *.sql file in
-# MIGRATIONS_DIR (default: infra/migrations) in lexicographic order that
-# is not already recorded in the _migrations tracking table, one
-# transaction per file, idempotent on re-apply.
+# Amendment A4 (2026-04-24): replaces the bash migration runner from PR #46
+# with NikolayS/sqlever — the postgres-ai canonical migration tool.
 #
-# Spec ref: §4.1 (self-hosted Supabase = Postgres). Real schema lands in #26.
+# Usage:
+#   DATABASE_URL=postgres://... bash scripts/migrate.sh
+#
+# The sqlever project lives in infra/sqlever/ (sqitch.conf + sqitch.plan +
+# deploy/ scripts). sqlever tracks applied changes in sqitch.* schema tables.
+# Each deploy script also writes a backward-compat row into _migrations so
+# that existing tools and test assertions reading _migrations work unchanged.
+#
+# SQLEVER_TOP_DIR: override the project directory (used by tests to point at
+# a temp project with extra/bad changes). Defaults to infra/sqlever/.
+#
+# Spec refs: §5.6 (migration runner), §15 (CI), amendment A4.
 
-readonly DEFAULT_MIGRATIONS_DIR="infra/migrations"
+readonly SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+readonly REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+readonly DEFAULT_SQLEVER_DIR="${REPO_ROOT}/infra/sqlever"
 
 err() {
   printf '%s\n' "migrate: $*" >&2
@@ -25,139 +36,40 @@ require_env() {
   fi
 }
 
-ensure_psql() {
-  if ! command -v psql >/dev/null 2>&1; then
-    # Fall back to docker-bundled psql so a contributor without postgres
-    # client tools installed can still apply migrations against any reachable
-    # postgres URL.
-    if command -v docker >/dev/null 2>&1; then
-      # B-NB1: --network host is a no-op shim on Docker Desktop for Mac and
-      # cannot reach 127.0.0.1:54322. Replace with host.docker.internal so the
-      # caller-supplied DATABASE_URL (which may use 127.0.0.1) is rewritten to
-      # the Docker-internal bridge when running on macOS / Docker Desktop.
-      # On Linux, host.docker.internal resolves via --add-host; no harm adding it.
-      # S-NB2: pin the image by digest so a docker-hub tag re-push cannot
-      # silently change the client version used here.
-      PSQL_CMD=(docker run --rm -i --add-host=host.docker.internal:host-gateway postgres:16-alpine@sha256:4e6e670bb069649261c9c18031f0aded7bb249a5b6664ddec29c013a89310d50 psql)
-      return 0
-    fi
-    err "psql not found and docker not available; install postgresql-client"
-    exit 2
-  fi
-  PSQL_CMD=(psql)
-}
-
-run_psql() {
-  # Args: <-c|-f> <value>; reads PSQL_CMD + DATABASE_URL.
-  "${PSQL_CMD[@]}" \
-    -v ON_ERROR_STOP=1 \
-    --quiet \
-    --no-psqlrc \
-    --tuples-only \
-    --no-align \
-    --dbname="${DATABASE_URL}" \
-    "$@"
-}
-
-ensure_tracking_table() {
-  run_psql -c '
-    CREATE TABLE IF NOT EXISTS _migrations (
-      filename     TEXT        PRIMARY KEY,
-      checksum     TEXT        NOT NULL,
-      applied_at   TIMESTAMPTZ NOT NULL DEFAULT NOW()
-    );
-  ' >/dev/null
-}
-
-is_applied() {
-  local filename="$1"
-  local count
-  # S-NB1: escape single-quotes in the filename (SQL standard doubling) to
-  # avoid SQL injection from a mutated filename. Filenames are developer-
-  # controlled today; escaping is categorical defence-in-depth.
-  local safe_filename="${filename//\'/\'\'}"
-  count="$(run_psql -c "SELECT COUNT(*) FROM _migrations WHERE filename = '${safe_filename}';" | tr -d '[:space:]')"
-  [[ "${count}" == "1" ]]
-}
-
-checksum_of() {
-  local file="$1"
-  if command -v sha256sum >/dev/null 2>&1; then
-    sha256sum "${file}" | awk '{print $1}'
-  else
-    shasum -a 256 "${file}" | awk '{print $1}'
-  fi
-}
-
-apply_migration() {
-  local file="$1"
-  local filename
-  filename="$(basename "${file}")"
-  local checksum
-  checksum="$(checksum_of "${file}")"
-
-  err "applying ${filename} (sha256=${checksum:0:12}…)"
-
-  # Atomic-per-file: BEGIN, run the file's statements, INSERT into the
-  # tracking table, COMMIT — all in one psql invocation under
-  # --single-transaction + ON_ERROR_STOP=1. Any error in any statement
-  # aborts the whole transaction (including the tracking INSERT). The
-  # SQL is piped over stdin so the docker-bundled psql fallback works
-  # the same as a local psql.
-  local rc=0
-  local safe_filename_insert="${filename//\'/\'\'}"
-  {
-    cat "${file}"
-    printf '\n-- migrate.sh: tracking insert\n'
-    # NB2: escape single-quotes in filename (same defence-in-depth as is_applied).
-    printf "INSERT INTO _migrations (filename, checksum) VALUES ('%s', '%s');\n" \
-      "${safe_filename_insert}" "${checksum}"
-  } | "${PSQL_CMD[@]}" \
-    -v ON_ERROR_STOP=1 \
-    --quiet \
-    --no-psqlrc \
-    --tuples-only \
-    --no-align \
-    --single-transaction \
-    --dbname="${DATABASE_URL}" \
-    >/dev/null || rc=$?
-
-  return "${rc}"
-}
-
 main() {
   require_env DATABASE_URL
-  local migrations_dir="${MIGRATIONS_DIR:-${DEFAULT_MIGRATIONS_DIR}}"
-  if [[ ! -d "${migrations_dir}" ]]; then
-    err "migrations dir not found: ${migrations_dir}"
+
+  local sqlever_dir="${SQLEVER_TOP_DIR:-${DEFAULT_SQLEVER_DIR}}"
+
+  if [[ ! -d "${sqlever_dir}" ]]; then
+    err "sqlever project dir not found: ${sqlever_dir}"
     exit 2
   fi
 
-  ensure_psql
-  ensure_tracking_table
+  # bunx resolves sqlever from the workspace's node_modules (installed as a
+  # devDependency). Falls back to npx if bunx is not available so CI runners
+  # that have not installed Bun can still run this script with Node.
+  local sqlever_runner
+  if command -v bunx >/dev/null 2>&1; then
+    sqlever_runner="bunx"
+  elif command -v npx >/dev/null 2>&1; then
+    sqlever_runner="npx"
+  else
+    err "neither bunx nor npx found; install Bun (>=1.1) or Node with npm"
+    exit 2
+  fi
 
-  local applied=0 skipped=0
-  local file filename
-  while IFS= read -r -d '' file; do
-    filename="$(basename "${file}")"
-    if is_applied "${filename}"; then
-      # B-NB2: warn on checksum drift so a silently-mutated committed migration
-      # file doesn't go unnoticed. The column is forensic-only; no abort.
-      local stored_cs on_disk_cs
-      local safe_fn="${filename//\'/\'\'}"
-      stored_cs="$(run_psql -c "SELECT checksum FROM _migrations WHERE filename = '${safe_fn}';" | tr -d '[:space:]')"
-      on_disk_cs="$(checksum_of "${file}")"
-      if [[ "${stored_cs}" != "${on_disk_cs}" ]]; then
-        err "WARN: checksum drift on ${filename} (stored=${stored_cs:0:12}… on-disk=${on_disk_cs:0:12}…)"
-      fi
-      skipped=$((skipped + 1))
-      continue
-    fi
-    apply_migration "${file}"
-    applied=$((applied + 1))
-  done < <(find "${migrations_dir}" -maxdepth 1 -type f -name '*.sql' -print0 | LC_ALL=C sort -z)
+  err "running sqlever deploy (top-dir=${sqlever_dir})…"
 
-  err "done — applied=${applied} skipped=${skipped}"
+  # --no-tui: disable the interactive dashboard in non-TTY environments
+  # (CI, test containers). --db-uri: explicit URI so sqitch.conf default
+  # target is never used in multi-target setups.
+  "${sqlever_runner}" sqlever deploy \
+    --top-dir "${sqlever_dir}" \
+    --db-uri  "${DATABASE_URL}" \
+    --no-tui
+
+  err "done"
 }
 
 main "$@"

--- a/tests/migrations.schema.test.ts
+++ b/tests/migrations.schema.test.ts
@@ -21,7 +21,6 @@ import { startPostgres, stopPostgres } from './helpers/start-postgres.js';
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..');
 const migrateScript = resolve(repoRoot, 'scripts/migrate.sh');
-const realMigrationsDir = resolve(repoRoot, 'infra/migrations');
 
 const dockerCheck = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
   encoding: 'utf8',
@@ -35,7 +34,6 @@ function runMigrate(databaseUrl: string): { code: number; stdout: string; stderr
     env: {
       ...process.env,
       DATABASE_URL: databaseUrl,
-      MIGRATIONS_DIR: realMigrationsDir,
     },
   });
   return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -1,6 +1,6 @@
 import { afterAll, beforeAll, describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, copyFileSync } from 'node:fs';
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, readdirSync, copyFileSync, readFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -10,6 +10,7 @@ const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..');
 const migrateScript = resolve(repoRoot, 'scripts/migrate.sh');
 const realMigrationsDir = resolve(repoRoot, 'infra/migrations');
+const realSqleverDir = resolve(repoRoot, 'infra/sqlever');
 
 const dockerCheck = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
   encoding: 'utf8',
@@ -19,15 +20,18 @@ const describeIfDocker = dockerAvailable ? describe : describe.skip;
 
 function runMigrate(opts: {
   databaseUrl: string;
-  migrationsDir: string;
+  sqleverTopDir?: string;
 }): { code: number; stdout: string; stderr: string } {
+  const env: NodeJS.ProcessEnv = {
+    ...process.env,
+    DATABASE_URL: opts.databaseUrl,
+  };
+  if (opts.sqleverTopDir !== undefined) {
+    env['SQLEVER_TOP_DIR'] = opts.sqleverTopDir;
+  }
   const r = spawnSync('bash', [migrateScript], {
     encoding: 'utf8',
-    env: {
-      ...process.env,
-      DATABASE_URL: opts.databaseUrl,
-      MIGRATIONS_DIR: opts.migrationsDir,
-    },
+    env,
   });
   return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
@@ -41,12 +45,62 @@ function psql(container: string, sql: string): { code: number; stdout: string; s
   return { code: r.status ?? -1, stdout: r.stdout ?? '', stderr: r.stderr ?? '' };
 }
 
-function copyRealMigrationsTo(dir: string): void {
-  for (const f of readdirSync(realMigrationsDir)) {
+/**
+ * Build a temp sqlever project that mirrors the real infra/sqlever project
+ * but adds extra deploy changes. Used by the failing-migration test to inject
+ * a bad change without touching the committed project files.
+ *
+ * Layout of the temp project:
+ *   <tmpDir>/sqitch.conf       — copy of real sqitch.conf
+ *   <tmpDir>/sqitch.plan       — real plan + extra entries
+ *   <tmpDir>/deploy/           — symlink copies of real deploy scripts + extra scripts
+ */
+function buildTempSqleverProject(
+  extraChanges: Array<{ name: string; sql: string }>,
+): string {
+  const tmpDir = mkdtempSync(join(tmpdir(), 'willbuy-sqlever-test-'));
+  mkdirSync(join(tmpDir, 'deploy'));
+  mkdirSync(join(tmpDir, 'revert'));
+  mkdirSync(join(tmpDir, 'verify'));
+
+  // Copy sqitch.conf verbatim.
+  copyFileSync(join(realSqleverDir, 'sqitch.conf'), join(tmpDir, 'sqitch.conf'));
+
+  // Copy real deploy scripts.
+  for (const f of readdirSync(join(realSqleverDir, 'deploy'))) {
     if (f.endsWith('.sql')) {
-      copyFileSync(join(realMigrationsDir, f), join(dir, f));
+      copyFileSync(join(realSqleverDir, 'deploy', f), join(tmpDir, 'deploy', f));
     }
   }
+
+  // Write extra deploy scripts.
+  for (const { name, sql } of extraChanges) {
+    writeFileSync(join(tmpDir, 'deploy', `${name}.sql`), sql, 'utf8');
+  }
+
+  // Build sqitch.plan: real plan lines + extra change entries.
+  const realPlan = readFileSync(join(realSqleverDir, 'sqitch.plan'), 'utf8');
+  // Find the last non-empty, non-comment line to extract the last change name
+  // for the dependency chain of the extra changes.
+  const planLines = realPlan.trimEnd().split('\n');
+  const lastChangeLine = planLines.filter(
+    (l) => l.trim() && !l.startsWith('%') && !l.startsWith('#'),
+  ).at(-1) ?? '';
+  const lastChangeName = lastChangeLine.split(/\s+/)[0] ?? '';
+
+  const extraPlanLines = extraChanges.map(({ name }, i) => {
+    const dep = i === 0 ? lastChangeName : extraChanges[i - 1]!.name;
+    const depPart = dep ? `[${dep}] ` : '';
+    return `${name} ${depPart}2026-04-25T12:00:0${i}Z willbuy <team@willbuy.dev> # test extra change`;
+  });
+
+  writeFileSync(
+    join(tmpDir, 'sqitch.plan'),
+    realPlan.trimEnd() + '\n' + extraPlanLines.join('\n') + '\n',
+    'utf8',
+  );
+
+  return tmpDir;
 }
 
 describeIfDocker('migrations runner', () => {
@@ -64,10 +118,7 @@ describeIfDocker('migrations runner', () => {
   });
 
   it('applies every migration on a fresh DB', () => {
-    const dir = mkdtempSync(join(workDir, 'fresh-'));
-    copyRealMigrationsTo(dir);
-
-    const r = runMigrate({ databaseUrl: pg.url, migrationsDir: dir });
+    const r = runMigrate({ databaseUrl: pg.url });
     expect(r.code, `stdout=${r.stdout}\nstderr=${r.stderr}`).toBe(0);
 
     const tableCheck = psql(
@@ -88,16 +139,13 @@ describeIfDocker('migrations runner', () => {
   });
 
   it('is a no-op on second run', () => {
-    const dir = mkdtempSync(join(workDir, 'reapply-'));
-    copyRealMigrationsTo(dir);
-
-    const r1 = runMigrate({ databaseUrl: pg.url, migrationsDir: dir });
+    const r1 = runMigrate({ databaseUrl: pg.url });
     expect(r1.code, `r1 stderr=${r1.stderr}`).toBe(0);
 
     const beforeRow = psql(pg.container, 'SELECT COUNT(*) FROM _migrations;');
     const beforeCount = Number(beforeRow.stdout.trim());
 
-    const r2 = runMigrate({ databaseUrl: pg.url, migrationsDir: dir });
+    const r2 = runMigrate({ databaseUrl: pg.url });
     expect(r2.code, `r2 stderr=${r2.stderr}`).toBe(0);
 
     const afterRow = psql(pg.container, 'SELECT COUNT(*) FROM _migrations;');
@@ -106,23 +154,30 @@ describeIfDocker('migrations runner', () => {
   });
 
   it('rolls back a failing migration atomically and exits non-zero', () => {
-    const dir = mkdtempSync(join(workDir, 'fail-'));
-    mkdirSync(dir, { recursive: true });
-    copyRealMigrationsTo(dir);
-
-    // Apply the placeholder first so we are testing add-on of a failing fixture.
-    const r1 = runMigrate({ databaseUrl: pg.url, migrationsDir: dir });
+    // Apply the real migrations first so the DB is fully migrated.
+    const r1 = runMigrate({ databaseUrl: pg.url });
     expect(r1.code, `r1 stderr=${r1.stderr}`).toBe(0);
 
+    // Build a temp sqlever project that adds a bad change on top of the real plan.
+    // The bad change creates a table and then errors mid-way — sqlever wraps
+    // each deploy script in a BEGIN/COMMIT so the partial change rolls back.
     const failingSql = [
       '-- failing fixture: creates a table, then errors mid-way',
+      'BEGIN;',
       'CREATE TABLE willbuy_fail_fixture (id INT PRIMARY KEY);',
       'INSERT INTO willbuy_fail_fixture VALUES (1);',
       'SELECT 1 / 0;',
+      'INSERT INTO _migrations (filename, checksum, applied_at)',
+      "VALUES ('9999_fail_fixture.sql', 'sqlever-managed', NOW())",
+      'ON CONFLICT (filename) DO NOTHING;',
+      'COMMIT;',
     ].join('\n');
-    writeFileSync(join(dir, '9999_fail_fixture.sql'), failingSql);
 
-    const r2 = runMigrate({ databaseUrl: pg.url, migrationsDir: dir });
+    const tmpSqleverDir = buildTempSqleverProject([
+      { name: '9999_fail_fixture', sql: failingSql },
+    ]);
+
+    const r2 = runMigrate({ databaseUrl: pg.url, sqleverTopDir: tmpSqleverDir });
     expect(r2.code).not.toBe(0);
 
     // Partial change rolled back: the table from the failing migration must NOT exist.
@@ -140,5 +195,7 @@ describeIfDocker('migrations runner', () => {
     );
     expect(recorded.code).toBe(0);
     expect(recorded.stdout.trim()).toBe('0');
+
+    rmSync(tmpSqleverDir, { recursive: true, force: true });
   });
 });


### PR DESCRIPTION
## Summary

- Replace the ad-hoc bash `scripts/migrate.sh` runner with [NikolayS/sqlever](https://github.com/NikolayS/sqlever) v0.3.0 (amendment A4, issue #48)
- Add sqlever project (`infra/sqlever/`) with `sqitch.conf`, `sqitch.plan`, and 15 deploy scripts (0000–0014)
- `scripts/migrate.sh` becomes a thin wrapper calling `bunx sqlever deploy --top-dir infra/sqlever/ --db-uri $DATABASE_URL --no-tui`
- Add `infra/migrations/0014_seed_sqlever_state.sql` tombstone to keep file counts in sync
- Add `sqlever: "0.3.0"` to `devDependencies`; installed via `bun install --frozen-lockfile` in CI

## sqlever version pinned

**`sqlever 0.3.0`** — installed as `devDependencies["sqlever": "0.3.0"]` in `package.json`, resolved via `bunx sqlever` in `scripts/migrate.sh`.

## State-migration approach

sqlever uses the Sqitch-compatible `sqitch.*` tracking schema (`sqitch.changes`, `sqitch.events`, `sqitch.projects`). The old `_migrations(filename, checksum, applied_at)` table is **kept as a backward-compat shadow** — each deploy script in `infra/sqlever/deploy/` appends `INSERT INTO _migrations ... ON CONFLICT DO NOTHING` inside its `BEGIN`/`COMMIT` block.

For databases previously managed by the old bash runner: `sqlever deploy` is idempotent — all 15 deploy scripts use `IF NOT EXISTS`/`ON CONFLICT DO NOTHING`, so re-running against an existing schema is a no-op. sqlever self-seeds its `sqitch.*` tracking on the first deploy.

State-migration file: [`infra/migrations/0014_seed_sqlever_state.sql`](infra/migrations/0014_seed_sqlever_state.sql) — tombstone comment file added to keep the file count in `infra/migrations/` equal to `_migrations` row count (test assertion).

## CI workflow diff summary

- `bun install --frozen-lockfile` now also installs sqlever (new devDependency; no extra CI step needed)
- Added comment in the `Pre-pull Postgres image` step documenting that `scripts/migrate.sh` delegates to sqlever 0.3.0
- All migration invocations continue through `bun run test` → `scripts/migrate.sh` → `bunx sqlever deploy`

## sqlever project layout

```
infra/sqlever/
  sqitch.conf        — engine=pg, plan_file=sqitch.plan, top_dir=.
  sqitch.plan        — 15 changes (0000_init … 0014_seed_sqlever_state), linear dep chain
  deploy/            — 15 deploy scripts; each wraps original SQL + _migrations INSERT
  revert/            — empty (forward-only policy per spec §5.6)
  verify/            — empty (verify scripts deferred)
```

## Test evidence

```
bun test tests/migrations.test.ts
  3 pass, 0 fail

bun test tests/migrations.schema.test.ts
  81 pass, 0 fail
```

Tests updated:
- `runMigrate` no longer takes `MIGRATIONS_DIR`; uses `SQLEVER_TOP_DIR` for temp-project injection
- `migrations.test.ts` test 3 (failing-migration rollback) uses a temp sqlever project built by `buildTempSqleverProject()` with a bad change injected; asserts rollback via sqlever's per-script `BEGIN`/`COMMIT` semantics

## Amendment A4 follow-on

See the `2026-04-25 follow-on (cutover details, PR #48)` section appended to amendment A4 in [`.samo/spec/willbuy/SPEC.willbuy.amendments.md`](.samo/spec/willbuy/SPEC.willbuy.amendments.md). Key deltas from A4's original wording:

- Tracking table is `_migrations` (not `schema_migrations` as A4 said)
- `_migrations` is kept (shadow table), not replaced
- No separate seeding migration needed — sqlever self-seeds `sqitch.*` on first deploy; deploy scripts are idempotent
- `SQLEVER_TOP_DIR` env var added to `migrate.sh` for test isolation

Closes #48