### PR TITLE
chore(api): address 3 REV non-blocking observations from PR #14 (#16)

### DIFF
--- a/apps/api/src/logger.ts
+++ b/apps/api/src/logger.ts
@@ -24,39 +24,59 @@ export function hashUrl(salt: string, url: string): string {
     .slice(0, 16);
 }
 
+// Fix 1: removed unreachable `typeof key !== 'string'` branch — the only call
+// site already guards with `typeof v === 'string'` before invoking maskApiKey.
 function maskApiKey(key: string): string {
-  if (typeof key !== 'string') return '***';
   const last4 = key.slice(-4);
   return `***${last4}`;
+}
+
+// Returns true when `value` is a complete URL string (not a substring within
+// a longer sentence). Used by Fix 3 to hash bare-URL values regardless of
+// field name.
+const BARE_URL_RE = /^https?:\/\/\S+$/;
+function isBareUrl(value: unknown): value is string {
+  return typeof value === 'string' && BARE_URL_RE.test(value);
 }
 
 // Recursively rewrite a log payload per the spec §5.12 redaction policy.
 // We do this in a custom serializer (not pino's `redact` paths) because the
 // spec requires field-name based stripping at any nesting depth, including
 // inside arbitrary user-supplied context objects.
-function redact(value: unknown, salt: string, seen: WeakSet<object>): unknown {
+//
+// Fix 2: `ancestry` tracks only the current call stack (depth-first path),
+// not every object ever visited. When we leave a node we remove it from the
+// set (backtracking), so a DAG node reachable via two paths is NOT falsely
+// reported as [Circular] — only a node that is an ancestor of itself is.
+function redact(value: unknown, salt: string, ancestry = new WeakSet<object>()): unknown {
   if (value === null || typeof value !== 'object') return value;
-  if (seen.has(value as object)) return '[Circular]';
-  seen.add(value as object);
-
-  if (Array.isArray(value)) {
-    return value.map((v) => redact(v, salt, seen));
-  }
-
-  const out: Record<string, unknown> = {};
-  for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
-    if (REMOVE_FIELDS.has(k)) continue;
-    if (k === URL_FIELD && typeof v === 'string') {
-      out['url_hash'] = hashUrl(salt, v);
-      continue;
+  if (ancestry.has(value as object)) return '[Circular]';
+  ancestry.add(value as object);
+  try {
+    if (Array.isArray(value)) {
+      return value.map((v) => redact(v, salt, ancestry));
     }
-    if (k === API_KEY_FIELD && typeof v === 'string') {
-      out[k] = maskApiKey(v);
-      continue;
+
+    const out: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      if (REMOVE_FIELDS.has(k)) continue;
+      if (k === API_KEY_FIELD && typeof v === 'string') {
+        out[k] = maskApiKey(v);
+        continue;
+      }
+      // Fix 3: hash any field whose entire value is a bare URL (https?://…),
+      // not just the literal field name "url". Emit <fieldName>_hash so the
+      // original key is replaced and the raw URL never reaches the log line.
+      if (isBareUrl(v)) {
+        out[`${k}_hash`] = hashUrl(salt, v);
+        continue;
+      }
+      out[k] = redact(v, salt, ancestry);
     }
-    out[k] = redact(v, salt, seen);
+    return out;
+  } finally {
+    ancestry.delete(value as object); // backtrack: remove when leaving this node
   }
-  return out;
 }
 
 export interface BuildLoggerOptions {
@@ -67,7 +87,7 @@ export interface BuildLoggerOptions {
 export function buildLogger(opts: BuildLoggerOptions, dest?: Writable): Logger {
   const formatters: NonNullable<LoggerOptions['formatters']> = {
     log(obj) {
-      return redact(obj, opts.urlHashSalt, new WeakSet()) as Record<string, unknown>;
+      return redact(obj, opts.urlHashSalt) as Record<string, unknown>;
     },
   };
   const options: LoggerOptions = {

--- a/apps/api/src/logger.ts
+++ b/apps/api/src/logger.ts
@@ -14,7 +14,6 @@ const REMOVE_FIELDS = new Set([
   'provider_payload',
   'password',
 ]);
-const URL_FIELD = 'url';
 const API_KEY_FIELD = 'api_key';
 
 export function hashUrl(salt: string, url: string): string {

--- a/apps/api/test/redact.test.ts
+++ b/apps/api/test/redact.test.ts
@@ -1,0 +1,127 @@
+/**
+ * redact.test.ts — TDD acceptance tests for PR #14 review findings (issue #16).
+ *
+ * Fix 1: maskApiKey dead branch — no new test needed (branch deleted, existing
+ *        tests still cover the happy-path masking behaviour).
+ * Fix 2: WeakSet DAG false-positive and real-cycle detection.
+ * Fix 3: URL hashing extended to any field whose value is a full https?:// URL.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { Writable } from 'node:stream';
+
+import { buildLogger, hashUrl } from '../src/logger.js';
+
+function captureLogs(salt: string): {
+  logs: () => Array<Record<string, unknown>>;
+  logger: ReturnType<typeof buildLogger>;
+} {
+  const chunks: string[] = [];
+  const stream = new Writable({
+    write(chunk, _enc, cb) {
+      chunks.push(chunk.toString('utf8'));
+      cb();
+    },
+  });
+  const logger = buildLogger({ level: 'info', urlHashSalt: salt }, stream);
+  return {
+    logs: () =>
+      chunks
+        .join('')
+        .split('\n')
+        .filter((l) => l.length > 0)
+        .map((l) => JSON.parse(l) as Record<string, unknown>),
+    logger,
+  };
+}
+
+const salt = 's'.repeat(40);
+
+// ---------------------------------------------------------------------------
+// Fix 2 — DAG: shared leaf object must NOT be reported as [Circular]
+// ---------------------------------------------------------------------------
+describe('Fix 2 — DAG shared object is not falsely flagged as [Circular]', () => {
+  it('{a: shared, b: shared} — both a.x and b.x should equal the original value', () => {
+    const { logger, logs } = captureLogs(salt);
+    const shared = { x: 'safe' };
+    logger.info({ a: shared, b: shared }, 'dag test');
+    const [rec] = logs();
+    const a = rec!['a'] as Record<string, unknown>;
+    const b = rec!['b'] as Record<string, unknown>;
+    expect(a['x']).toBe('safe');
+    expect(b['x']).toBe('safe');
+    // Neither branch should be [Circular]
+    expect(a['x']).not.toBe('[Circular]');
+    expect(b['x']).not.toBe('[Circular]');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 2 — Real cycle: a self-referencing object MUST be reported as [Circular]
+// ---------------------------------------------------------------------------
+describe('Fix 2 — real circular reference is detected and reported', () => {
+  it('a.self = a → a.self should be "[Circular]"', () => {
+    const { logger, logs } = captureLogs(salt);
+    const a: Record<string, unknown> = { id: 'node' };
+    a['self'] = a; // real cycle
+    logger.info({ node: a }, 'cycle test');
+    const [rec] = logs();
+    const node = rec!['node'] as Record<string, unknown>;
+    expect(node['self']).toBe('[Circular]');
+    expect(node['id']).toBe('node');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Fix 3 — URL hashing extended to any *_url fields and full-URL values
+// ---------------------------------------------------------------------------
+describe('Fix 3 — URL hashing on non-"url" field names', () => {
+  it('hashes redirect_url, webhook_url, target_url fields', () => {
+    const { logger, logs } = captureLogs(salt);
+    const redirectUrl = 'https://example.com/redirect';
+    const webhookUrl = 'https://hooks.example.com/webhook/abc';
+    const targetUrl = 'https://target.example.net/page';
+    logger.info(
+      {
+        redirect_url: redirectUrl,
+        webhook_url: webhookUrl,
+        target_url: targetUrl,
+        safe_field: 'unchanged',
+      },
+      'url fields test',
+    );
+    const [rec] = logs();
+    // Original field names should be gone or replaced
+    expect(rec!['redirect_url']).toBeUndefined();
+    expect(rec!['redirect_url_hash']).toBe(hashUrl(salt, redirectUrl));
+    expect(rec!['webhook_url']).toBeUndefined();
+    expect(rec!['webhook_url_hash']).toBe(hashUrl(salt, webhookUrl));
+    expect(rec!['target_url']).toBeUndefined();
+    expect(rec!['target_url_hash']).toBe(hashUrl(salt, targetUrl));
+    expect(rec!['safe_field']).toBe('unchanged');
+    // Raw hostnames must not appear
+    const ser = JSON.stringify(rec);
+    expect(ser).not.toContain('example.com/redirect');
+    expect(ser).not.toContain('hooks.example.com');
+    expect(ser).not.toContain('target.example.net');
+  });
+
+  it('does NOT hash a description field that merely contains a URL as a substring', () => {
+    const { logger, logs } = captureLogs(salt);
+    const desc = 'see https://example.com for details';
+    logger.info({ description: desc }, 'substring url test');
+    const [rec] = logs();
+    // The full string should pass through unchanged because it is not a bare URL
+    expect(rec!['description']).toBe(desc);
+  });
+
+  it('hashes a string field whose entire value is a URL regardless of field name', () => {
+    const { logger, logs } = captureLogs(salt);
+    const fullUrl = 'https://example.com/path?q=1';
+    logger.info({ endpoint: fullUrl }, 'bare-url field test');
+    const [rec] = logs();
+    // endpoint value is a bare URL → should be hashed
+    expect(rec!['endpoint']).toBeUndefined();
+    expect(rec!['endpoint_hash']).toBe(hashUrl(salt, fullUrl));
+  });
+});

--- a/apps/api/test/stripe.test.ts
+++ b/apps/api/test/stripe.test.ts
@@ -465,6 +465,7 @@ describe('Stripe checkout error-handling (issue #73)', () => {
             STRIPE_PRICE_ID_STARTER: 'price_test_starter',
             STRIPE_PRICE_ID_GROWTH: 'price_test_growth',
             STRIPE_PRICE_ID_SCALE: 'price_test_scale',
+            SHARE_TOKEN_HMAC_KEY: 'x'.repeat(64),
           },
           stripe: throwingStripe,
         });


### PR DESCRIPTION
## Summary

- **Fix 1 — Dead branch in `maskApiKey`:** deleted the unreachable `typeof key !== 'string'` guard; the only call site already narrows to `string` before invoking the function. No behaviour change, no new test needed.
- **Fix 2 — WeakSet DAG false-positive:** switched from a global visited-set to an ancestry-only (depth-tracking) `WeakSet` with `finally { ancestry.delete(node) }` backtracking. A DAG node reachable via two paths is no longer falsely reported as `[Circular]`; real self-referential cycles are still caught.
- **Fix 3 — URL hashing extended to all bare-URL values:** instead of matching only the literal field name `url`, the redactor now hashes any string field whose entire value matches `^https?:\/\/\S+$` (option b from the issue). The output key becomes `<fieldName>_hash`. A `description` containing a URL as a substring is intentionally left untouched (full-string match only).

## Test summary

5 new tests in `apps/api/test/redact.test.ts` (TDD red→green):
- DAG shared object is not falsely flagged as `[Circular]`
- Real self-referential cycle (`a.self = a`) is correctly reported as `[Circular]`
- `redirect_url`, `webhook_url`, `target_url` fields are hashed
- `description: "see https://example.com for details"` is NOT hashed
- Arbitrary field (`endpoint`) whose full value is a bare URL is hashed

All 60 tests pass; `tsc --noEmit` clean.

Closes #16