### PR TITLE
chore(infra): rev-pr91 nits — README + tombstone comment + savepoint note (#93)

### DIFF
--- a/infra/migrations/0015_seed_sqlever_state.sql
+++ b/infra/migrations/0015_seed_sqlever_state.sql
@@ -1,23 +1,21 @@
--- 0015_seed_sqlever_state.sql — one-shot state seed for NikolayS/sqlever (issue #48, amendment A4).
+-- 0015_seed_sqlever_state.sql — HISTORICAL REFERENCE (issue #48, amendment A4 + PR #91).
 --
--- Context: PR #46 landed a bash migrate.sh that tracked applied migrations in
--- _migrations(filename, checksum, applied_at). Amendment A4 (2026-04-24)
--- replaces the bash runner with NikolayS/sqlever, which tracks state in the
--- sqitch.* schema (sqitch.changes, sqitch.events, sqitch.projects).
+-- This file is HISTORICAL REFERENCE ONLY. See infra/migrations/README.md.
+-- The operative source for this migration is
+-- `infra/sqlever/deploy/0015_seed_sqlever_state.sql`.
 --
--- For databases that ran the old bash runner (i.e. _migrations is already
--- populated with rows 0000–0013), sqlever would otherwise try to re-apply
--- every migration on the first `sqlever deploy` run.
+-- What this migration actually does (in the operative deploy script):
+-- it seeds the legacy `_migrations` shadow row for 0015 so the row count
+-- stays consistent with the .sql file count in infra/migrations/ (which
+-- the test suite uses as the expected row count).
 --
--- This migration seeds sqlever's sqitch.* state tables with one row per
--- existing _migrations entry so that sqlever sees 0000–0013 as already
--- deployed and only applies genuinely new migrations going forward.
---
--- Idempotency: the INSERT uses ON CONFLICT DO NOTHING, so re-running this
--- migration on a database that already has the sqitch.* rows is a no-op.
--- The sqlever deploy scripts (infra/sqlever/deploy/) use IF NOT EXISTS /
--- ON CONFLICT guards on all schema DDL, so they are also safe to re-run.
+-- It does NOT seed sqlever's own state tables. sqlever manages its own
+-- sqitch.* state (sqitch.changes, sqitch.events, sqitch.projects) on its
+-- own — this migration does not write to those tables. The bash-to-sqlever
+-- transition is handled outside this migration.
 --
 -- NOTE: This file is intentionally kept in infra/migrations/ so that the
 -- legacy _migrations table (and test assertions that count .sql files there)
--- continues to reflect the full migration history.
+-- continues to reflect the full migration history. The CI guard
+-- (scripts/check-migrations.sh) ensures this file stays in sync with the
+-- operative deploy script under infra/sqlever/deploy/.

--- a/infra/migrations/README.md
+++ b/infra/migrations/README.md
@@ -1,0 +1,14 @@
+# willbuy migrations — historical reference
+
+These files are HISTORICAL REFERENCE ONLY. The operative source for
+schema migrations is `infra/sqlever/deploy/` (per amendment A4 + PR #91).
+
+To add a new migration, run:
+  bun run scripts/next-migration.sh <slug>
+
+This creates files in BOTH dirs and prints a sqitch.plan reminder. Do NOT
+modify files here directly — modify the corresponding `infra/sqlever/deploy/`
+script instead.
+
+The pre-commit / CI guard (PR #101 / scripts/check-migrations.sh) will fail
+if these dirs drift.

--- a/infra/sqlever/deploy/0015_seed_sqlever_state.sql
+++ b/infra/sqlever/deploy/0015_seed_sqlever_state.sql
@@ -1,15 +1,22 @@
 -- Deploy 0015_seed_sqlever_state
--- Spec ref: issue #48, amendment A4 — one-shot sqlever state seed.
+-- Spec ref: issue #48, amendment A4 + PR #91.
 --
--- This deploy script is a no-op when applied via `sqlever deploy` on a fresh
--- database (sqlever already tracks 0000–0013 in sqitch.changes before this
--- runs). On databases that were previously managed by the old bash migrate.sh,
--- the bash-to-sqlever transition script seeds sqitch.* from _migrations before
--- this change is ever deployed, so again this is a no-op in both cases.
+-- What this script DOES:
+--   Seeds the legacy `_migrations` shadow row for 0015 so the row count
+--   stays consistent with the .sql file count in infra/migrations/ (which
+--   the test suite uses as the expected row count). That is the entire
+--   payload — a single ON CONFLICT DO NOTHING insert into _migrations.
 --
--- What it DOES do: records its own _migrations row so the count stays
--- consistent with the .sql file count in infra/migrations/ (which the
--- test suite uses as the expected row count).
+-- What this script does NOT do:
+--   It does NOT seed sqlever's own state tables (sqitch.changes,
+--   sqitch.events, sqitch.projects). sqlever manages those itself when
+--   it deploys this change — this migration does not write to them. The
+--   bash-to-sqlever state transition for previously bash-managed databases
+--   is handled outside this migration (see amendment A4 transition notes).
+--
+-- Net effect: on a fresh DB or a DB already migrated via sqlever, this is
+-- a no-op for the sqitch.* tables and a single shadow-row insert into
+-- _migrations.
 
 BEGIN;
 

--- a/scripts/check-migrations.sh
+++ b/scripts/check-migrations.sh
@@ -40,9 +40,10 @@ if [[ -n "${dups}" ]]; then
 fi
 
 # Check 3: every infra/migrations/00NN_*.sql has a matching deploy script.
+# Filter to .sql files so non-SQL artefacts (e.g. README.md) don't trip the guard.
 missing_in_deploy=$(comm -23 \
-  <(ls "${migrations_dir}" | sort) \
-  <(ls "${sqlever_dir}" | sort) || true)
+  <(ls "${migrations_dir}" | grep '\.sql$' | sort) \
+  <(ls "${sqlever_dir}" | grep '\.sql$' | sort) || true)
 if [[ -n "${missing_in_deploy}" ]]; then
   echo "ERROR: migrations present in ${migrations_dir} but missing in ${sqlever_dir}:" >&2
   echo "${missing_in_deploy}" >&2
@@ -58,5 +59,5 @@ for f in "${sqlever_dir}"/[0-9]*.sql; do
   fi
 done
 
-count=$(ls "${migrations_dir}" | grep -c '^[0-9]')
+count=$(ls "${migrations_dir}" | grep -E '^[0-9].*\.sql$' | wc -l | tr -d ' ')
 echo "migration-collision check: OK (${count} migrations, all unique, all paired, all in plan)"

--- a/tests/migrations.test.ts
+++ b/tests/migrations.test.ts
@@ -161,6 +161,21 @@ describeIfDocker('migrations runner', () => {
     // Build a temp sqlever project that adds a bad change on top of the real plan.
     // The bad change creates a table and then errors mid-way — sqlever wraps
     // each deploy script in a BEGIN/COMMIT so the partial change rolls back.
+    //
+    // SAVEPOINT/TRANSACTION DEPENDENCY (issue #93, LOW-3):
+    // This fixture intentionally embeds its own inline `BEGIN; ... COMMIT;`
+    // block. sqlever currently runs each deploy script inside an outer
+    // transaction; the inner BEGIN/COMMIT here is treated by Postgres as
+    // an implicit SAVEPOINT (Postgres does not nest top-level transactions
+    // and emits a `WARNING: there is already a transaction in progress`).
+    // The outer transaction is what actually rolls the partial DDL back
+    // when `SELECT 1/0` raises. If sqlever's transaction model ever changes
+    // (e.g. it stops wrapping each change in a single transaction, or it
+    // promotes inner BEGIN/COMMIT to true subtransactions), this fixture
+    // could either (a) leak the half-created willbuy_fail_fixture table
+    // into the DB, or (b) commit the inner block and only the post-error
+    // rollback would catch it. If those assertions below start failing
+    // mysteriously, audit sqlever's transaction-wrapping behaviour first.
     const failingSql = [
       '-- failing fixture: creates a table, then errors mid-way',
       'BEGIN;',


### PR DESCRIPTION
Closes the three LOW-severity nits from the rev-pr91 review on issue #93.

## Fixes

- **LOW-1 — Dual-maintenance warning.** New `infra/migrations/README.md`
  marks the dir as historical reference and points future editors at
  `infra/sqlever/deploy/` and `scripts/next-migration.sh`. The CI guard
  in `scripts/check-migrations.sh` is the durable enforcement; this
  README is just for human readers who land in the wrong dir.

- **LOW-2 — Tombstone comment in `0015_seed_sqlever_state.sql`.** The
  old header claimed to "seed sqlever's sqitch.* state tables" — the
  deploy script only writes a single `_migrations` shadow row. Headers
  on **both** copies (`infra/migrations/` historical + `infra/sqlever/deploy/`
  operative) now accurately describe the payload: a single ON CONFLICT
  insert into `_migrations` to keep the row count aligned with the .sql
  file count; sqlever manages its own `sqitch.*` state itself.

- **LOW-3 — Failing-migration fixture savepoint note.** The fixture in
  `tests/migrations.test.ts` embeds inline `BEGIN; … COMMIT;` and
  relies on sqlever's outer-transaction model (the inner BEGIN/COMMIT
  is treated by Postgres as an implicit savepoint inside sqlever's
  wrapping transaction). Added an inline comment near the fixture
  explaining the dependency and what would break if sqlever changes
  its transaction model.

## Drive-by

`scripts/check-migrations.sh` previously did `comm` over the raw `ls`
of both migration dirs, which meant adding the new `infra/migrations/README.md`
broke the guard ("missing in `infra/sqlever/deploy/`"). Filtered the
diff and the migration count to `*.sql` so non-SQL artefacts don't
trip the check. No prefix or pairing logic changed.

## Skipped

- **MEDIUM-1** (squash commit ate red→green TDD history) — not
  actionable retroactively, per #93.

## Verification

- `bash scripts/check-migrations.sh` → `migration-collision check: OK
  (19 migrations, all unique, all paired, all in plan)`
- Docs/comments only otherwise; no test changes that affect runtime.

🤖 Generated with [Claude Code](https://claude.com/claude-code)