### PR TITLE
chore(infra): migration-collision guard + next-migration generator (#100)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,13 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Check migration-number collisions (#100)
+        # Fail fast on duplicate 4-digit prefixes in infra/migrations/ or
+        # infra/sqlever/deploy/, missing deploy pairs, or missing sqitch.plan
+        # entries. Three collisions in one day (PR #89+#91, PR #95+#96) cost
+        # a ~30-min hotfix each — this is the cheap pre-test guard.
+        run: bash scripts/check-migrations.sh
+
       - name: Cache Playwright browsers
         uses: actions/cache@v4
         with:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -108,6 +108,10 @@ Then:
 
 Use binary units (KiB, MiB, GiB, TiB) for memory, storage, and data sizes in prose, reports, and documentation. Exception: provider-native config formats stay as the provider writes them (e.g. Postgres `shared_buffers = '2GB'`).
 
+## Working with migrations
+
+New migration? Use `bash scripts/next-migration.sh <slug>` — it picks the next free 4-digit prefix and creates both `infra/migrations/` and `infra/sqlever/deploy/` stubs at once. Then add the matching entry to `infra/sqlever/sqitch.plan`. CI runs `bash scripts/check-migrations.sh` (issue #100) to fail fast on prefix collisions.
+
 ## Commands you'll use a lot
 
 ```sh

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+# scripts/check-migrations.sh — guard against migration-number collisions.
+#
+# Issue #100. Three collisions in one day (PR #89+#91 on 0014, PR #95+#96 on
+# 0016, plus a near-miss on PR #82) each cost a ~30-min hotfix or in-PR
+# renumber. Run this in CI before tests so duplicates fail fast.
+#
+# Checks:
+#   1. No duplicate 4-digit prefixes in infra/migrations/.
+#   2. No duplicate 4-digit prefixes in infra/sqlever/deploy/.
+#   3. Every infra/migrations/00NN_*.sql has a matching deploy script.
+#   4. Every infra/sqlever/deploy/00NN_*.sql has a sqitch.plan entry.
+#
+# Run path is the cwd, so tests can point it at a fixture tree.
+
+migrations_dir="infra/migrations"
+sqlever_dir="infra/sqlever/deploy"
+plan_file="infra/sqlever/sqitch.plan"
+
+# Check 1: no duplicate prefixes in infra/migrations/.
+dups=$(ls "${migrations_dir}" | grep -oE '^[0-9]{4}' | sort | uniq -d || true)
+if [[ -n "${dups}" ]]; then
+  echo "ERROR: duplicate migration number prefix(es) in ${migrations_dir}: ${dups}" >&2
+  # Show the offending files so the engineer doesn't have to grep manually.
+  pattern=$(echo "${dups}" | tr '\n' '|' | sed 's/|$//')
+  ls "${migrations_dir}" | grep -E "^(${pattern})_" >&2 || true
+  exit 1
+fi
+
+# Check 2: no duplicate prefixes in infra/sqlever/deploy/.
+dups=$(ls "${sqlever_dir}" | grep -oE '^[0-9]{4}' | sort | uniq -d || true)
+if [[ -n "${dups}" ]]; then
+  echo "ERROR: duplicate migration number prefix(es) in ${sqlever_dir}: ${dups}" >&2
+  pattern=$(echo "${dups}" | tr '\n' '|' | sed 's/|$//')
+  ls "${sqlever_dir}" | grep -E "^(${pattern})_" >&2 || true
+  exit 1
+fi
+
+# Check 3: every infra/migrations/00NN_*.sql has a matching deploy script.
+missing_in_deploy=$(comm -23 \
+  <(ls "${migrations_dir}" | sort) \
+  <(ls "${sqlever_dir}" | sort) || true)
+if [[ -n "${missing_in_deploy}" ]]; then
+  echo "ERROR: migrations present in ${migrations_dir} but missing in ${sqlever_dir}:" >&2
+  echo "${missing_in_deploy}" >&2
+  exit 1
+fi
+
+# Check 4: every sqlever/deploy/00NN_*.sql has a sqitch.plan entry.
+for f in "${sqlever_dir}"/[0-9]*.sql; do
+  name=$(basename "${f}" .sql)
+  if ! grep -qE "^${name}\\b" "${plan_file}"; then
+    echo "ERROR: ${name} has no entry in ${plan_file}" >&2
+    exit 1
+  fi
+done
+
+count=$(ls "${migrations_dir}" | grep -c '^[0-9]')
+echo "migration-collision check: OK (${count} migrations, all unique, all paired, all in plan)"

--- a/scripts/next-migration.sh
+++ b/scripts/next-migration.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+# scripts/next-migration.sh — generate the next migration pair.
+#
+# Issue #100. Removes the manual step of looking at the highest existing
+# prefix and bumping by one — that's the step where parallel PRs collide.
+# This script picks the next free prefix and creates both the migrations/
+# and sqlever/deploy/ stub at once.
+#
+# Usage:
+#   bash scripts/next-migration.sh <slug>
+#
+# Don't forget to add the new entry to infra/sqlever/sqitch.plan.
+
+if [[ $# -lt 1 ]]; then
+  echo "usage: $0 <slug>" >&2
+  exit 1
+fi
+
+slug="$1"
+migrations_dir="infra/migrations"
+sqlever_dir="infra/sqlever/deploy"
+
+last=$(ls "${migrations_dir}" | grep -oE '^[0-9]{4}' | sort -n | tail -1)
+next=$(printf "%04d" $((10#${last} + 1)))
+name="${next}_${slug}"
+
+touch "${migrations_dir}/${name}.sql"
+touch "${sqlever_dir}/${name}.sql"
+
+echo "${name} created in both dirs. Don't forget to add to infra/sqlever/sqitch.plan."

--- a/tests/check-migrations.test.ts
+++ b/tests/check-migrations.test.ts
@@ -10,13 +10,7 @@
 //      tree is never touched.
 import { afterEach, describe, expect, it } from 'vitest';
 import { spawnSync } from 'node:child_process';
-import {
-  cpSync,
-  mkdtempSync,
-  readFileSync,
-  rmSync,
-  writeFileSync,
-} from 'node:fs';
+import { cpSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs';
 import { tmpdir } from 'node:os';
 import { dirname, join, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -54,10 +48,7 @@ describe('scripts/check-migrations.sh (#100)', () => {
       });
       // Induce the failure mode: clone 0014_share_tokens.sql under a new
       // name with the same 4-digit prefix.
-      const dupSrc = join(
-        fixtureRoot,
-        'infra/migrations/0014_share_tokens.sql',
-      );
+      const dupSrc = join(fixtureRoot, 'infra/migrations/0014_share_tokens.sql');
       const dupDst = join(fixtureRoot, 'infra/migrations/0014_dup.sql');
       writeFileSync(dupDst, readFileSync(dupSrc));
 

--- a/tests/check-migrations.test.ts
+++ b/tests/check-migrations.test.ts
@@ -1,0 +1,73 @@
+// Issue #100 — guard against migration-number collisions.
+//
+// Three collisions in one day (PR #89+#91 on 0014, PR #95+#96 on 0016, plus a
+// near-miss on PR #82) cost a ~30-min hotfix or in-PR renumber each. This test
+// pins the contract for `scripts/check-migrations.sh`:
+//
+//   1. Exit 0 against the current repo (no collisions, all paired, all in plan).
+//   2. Exit 1 with a clear stderr message when a duplicate prefix is dropped
+//      into infra/migrations/ — proven via a temp-fixture repo so the real
+//      tree is never touched.
+import { afterEach, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import {
+  cpSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  writeFileSync,
+} from 'node:fs';
+import { tmpdir } from 'node:os';
+import { dirname, join, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '..');
+const checkScript = resolve(repoRoot, 'scripts/check-migrations.sh');
+
+describe('scripts/check-migrations.sh (#100)', () => {
+  it('passes on the current repo', () => {
+    const r = spawnSync('bash', [checkScript], {
+      cwd: repoRoot,
+      encoding: 'utf8',
+    });
+    expect(r.status, `stdout:\n${r.stdout}\nstderr:\n${r.stderr}`).toBe(0);
+    expect(r.stdout).toMatch(/migration-collision check: OK/);
+  });
+
+  describe('fixture: induced duplicate prefix', () => {
+    let fixtureRoot: string | null = null;
+    afterEach(() => {
+      if (fixtureRoot !== null) {
+        rmSync(fixtureRoot, { recursive: true, force: true });
+        fixtureRoot = null;
+      }
+    });
+
+    it('fails with exit 1 and a clear stderr message', () => {
+      // Build a minimal fixture mirroring the real layout, then drop a
+      // duplicate-prefix file into it. We don't mutate the real repo.
+      fixtureRoot = mkdtempSync(join(tmpdir(), 'willbuy-mig-guard-'));
+      // Copy infra/ into the fixture (cheap: a few KiB of .sql).
+      cpSync(resolve(repoRoot, 'infra'), join(fixtureRoot, 'infra'), {
+        recursive: true,
+      });
+      // Induce the failure mode: clone 0014_share_tokens.sql under a new
+      // name with the same 4-digit prefix.
+      const dupSrc = join(
+        fixtureRoot,
+        'infra/migrations/0014_share_tokens.sql',
+      );
+      const dupDst = join(fixtureRoot, 'infra/migrations/0014_dup.sql');
+      writeFileSync(dupDst, readFileSync(dupSrc));
+
+      const r = spawnSync('bash', [checkScript], {
+        cwd: fixtureRoot,
+        encoding: 'utf8',
+      });
+      expect(r.status).toBe(1);
+      expect(r.stderr).toMatch(/duplicate migration number prefix/i);
+      expect(r.stderr).toContain('0014');
+    });
+  });
+});


### PR DESCRIPTION
Closes #100.

## Why

Three migration-number collisions in one day (Sprint 3): PR #89+#91 on
`0014`, PR #95+#96 on `0016`, plus a near-miss on PR #82. Each cost a
~30-min hotfix or in-PR renumber. This adds a cheap CI guard and a
generator so the manual "find the highest prefix and +1" step where
parallel PRs collide is gone.

## What

- **`scripts/check-migrations.sh`** — 4 checks, fail-fast:
  1. No duplicate 4-digit prefixes in `infra/migrations/`.
  2. No duplicate 4-digit prefixes in `infra/sqlever/deploy/`.
  3. Every `infra/migrations/00NN_*.sql` has a matching deploy.
  4. Every deploy script has an entry in `infra/sqlever/sqitch.plan`.
- **`scripts/next-migration.sh <slug>`** — picks the next free prefix
  and creates both stubs at once. Reminder to update `sqitch.plan`.
- **`.github/workflows/ci.yml`** — new step `Check migration-number
  collisions (#100)` runs right after `bun install`, before
  typecheck/lint/build/test, so duplicates fail in <30s.
- **`CLAUDE.md`** — one-liner under a new "Working with migrations"
  section pointing engineers at the generator.

## TDD

Two commits — RED (`6fa5c67`) then GREEN (`c2efe9e`).

The test (`tests/check-migrations.test.ts`) builds a temp-fixture copy
of `infra/`, drops a duplicate-prefix file in, and asserts exit 1 +
matching stderr. The real tree is never mutated, so no manual cleanup
is needed.

## Local evidence

Green case (current `main`):

```
$ bash scripts/check-migrations.sh
migration-collision check: OK (18 migrations, all unique, all paired, all in plan)
```

Manually-induced failure (against a temp copy of `infra/`, real tree
untouched):

```
$ tmp=$(mktemp -d) && cp -R infra "$tmp/infra" \
    && cp "$tmp/infra/migrations/0014_share_tokens.sql" \
          "$tmp/infra/migrations/0014_dup.sql" \
    && (cd "$tmp" && bash $PWD/scripts/check-migrations.sh; echo "exit=$?") \
    && rm -rf "$tmp"
ERROR: duplicate migration number prefix(es) in infra/migrations: 0014
0014_dup.sql
0014_share_tokens.sql
exit=1
```

Vitest:

```
$ ./node_modules/.bin/vitest run tests/check-migrations.test.ts
 ✓ |rest| tests/check-migrations.test.ts (2 tests) 83ms
 Test Files  1 passed (1)
      Tests  2 passed (2)
```

## Spec

Operational guard. No spec section affected; touches infra hygiene
only.

## Public-repo audit

No secrets, IPs, or VM identifiers in the diff.