### PR TITLE
feat(web+api): domain list page /dashboard/domains (#83)

### DIFF
--- a/apps/api/src/routes/domains.ts
+++ b/apps/api/src/routes/domains.ts
@@ -23,6 +23,25 @@
  *     accounts.verified_domains, returns { verified: true, method }.
  *     On no match: updates last_checked_at, returns { verified: false }.
  *
+ *   GET /api/domains                       — issue #83, list page.
+ *     Returns: { domains: [{ domain, verify_token, verified_at,
+ *                            last_checked_at, created_at }] }
+ *     Order: created_at DESC. Scoped to req.account.id.
+ *
+ *   DELETE /api/domains/:domain            — issue #83, list page.
+ *     Removes the row from domain_verifications AND drops the value from
+ *     accounts.verified_domains[] in a single transaction.
+ *     204 on success; 404 if the (account, domain) pair has no row
+ *     (looks identical for "doesn't exist" and "owned by another account"
+ *     to avoid leaking existence — spec §2 #20).
+ *
+ *   POST /api/domains/:domain/delete       — CSP-safe form workaround.
+ *     Browsers can only emit GET/POST from <form>; the dashboard runs
+ *     under a strict CSP (no inline JS), so a literal DELETE button via
+ *     fetch() is not an option for the no-JS list page. This route
+ *     performs the same SQL as DELETE and 302-redirects back to
+ *     /dashboard/domains so the user lands on a refreshed list.
+ *
  * Design notes:
  *   - The token is a 22-char nanoid (≈131 bits of entropy) — same length as
  *     the magic-link token in routes/auth.ts. Cleartext storage is fine here:
@@ -343,6 +362,132 @@ export async function registerDomainsRoutes(
         [row.id],
       );
       return reply.code(200).send({ verified: false });
+    },
+  );
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // GET /api/domains — list domains for the authenticated account (issue #83).
+  // ──────────────────────────────────────────────────────────────────────────
+  app.get(
+    '/api/domains',
+    { preHandler: [sessionMw] },
+    async (req: FastifyRequest, reply: FastifyReply) => {
+      const account = req.account!;
+      const r = await pool.query<{
+        domain: string;
+        verify_token: string;
+        verified_at: Date | null;
+        last_checked_at: Date | null;
+        created_at: Date;
+      }>(
+        `SELECT domain, verify_token, verified_at, last_checked_at, created_at
+           FROM domain_verifications
+          WHERE account_id = $1
+          ORDER BY created_at DESC, id DESC`,
+        [String(account.id)],
+      );
+      return reply.code(200).send({
+        domains: r.rows.map((row) => ({
+          domain: row.domain,
+          verify_token: row.verify_token,
+          verified_at: row.verified_at?.toISOString() ?? null,
+          last_checked_at: row.last_checked_at?.toISOString() ?? null,
+          created_at: row.created_at.toISOString(),
+        })),
+      });
+    },
+  );
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // DELETE /api/domains/:domain — remove a (account, domain) pair (issue #83).
+  //
+  // Atomic: drops the verification row AND removes the value from
+  // accounts.verified_domains[] in a single transaction so the list view
+  // can never show a "phantom" verified domain that's missing its challenge
+  // record (or vice-versa).
+  // ──────────────────────────────────────────────────────────────────────────
+  async function deleteDomainForAccount(
+    accountId: string,
+    domain: string,
+  ): Promise<boolean> {
+    const client = await pool.connect();
+    try {
+      await client.query('BEGIN');
+
+      // Use RETURNING to confirm the row was actually owned by this account.
+      // If 0 rows are deleted, the (account, domain) pair didn't exist or
+      // belonged to a different account — caller treats both as 404.
+      const del = await client.query(
+        `DELETE FROM domain_verifications
+          WHERE account_id = $1 AND domain = $2
+          RETURNING id`,
+        [accountId, domain],
+      );
+      if (del.rowCount === 0) {
+        await client.query('ROLLBACK');
+        return false;
+      }
+
+      // array_remove drops every occurrence of the value (NULL-safe).
+      await client.query(
+        `UPDATE accounts
+            SET verified_domains = array_remove(COALESCE(verified_domains, '{}'), $2)
+          WHERE id = $1`,
+        [accountId, domain],
+      );
+
+      await client.query('COMMIT');
+      return true;
+    } catch (err) {
+      try { await client.query('ROLLBACK'); } catch { /* ignore */ }
+      throw err;
+    } finally {
+      client.release();
+    }
+  }
+
+  app.delete<{ Params: { domain: string } }>(
+    '/api/domains/:domain',
+    { preHandler: [sessionMw] },
+    async (req, reply) => {
+      const account = req.account!;
+      const domain = normalizeEtldPlusOne(req.params.domain);
+      if (!domain) {
+        // Treat malformed domain identical to non-existent — same 404 shape.
+        return reply.code(404).send({ error: 'not found' });
+      }
+
+      const ok = await deleteDomainForAccount(String(account.id), domain);
+      if (!ok) {
+        return reply.code(404).send({ error: 'not found' });
+      }
+      // 204 No Content per HTTP semantics; no body.
+      return reply.code(204).send();
+    },
+  );
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // POST /api/domains/:domain/delete — form-submit fallback (issue #83).
+  //
+  // The /dashboard/domains list runs under a strict CSP (§5.10) and uses
+  // native HTML <form> posts instead of fetch() for the action buttons.
+  // Because forms can only emit GET or POST, this sibling route does the
+  // same work as DELETE and redirects back to the list page.
+  // ──────────────────────────────────────────────────────────────────────────
+  app.post<{ Params: { domain: string } }>(
+    '/api/domains/:domain/delete',
+    { preHandler: [sessionMw] },
+    async (req, reply) => {
+      const account = req.account!;
+      const domain = normalizeEtldPlusOne(req.params.domain);
+      if (!domain) {
+        return reply.code(404).send({ error: 'not found' });
+      }
+      // Best-effort delete: even if the row didn't exist, redirect back to
+      // the list. Any leak is bounded to "is this domain in your list" —
+      // which the user already sees on the page they came from.
+      await deleteDomainForAccount(String(account.id), domain);
+      return reply.code(302).redirect('/dashboard/domains');
     },
   );
 }

--- a/apps/api/test/domains-list.test.ts
+++ b/apps/api/test/domains-list.test.ts
@@ -1,0 +1,429 @@
+/**
+ * domains-list.test.ts — TDD acceptance tests for issue #83 (domain list page).
+ *
+ * Spec refs: §2 #1 (verified-domain authorization — tokens rotated on
+ *            verification-list changes), §4.1 (web app — Sprint 3).
+ *
+ * Routes under test (NEW in this PR — must NOT exist before this commit):
+ *   GET    /api/domains          — list account's domains
+ *   DELETE /api/domains/:domain  — remove a domain (and from
+ *                                   accounts.verified_domains)
+ *
+ * Both endpoints sit behind buildSessionMiddleware (wb_session cookie),
+ * matching the existing POST /api/domains and POST /api/domains/:d/verify
+ * routes added in PR #103 (issue #82).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { FastifyInstance } from 'fastify';
+import { Client } from 'pg';
+
+import { startPostgres, stopPostgres } from '../../../tests/helpers/start-postgres.js';
+import { buildServer } from '../src/server.js';
+import { encodeSession } from '../src/auth/session.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../..');
+const migrationsDir = resolve(repoRoot, 'infra/migrations');
+
+const dockerCheck = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+  encoding: 'utf8',
+});
+const dockerAvailable = dockerCheck.status === 0;
+const describeIfDocker = dockerAvailable ? describe : describe.skip;
+
+async function applyMigrations(url: string): Promise<void> {
+  const files = readdirSync(migrationsDir)
+    .filter((f) => /^\d{4}_.*\.sql$/.test(f))
+    .sort();
+  const client = new Client({ connectionString: url });
+  await client.connect();
+  try {
+    for (const file of files) {
+      const sql = readFileSync(resolve(migrationsDir, file), 'utf8');
+      await client.query(sql);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+const SESSION_HMAC_KEY = 'test_hmac_key_at_least_32_characters_long_abc';
+
+const BASE_ENV = {
+  PORT: 3099,
+  LOG_LEVEL: 'silent' as const,
+  URL_HASH_SALT: 'test_salt_at_least_32_characters_long_abc',
+  DAILY_CAP_CENTS: 10_000,
+  STRIPE_SECRET_KEY: 'sk_test_not_configured',
+  STRIPE_WEBHOOK_SECRET: 'whsec_not_configured',
+  STRIPE_PRICE_ID_STARTER: 'price_not_configured',
+  STRIPE_PRICE_ID_GROWTH: 'price_not_configured',
+  STRIPE_PRICE_ID_SCALE: 'price_not_configured',
+  RESEND_API_KEY: 're_test_dummy',
+  RESEND_TEST_MODE: 'stub' as const,
+  SESSION_HMAC_KEY,
+  NODE_ENV: 'test' as const,
+};
+
+function buildSessionCookie(accountId: string, email: string): string {
+  const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  const value = encodeSession(
+    { account_id: accountId, owner_email: email, expires_at: expiresAt },
+    SESSION_HMAC_KEY,
+  );
+  return `wb_session=${value}`;
+}
+
+describeIfDocker('domains list/delete routes (issue #83, real DB)', () => {
+  let container = '';
+  let dbUrl = '';
+  let app: FastifyInstance;
+  let accountIdA: string;
+  let accountIdB: string;
+  let cookieA: string;
+  let cookieB: string;
+
+  beforeAll(async () => {
+    const pg = await startPostgres({ containerPrefix: 'willbuy-domains-list-test-' });
+    container = pg.container;
+    dbUrl = pg.url;
+
+    await applyMigrations(dbUrl);
+
+    const db = new Client({ connectionString: dbUrl });
+    await db.connect();
+    try {
+      const a = await db.query<{ id: string }>(
+        `INSERT INTO accounts (owner_email) VALUES ('a@example.com') RETURNING id`,
+      );
+      accountIdA = a.rows[0]!.id;
+      const b = await db.query<{ id: string }>(
+        `INSERT INTO accounts (owner_email) VALUES ('b@example.com') RETURNING id`,
+      );
+      accountIdB = b.rows[0]!.id;
+    } finally {
+      await db.end();
+    }
+
+    cookieA = buildSessionCookie(accountIdA, 'a@example.com');
+    cookieB = buildSessionCookie(accountIdB, 'b@example.com');
+
+    app = await buildServer({
+      env: { ...BASE_ENV, DATABASE_URL: dbUrl },
+    });
+  }, 90_000);
+
+  afterAll(async () => {
+    await app?.close();
+    stopPostgres(container);
+  });
+
+  // Helpers for seeding state directly in DB so tests don't depend on probes.
+  async function seed(
+    accountId: string,
+    rows: Array<{
+      domain: string;
+      verify_token: string;
+      verified_at: Date | null;
+      last_checked_at: Date | null;
+      created_at?: Date;
+    }>,
+  ): Promise<void> {
+    const db = new Client({ connectionString: dbUrl });
+    await db.connect();
+    try {
+      for (const r of rows) {
+        await db.query(
+          `INSERT INTO domain_verifications
+             (account_id, domain, verify_token, verified_at, last_checked_at, created_at)
+           VALUES ($1, $2, $3, $4, $5, COALESCE($6, now()))
+           ON CONFLICT ON CONSTRAINT domain_verifications_account_domain_uniq
+             DO UPDATE SET verify_token = EXCLUDED.verify_token,
+                           verified_at = EXCLUDED.verified_at,
+                           last_checked_at = EXCLUDED.last_checked_at`,
+          [
+            accountId,
+            r.domain,
+            r.verify_token,
+            r.verified_at,
+            r.last_checked_at,
+            r.created_at ?? null,
+          ],
+        );
+        if (r.verified_at) {
+          await db.query(
+            `UPDATE accounts
+                SET verified_domains =
+                  CASE
+                    WHEN $2 = ANY(COALESCE(verified_domains, '{}')) THEN verified_domains
+                    ELSE COALESCE(verified_domains, '{}') || ARRAY[$2]::text[]
+                  END
+              WHERE id = $1`,
+            [accountId, r.domain],
+          );
+        }
+      }
+    } finally {
+      await db.end();
+    }
+  }
+
+  async function clearAll(): Promise<void> {
+    const db = new Client({ connectionString: dbUrl });
+    await db.connect();
+    try {
+      await db.query(`DELETE FROM domain_verifications`);
+      await db.query(`UPDATE accounts SET verified_domains = '{}'`);
+      await db.query(`DELETE FROM studies`);
+    } finally {
+      await db.end();
+    }
+  }
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC1: GET /api/domains → list ordered created_at DESC
+  // ──────────────────────────────────────────────────────────────────────────
+  it('AC1: GET /api/domains with valid session returns rows ordered by created_at DESC', async () => {
+    await clearAll();
+    const older = new Date(Date.now() - 60_000);
+    const newer = new Date();
+    await seed(accountIdA, [
+      {
+        domain: 'older.example',
+        verify_token: 'tok-older-zzzzzzzzzzzz',
+        verified_at: older,
+        last_checked_at: older,
+        created_at: older,
+      },
+      {
+        domain: 'newer.example',
+        verify_token: 'tok-newer-zzzzzzzzzzzz',
+        verified_at: null,
+        last_checked_at: null,
+        created_at: newer,
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/domains',
+      headers: { cookie: cookieA },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{
+      domains: Array<{
+        domain: string;
+        verify_token: string;
+        verified_at: string | null;
+        last_checked_at: string | null;
+        created_at: string;
+      }>;
+    }>();
+    expect(body.domains).toHaveLength(2);
+    expect(body.domains[0]!.domain).toBe('newer.example');
+    expect(body.domains[1]!.domain).toBe('older.example');
+    expect(body.domains[0]!.verified_at).toBeNull();
+    expect(body.domains[1]!.verified_at).not.toBeNull();
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC2: GET /api/domains without session → 401
+  // ──────────────────────────────────────────────────────────────────────────
+  it('AC2: GET /api/domains without session → 401', async () => {
+    const res = await app.inject({ method: 'GET', url: '/api/domains' });
+    expect(res.statusCode).toBe(401);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC3: cross-account isolation
+  // ──────────────────────────────────────────────────────────────────────────
+  it("AC3: account A cannot see account B's domains", async () => {
+    await clearAll();
+    await seed(accountIdA, [
+      {
+        domain: 'a-only.example',
+        verify_token: 'tok-a-zzzzzzzzzzzzzz',
+        verified_at: new Date(),
+        last_checked_at: new Date(),
+      },
+    ]);
+    await seed(accountIdB, [
+      {
+        domain: 'b-only.example',
+        verify_token: 'tok-b-zzzzzzzzzzzzzz',
+        verified_at: new Date(),
+        last_checked_at: new Date(),
+      },
+    ]);
+
+    const resA = await app.inject({
+      method: 'GET',
+      url: '/api/domains',
+      headers: { cookie: cookieA },
+    });
+    expect(resA.statusCode).toBe(200);
+    const a = resA.json<{ domains: Array<{ domain: string }> }>();
+    expect(a.domains.map((d) => d.domain)).toEqual(['a-only.example']);
+
+    const resB = await app.inject({
+      method: 'GET',
+      url: '/api/domains',
+      headers: { cookie: cookieB },
+    });
+    expect(resB.statusCode).toBe(200);
+    const b = resB.json<{ domains: Array<{ domain: string }> }>();
+    expect(b.domains.map((d) => d.domain)).toEqual(['b-only.example']);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC4: DELETE /api/domains/:domain → 204; row gone, removed from accounts.verified_domains
+  // ──────────────────────────────────────────────────────────────────────────
+  it('AC4: DELETE removes from domain_verifications and accounts.verified_domains', async () => {
+    await clearAll();
+    await seed(accountIdA, [
+      {
+        domain: 'remove-me.example',
+        verify_token: 'tok-rm-zzzzzzzzzzzzzz',
+        verified_at: new Date(),
+        last_checked_at: new Date(),
+      },
+      {
+        domain: 'keep-me.example',
+        verify_token: 'tok-keep-zzzzzzzzzzzz',
+        verified_at: new Date(),
+        last_checked_at: new Date(),
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/domains/remove-me.example',
+      headers: { cookie: cookieA },
+    });
+    expect(res.statusCode).toBe(204);
+
+    const db = new Client({ connectionString: dbUrl });
+    await db.connect();
+    try {
+      const dvs = await db.query(
+        `SELECT domain FROM domain_verifications WHERE account_id = $1 ORDER BY domain`,
+        [accountIdA],
+      );
+      expect(dvs.rows.map((r) => r.domain)).toEqual(['keep-me.example']);
+
+      const acc = await db.query<{ verified_domains: string[] }>(
+        `SELECT verified_domains FROM accounts WHERE id = $1`,
+        [accountIdA],
+      );
+      expect(acc.rows[0]!.verified_domains).toEqual(['keep-me.example']);
+    } finally {
+      await db.end();
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC5: DELETE non-existent domain → 404
+  // ──────────────────────────────────────────────────────────────────────────
+  it('AC5: DELETE for a domain that does not exist → 404', async () => {
+    await clearAll();
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/domains/never-seen.example',
+      headers: { cookie: cookieA },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC6: DELETE on someone else's domain → 404 (no leak)
+  // ──────────────────────────────────────────────────────────────────────────
+  it("AC6: DELETE on another account's domain → 404 (no existence leak)", async () => {
+    await clearAll();
+    await seed(accountIdB, [
+      {
+        domain: 'b-secret.example',
+        verify_token: 'tok-b2-zzzzzzzzzzzzz',
+        verified_at: new Date(),
+        last_checked_at: new Date(),
+      },
+    ]);
+
+    // A tries to delete B's domain — must look identical to a non-existent.
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/domains/b-secret.example',
+      headers: { cookie: cookieA },
+    });
+    expect(res.statusCode).toBe(404);
+
+    // B's row is still intact.
+    const db = new Client({ connectionString: dbUrl });
+    await db.connect();
+    try {
+      const r = await db.query(
+        `SELECT 1 FROM domain_verifications WHERE account_id = $1 AND domain = $2`,
+        [accountIdB, 'b-secret.example'],
+      );
+      expect(r.rows).toHaveLength(1);
+    } finally {
+      await db.end();
+    }
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC7: DELETE without session → 401
+  // ──────────────────────────────────────────────────────────────────────────
+  it('AC7: DELETE without session → 401', async () => {
+    const res = await app.inject({
+      method: 'DELETE',
+      url: '/api/domains/anything.example',
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC8: POST /api/domains/:domain/delete (form workaround) behaves like DELETE
+  //      and redirects 302 to /dashboard/domains.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('AC8: POST /api/domains/:domain/delete works as a form-submit DELETE (302 → /dashboard/domains)', async () => {
+    await clearAll();
+    await seed(accountIdA, [
+      {
+        domain: 'form-delete.example',
+        verify_token: 'tok-fd-zzzzzzzzzzzzzz',
+        verified_at: new Date(),
+        last_checked_at: new Date(),
+      },
+    ]);
+
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/domains/form-delete.example/delete',
+      headers: { cookie: cookieA },
+    });
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/dashboard/domains');
+
+    const db = new Client({ connectionString: dbUrl });
+    await db.connect();
+    try {
+      const dvs = await db.query(
+        `SELECT 1 FROM domain_verifications WHERE account_id = $1 AND domain = $2`,
+        [accountIdA, 'form-delete.example'],
+      );
+      expect(dvs.rows).toHaveLength(0);
+      const acc = await db.query<{ verified_domains: string[] }>(
+        `SELECT verified_domains FROM accounts WHERE id = $1`,
+        [accountIdA],
+      );
+      expect(acc.rows[0]!.verified_domains ?? []).not.toContain('form-delete.example');
+    } finally {
+      await db.end();
+    }
+  });
+});

--- a/apps/web/app/dashboard/domains/DomainsListView.tsx
+++ b/apps/web/app/dashboard/domains/DomainsListView.tsx
@@ -1,0 +1,212 @@
+/**
+ * DomainsListView.tsx — pure presentational renderer for the
+ * /dashboard/domains list (issue #83).
+ *
+ * Server-Component-friendly (no client hooks). Imported by:
+ *   - apps/web/app/dashboard/domains/page.tsx (production: SSR-fetches GET /api/domains)
+ *   - apps/web/test/domains-list.test.tsx (renderToStaticMarkup with fixtures)
+ *
+ * Spec refs:
+ *   §2 #1  — verified-domain authorization (status badges differentiate
+ *            verified vs. pending challenges).
+ *   §4.1   — Next.js 14 App Router + Tailwind.
+ *   §5.10  — CSP: no inline scripts; no style="" attributes; action buttons
+ *            use native HTML <form> posts. The dashboard CSP allows
+ *            form-action 'self', so a form posting to /api/* on the same
+ *            origin is fine. We never use fetch() / onClick handlers here.
+ *
+ * CSP-safe action wiring:
+ *   - "Re-verify" → POST /api/domains/<domain>/verify (defined in PR #103;
+ *     the API returns JSON, but the page just reloads when the form
+ *     submits because we don't intercept). For a fully no-JS UX the
+ *     existing endpoint is fine — the reloaded list shows updated state
+ *     because the API also bumps last_checked_at.
+ *   - "Remove"    → POST /api/domains/<domain>/delete (sibling route added
+ *     in this PR specifically for the form-submit case; the API redirects
+ *     302 to /dashboard/domains).
+ */
+
+import type { ReactElement } from 'react';
+
+export interface DomainRow {
+  domain: string;
+  verify_token: string;
+  verified_at: string | null; // ISO-8601 or null
+  last_checked_at: string | null; // ISO-8601 or null
+  created_at: string; // ISO-8601
+}
+
+export interface DomainsListViewProps {
+  domains: DomainRow[];
+}
+
+/** Format an ISO timestamp as "YYYY-MM-DD HH:MM UTC" or "—" if null. */
+function formatTs(iso: string | null): string {
+  if (!iso) return '—';
+  const d = new Date(iso);
+  if (Number.isNaN(d.getTime())) return iso;
+  const pad = (n: number) => String(n).padStart(2, '0');
+  const yyyy = d.getUTCFullYear();
+  const mm = pad(d.getUTCMonth() + 1);
+  const dd = pad(d.getUTCDate());
+  const hh = pad(d.getUTCHours());
+  const mi = pad(d.getUTCMinutes());
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi} UTC`;
+}
+
+function StatusBadge({ verifiedAt }: { verifiedAt: string | null }): ReactElement {
+  if (verifiedAt) {
+    return (
+      <span className="inline-flex items-center gap-1 rounded-full bg-green-100 px-2 py-0.5 text-xs font-medium text-green-800 ring-1 ring-inset ring-green-200">
+        {/* Cleartext check; spec §5.10 forbids dangerouslySetInnerHTML. */}
+        <span aria-hidden="true">✅</span> Verified
+      </span>
+    );
+  }
+  return (
+    <span className="inline-flex items-center gap-1 rounded-full bg-yellow-100 px-2 py-0.5 text-xs font-medium text-yellow-800 ring-1 ring-inset ring-yellow-200">
+      <span aria-hidden="true">⏳</span> Pending
+    </span>
+  );
+}
+
+export function DomainsListView({ domains }: DomainsListViewProps): ReactElement {
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-10">
+      {/* Header: title + Add-domain CTA — always visible. */}
+      <header className="mb-6 flex items-baseline justify-between gap-4">
+        <div>
+          <h1 className="text-3xl font-bold tracking-tight text-gray-900">Domains</h1>
+          <p className="mt-1 text-sm text-gray-500">
+            Domains you have registered with willbuy. Studies can only target
+            verified domains (spec §2 #1).
+          </p>
+        </div>
+        <a
+          href="/dashboard/domains/new"
+          className="inline-flex shrink-0 items-center justify-center rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white shadow hover:bg-gray-700 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2"
+        >
+          Add domain
+        </a>
+      </header>
+
+      {domains.length === 0 ? (
+        <section className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center">
+          <p className="text-sm text-gray-700">
+            No domains yet. Add a domain to get started.
+          </p>
+          <a
+            href="/dashboard/domains/new"
+            className="mt-3 inline-block text-sm font-medium text-indigo-600 hover:underline"
+          >
+            Add your first domain
+          </a>
+        </section>
+      ) : (
+        <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">
+          <table className="min-w-full divide-y divide-gray-200">
+            <thead className="bg-gray-50">
+              <tr>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500"
+                >
+                  Domain
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500"
+                >
+                  Status
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500"
+                >
+                  Verified at
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500"
+                >
+                  Last checked
+                </th>
+                <th
+                  scope="col"
+                  className="px-4 py-3 text-right text-xs font-medium uppercase tracking-wide text-gray-500"
+                >
+                  Actions
+                </th>
+              </tr>
+            </thead>
+            <tbody className="divide-y divide-gray-100">
+              {domains.map((d) => {
+                // Encode for use inside a URL path segment. encodeURIComponent
+                // doesn't escape '.', which is what we want for hostnames.
+                const enc = encodeURIComponent(d.domain);
+                return (
+                  <tr key={d.domain} className="hover:bg-gray-50">
+                    <td className="whitespace-nowrap px-4 py-3 text-sm font-mono text-gray-900">
+                      {d.domain}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm">
+                      <StatusBadge verifiedAt={d.verified_at} />
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-xs text-gray-500">
+                      {formatTs(d.verified_at)}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-xs text-gray-500">
+                      {formatTs(d.last_checked_at)}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-right text-sm">
+                      <div className="flex items-center justify-end gap-2">
+                        {/*
+                          Re-verify: native form post to the existing PR #103
+                          endpoint. The API returns JSON; the browser will
+                          land on that JSON page, but the user can refresh
+                          /dashboard/domains to see the updated last_checked_at.
+                          (A future PR can wire a 302-redirect alias if we
+                          want a fully zero-JS round-trip.)
+                        */}
+                        <form
+                          action={`/api/domains/${enc}/verify`}
+                          method="post"
+                          className="inline"
+                        >
+                          <button
+                            type="submit"
+                            className="rounded-md border border-gray-300 bg-white px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-gray-900 focus:ring-offset-2"
+                          >
+                            Re-verify
+                          </button>
+                        </form>
+                        {/*
+                          Remove: native form post to the CSP-safe
+                          /api/domains/<domain>/delete sibling that this PR
+                          adds — the API performs the same SQL as DELETE
+                          and 302-redirects back to /dashboard/domains.
+                        */}
+                        <form
+                          action={`/api/domains/${enc}/delete`}
+                          method="post"
+                          className="inline"
+                        >
+                          <button
+                            type="submit"
+                            className="rounded-md border border-red-300 bg-white px-3 py-1 text-xs font-medium text-red-700 hover:bg-red-50 focus:outline-none focus:ring-2 focus:ring-red-500 focus:ring-offset-2"
+                          >
+                            Remove
+                          </button>
+                        </form>
+                      </div>
+                    </td>
+                  </tr>
+                );
+              })}
+            </tbody>
+          </table>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/domains/page.tsx
+++ b/apps/web/app/dashboard/domains/page.tsx
@@ -1,0 +1,103 @@
+/**
+ * /dashboard/domains — domain list page (issue #83).
+ *
+ * Server Component. SSR-fetches GET /api/domains using the wb_session
+ * HttpOnly cookie that PR #95 plants on successful magic-link verification.
+ *
+ * Behaviour:
+ *   - 200 → render <DomainsListView/> with the rows.
+ *   - 401 → redirect to /sign-in. Per spec §3 + §2 #20 we don't surface
+ *           server-side errors that could leak account state.
+ *   - any other status → fall through to a generic error message.
+ *
+ * Spec refs:
+ *   §2 #1  — verified-domain authorization (this is the management UI).
+ *   §4.1   — Next.js 14 App Router + Tailwind.
+ *   §5.10  — strict CSP attached by apps/web/middleware.ts on /dashboard/*.
+ *            All action buttons in <DomainsListView/> are native HTML
+ *            <form> posts (no inline JS).
+ */
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+import { DomainsListView, type DomainRow } from './DomainsListView';
+
+// Force SSR — this page must read the request's cookie on every load.
+// Without this, Next.js may statically pre-render at build time, which would
+// 401 (no cookie at build time).
+export const dynamic = 'force-dynamic';
+
+/**
+ * Resolve the API base URL for server-side fetches.
+ *
+ * In production the API and web are deployed behind the same hostname, so
+ * a relative URL ("/api/domains") routed via nginx is the idiomatic shape.
+ * Server Components, however, run inside Node and need an absolute URL for
+ * fetch(). Honour env overrides first; fall back to the dev port.
+ *
+ * Mirrors apps/web/app/dashboard/page.tsx (issue #80, PR #102).
+ */
+function apiBaseUrl(): string {
+  const explicit = process.env['WILLBUY_API_URL'] ?? process.env['NEXT_PUBLIC_API_URL'];
+  if (explicit) return explicit.replace(/\/$/, '');
+  return 'http://127.0.0.1:3000';
+}
+
+async function fetchDomains(cookieHeader: string): Promise<
+  | { ok: true; data: DomainRow[] }
+  | { ok: false; status: number }
+> {
+  let res: Response;
+  try {
+    res = await fetch(`${apiBaseUrl()}/api/domains`, {
+      headers: { cookie: cookieHeader },
+      // Each request must hit the API — no Next.js cache.
+      cache: 'no-store',
+    });
+  } catch {
+    // Network / connect-refused.
+    return { ok: false, status: 0 };
+  }
+  if (!res.ok) {
+    return { ok: false, status: res.status };
+  }
+  const body = (await res.json()) as { domains: DomainRow[] };
+  return { ok: true, data: body.domains };
+}
+
+export default async function DomainsListPage(): Promise<JSX.Element> {
+  // In Next 14 cookies() is sync; in Next 15 it became async. Cast to
+  // accommodate both without pulling in version-specific types.
+  const cookieStore = (cookies() as unknown) as {
+    getAll: () => Array<{ name: string; value: string }>;
+  };
+  const all = cookieStore.getAll();
+  const cookieHeader = all.map((c) => `${c.name}=${c.value}`).join('; ');
+
+  // Without a wb_session cookie the API will 401; redirect early.
+  const hasSession = all.some(
+    (c) => c.name === 'wb_session' || c.name === '__Host-wb_session',
+  );
+  if (!hasSession) {
+    redirect('/sign-in');
+  }
+
+  const result = await fetchDomains(cookieHeader);
+
+  if (!result.ok) {
+    if (result.status === 401) {
+      redirect('/sign-in');
+    }
+    return (
+      <main className="mx-auto max-w-2xl px-6 py-16">
+        <h1 className="text-2xl font-bold text-gray-900">Domains unavailable</h1>
+        <p className="mt-2 text-sm text-gray-600">
+          We could not load your domains just now. Please refresh the page; if
+          the problem persists, contact support.
+        </p>
+      </main>
+    );
+  }
+
+  return <DomainsListView domains={result.data} />;
+}

--- a/apps/web/test/domains-list.test.tsx
+++ b/apps/web/test/domains-list.test.tsx
@@ -1,0 +1,107 @@
+/**
+ * domains-list.test.tsx — TDD acceptance tests for issue #83 (domain list page).
+ *
+ * Spec refs:
+ *   §2 #1  — verified-domain authorization (status badges differentiate
+ *            verified vs. pending challenges).
+ *   §4.1   — Next.js 14 App Router + Tailwind.
+ *   §5.10  — CSP: no inline scripts; action buttons use native HTML <form>
+ *            posts (no JS) so the page works under the strict CSP.
+ *
+ * Component under test: app/dashboard/domains/DomainsListView.tsx — a pure
+ * presentational renderer used by app/dashboard/domains/page.tsx (the
+ * Server Component that SSR-fetches GET /api/domains).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { DomainsListView } from '../app/dashboard/domains/DomainsListView';
+
+const VERIFIED = {
+  domain: 'verified.example',
+  verify_token: 'tok-verified-zzzzzzzzzz',
+  verified_at: '2026-04-20T12:00:00.000Z',
+  last_checked_at: '2026-04-20T12:00:00.000Z',
+  created_at: '2026-04-20T12:00:00.000Z',
+};
+
+const PENDING = {
+  domain: 'pending.example',
+  verify_token: 'tok-pending-zzzzzzzzzzz',
+  verified_at: null,
+  last_checked_at: '2026-04-21T08:00:00.000Z',
+  created_at: '2026-04-21T08:00:00.000Z',
+};
+
+describe('/dashboard/domains list view (issue #83)', () => {
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC1: Table renders rows with correct status badges.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('renders one row per domain with correct status (verified vs pending)', () => {
+    const html = renderToStaticMarkup(
+      <DomainsListView domains={[VERIFIED, PENDING]} />,
+    );
+
+    // Both domain names appear.
+    expect(html).toMatch(/verified\.example/);
+    expect(html).toMatch(/pending\.example/);
+
+    // Status text differentiates the two.
+    // We accept either textual ("Verified" / "Pending") or symbolic ("✅" / "⏳")
+    // — the implementation may use either; what matters is they differ.
+    const hasVerifiedBadge = /verified\.example[\s\S]*?(?:Verified|✅)/i.test(html)
+      || /(?:Verified|✅)[\s\S]*?verified\.example/i.test(html);
+    const hasPendingBadge = /pending\.example[\s\S]*?(?:Pending|⏳)/i.test(html)
+      || /(?:Pending|⏳)[\s\S]*?pending\.example/i.test(html);
+    expect(hasVerifiedBadge).toBe(true);
+    expect(hasPendingBadge).toBe(true);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC2: Empty state.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('renders the empty-state CTA when there are no domains', () => {
+    const html = renderToStaticMarkup(<DomainsListView domains={[]} />);
+    expect(html).toMatch(/no domains yet/i);
+    // CTA links to /dashboard/domains/new (the verify-flow page from PR #103).
+    expect(html).toMatch(/href="\/dashboard\/domains\/new"/);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC3: Re-verify form posts to the existing verify endpoint (PR #103).
+  // ──────────────────────────────────────────────────────────────────────────
+  it('renders a Re-verify <form> targeting POST /api/domains/<domain>/verify (CSP-safe, no JS)', () => {
+    const html = renderToStaticMarkup(<DomainsListView domains={[VERIFIED]} />);
+    // The form action MUST be the verify endpoint for this exact domain.
+    // Native <form action="..." method="post"> works under the dashboard's
+    // strict CSP because it has no inline JS.
+    expect(html).toMatch(
+      /<form[^>]*action="\/api\/domains\/verified\.example\/verify"[^>]*method="post"/i,
+    );
+    // Re-verify button label.
+    expect(html).toMatch(/Re-verify/i);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC4: Remove form posts to a CSP-safe endpoint that the API treats as DELETE.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('renders a Remove <form> targeting POST /api/domains/<domain>/delete (CSP-safe form workaround)', () => {
+    const html = renderToStaticMarkup(<DomainsListView domains={[VERIFIED]} />);
+    // HTML forms can only emit GET or POST, so the API exposes a sibling
+    // POST .../delete that internally executes the same SQL as DELETE
+    // and 302-redirects back to /dashboard/domains.
+    expect(html).toMatch(
+      /<form[^>]*action="\/api\/domains\/verified\.example\/delete"[^>]*method="post"/i,
+    );
+    expect(html).toMatch(/Remove/i);
+  });
+
+  // ──────────────────────────────────────────────────────────────────────────
+  // AC5: Top-of-page "Add domain" CTA is always present.
+  // ──────────────────────────────────────────────────────────────────────────
+  it('renders an Add-domain CTA linking to /dashboard/domains/new', () => {
+    const html = renderToStaticMarkup(<DomainsListView domains={[VERIFIED]} />);
+    // It's a plain anchor (no JS) to the new-domain flow page.
+    expect(html).toMatch(/<a[^>]*href="\/dashboard\/domains\/new"[^>]*>[\s\S]*?Add domain/i);
+  });
+});


### PR DESCRIPTION
Closes #83.

## Summary

- **API** — adds three handlers in `apps/api/src/routes/domains.ts` (existing POSTs untouched):
  - `GET /api/domains` — list of `{ domain, verify_token, verified_at, last_checked_at, created_at }` for the authenticated account, ordered `created_at DESC`.
  - `DELETE /api/domains/:domain` — atomic transaction: deletes the `domain_verifications` row and removes the value from `accounts.verified_domains[]`. 204 on success; 404 indistinguishably for "doesn't exist" and "owned by another account" (spec §2 #20, no existence leak).
  - `POST /api/domains/:domain/delete` — CSP-safe form-submit fallback for the dashboard list page. Same SQL as DELETE; 302-redirects to `/dashboard/domains`. Required because HTML forms can only emit GET/POST and the dashboard CSP forbids inline JS, so a literal `<button onclick=fetch(...,{method:'DELETE'})>` is not an option.

- **Web** — adds `apps/web/app/dashboard/domains/page.tsx` (Server Component) + `DomainsListView.tsx` (pure renderer, mirrors the `DashboardView` pattern from PR #102):
  - Table: domain, status badge (Verified / Pending), verified_at, last_checked_at, action buttons.
  - Empty state with CTA → `/dashboard/domains/new` (verify flow from PR #103).
  - Top "Add domain" button → `/dashboard/domains/new`.
  - "Re-verify" button → native `<form action="/api/domains/<d>/verify" method="post">` (PR #103 endpoint).
  - "Remove" button → native `<form action="/api/domains/<d>/delete" method="post">` (this PR's form fallback).

- **CSP** — every action is a native HTML form. No inline JS, no `onClick`, no `fetch()` from this page. Works under the strict `/dashboard/*` CSP from PR #80 unchanged.

## Test plan

API (`apps/api/test/domains-list.test.ts`, 8/8 passing):
- [x] AC1 GET ordered DESC
- [x] AC2 GET no session → 401
- [x] AC3 cross-account isolation
- [x] AC4 DELETE removes from both `domain_verifications` and `accounts.verified_domains`
- [x] AC5 DELETE non-existent → 404
- [x] AC6 DELETE other account's domain → 404 (no leak); their row stays intact
- [x] AC7 DELETE no session → 401
- [x] AC8 POST `.../delete` form-fallback → 302 to `/dashboard/domains`

Web (`apps/web/test/domains-list.test.tsx`, 5/5 passing):
- [x] AC1 status badges differ for verified vs pending
- [x] AC2 empty-state CTA to `/dashboard/domains/new`
- [x] AC3 Re-verify form `action` correct
- [x] AC4 Remove form `action` correct (CSP-safe POST workaround)
- [x] AC5 Top-of-page Add-domain CTA to `/dashboard/domains/new`

Local scope only — no root tests touched. `bun run lint` clean. `bun --cwd apps/api typecheck` + `bun --cwd apps/web typecheck` pass.

## Curl evidence

Captured against a real Postgres 16 testcontainer + the in-process Fastify server using `app.inject()` (printed in `curl -isS` shape):

~~~
### 1. GET /api/domains (no session) — expect 401
$ curl -isS -X GET http://api.willbuy.dev/api/domains
HTTP/1.1 401
content-type: application/json; charset=utf-8
content-length: 35

{"error":"authentication required"}

### 2. GET /api/domains (with session) — expect 200, two rows DESC
$ curl -isS -X GET -H "cookie: wb_session=..." http://api.willbuy.dev/api/domains
HTTP/1.1 200
content-type: application/json; charset=utf-8
content-length: 362

{
  "domains": [
    { "domain": "pending.example",  "verify_token": "tok-pending-zzzzzzzzzzz",
      "verified_at": null, "last_checked_at": null,
      "created_at": "2026-04-25T21:46:29.824Z" },
    { "domain": "verified.example", "verify_token": "tok-verified-zzzzzzzzzz",
      "verified_at": "2026-04-24T22:46:29.824Z",
      "last_checked_at": "2026-04-24T22:46:29.824Z",
      "created_at": "2026-04-23T22:46:29.824Z" }
  ]
}

### 3. DELETE /api/domains/pending.example — expect 204
$ curl -isS -X DELETE -H "cookie: wb_session=..." http://api.willbuy.dev/api/domains/pending.example
HTTP/1.1 204

### 4. DELETE non-existent — expect 404
$ curl -isS -X DELETE -H "cookie: wb_session=..." http://api.willbuy.dev/api/domains/never-existed.example
HTTP/1.1 404

{"error":"not found"}

### 5. POST /api/domains/verified.example/delete (form fallback) — expect 302
$ curl -isS -X POST -H "cookie: wb_session=..." http://api.willbuy.dev/api/domains/verified.example/delete
HTTP/1.1 302
location: /dashboard/domains

### 6. GET /api/domains again — list now empty
$ curl -isS -X GET -H "cookie: wb_session=..." http://api.willbuy.dev/api/domains
HTTP/1.1 200

{"domains":[]}

### 7. SQL: confirm accounts.verified_domains was also drained
SELECT verified_domains FROM accounts WHERE id=1;
 verified_domains = []
~~~

## Rendered HTML excerpt (the four CSP-safe forms)

`renderToStaticMarkup` of `<DomainsListView>` with a verified + a pending row:

~~~html
<form action="/api/domains/pending.example/verify"  method="post" class="inline">
<form action="/api/domains/pending.example/delete"  method="post" class="inline">
<form action="/api/domains/verified.example/verify" method="post" class="inline">
<form action="/api/domains/verified.example/delete" method="post" class="inline">
<a href="/dashboard/domains/new" ...>Add domain</a>
~~~

Every action button is a native HTML `<form method="post">` — no inline JS, no `onClick`, no `fetch()`. Works under the strict `/dashboard/*` CSP from PR #80 unchanged.

## Out of scope (per issue #83 + sprint plan)

- Bulk re-verify (Sprint 4).
- Audit log / who-removed-when (Sprint 4).
- Blocking removal when an in-flight study targets the domain (deferred — needs Sprint 4 study-listing work to surface the conflict in the UI).
- Token rotation on removal (deferred to Sprint 4 alongside the audit-log work).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>