### PR TITLE
fix(web): progress bar CSP-compliant via Tailwind class lookup (#111)

### DIFF
--- a/apps/web/app/dashboard/studies/[id]/page.tsx
+++ b/apps/web/app/dashboard/studies/[id]/page.tsx
@@ -50,7 +50,49 @@ const STATUS_COLOURS: Record<StudyStatus, string> = {
 
 // ── Visit progress bar ────────────────────────────────────────────────────────
 
-function ProgressBar({ ok, failed, total }: { ok: number; failed: number; total: number }) {
+/**
+ * CSP-safe progress bar (issue #111).
+ *
+ * The previous implementation used `style={{ width: `${pct}%` }}`, which is an
+ * inline style. SPEC §5.10 forbids `'unsafe-inline'` in `style-src`, so the
+ * middleware's CSP would block these styles, leaving the bar invisible.
+ *
+ * Fix: round the percentage to the nearest twelfth (12 buckets + 0%/100% = 13
+ * fixed values) and look up a static Tailwind width class. Pure className,
+ * no inline styles, fully CSP-clean.
+ *
+ * Resolution loss is ~4% per twelfth, which is fine for a progress bar and
+ * matches Tailwind's stock width fractions, so no Tailwind config changes
+ * are required.
+ */
+
+// SAFELIST: w-0 w-1/12 w-1/6 w-1/4 w-1/3 w-5/12 w-1/2 w-7/12 w-2/3 w-3/4 w-5/6 w-11/12 w-full
+// Listed literally as a plain string above so Tailwind's JIT scanner keeps
+// every class even when only some indices are referenced at runtime.
+export const PROGRESS_CLASSES = [
+  'w-0',
+  'w-1/12',
+  'w-1/6',
+  'w-1/4',
+  'w-1/3',
+  'w-5/12',
+  'w-1/2',
+  'w-7/12',
+  'w-2/3',
+  'w-3/4',
+  'w-5/6',
+  'w-11/12',
+  'w-full',
+] as const;
+
+export function progressClass(pct: number): string {
+  // Clamp [0, 100] then round to nearest twelfth (13 buckets: 0..12).
+  const clamped = Math.max(0, Math.min(100, pct));
+  const idx = Math.round(clamped / (100 / 12));
+  return PROGRESS_CLASSES[idx] ?? 'w-0';
+}
+
+export function ProgressBar({ ok, failed, total }: { ok: number; failed: number; total: number }) {
   if (total === 0) return null;
   const okPct = Math.round((ok / total) * 100);
   const failedPct = Math.round((failed / total) * 100);
@@ -65,14 +107,8 @@ function ProgressBar({ ok, failed, total }: { ok: number; failed: number; total:
       </div>
       {/* Combined bar: green=ok, red=failed, gray=pending */}
       <div className="h-2 w-full overflow-hidden rounded-full bg-gray-100">
-        <div
-          className="h-full bg-green-500 float-left"
-          style={{ width: `${okPct}%` }}
-        />
-        <div
-          className="h-full bg-red-400 float-left"
-          style={{ width: `${failedPct}%` }}
-        />
+        <div className={`h-full bg-green-500 float-left ${progressClass(okPct)}`} />
+        <div className={`h-full bg-red-400 float-left ${progressClass(failedPct)}`} />
       </div>
     </div>
   );

--- a/apps/web/test/study-status.test.tsx
+++ b/apps/web/test/study-status.test.tsx
@@ -1,0 +1,131 @@
+/**
+ * study-status.test.tsx — TDD acceptance for issue #111 (CSP-safe progress bar).
+ *
+ * Spec refs:
+ *   §5.10 — CSP: no inline scripts/styles. The middleware's `style-src` does
+ *           NOT allow `'unsafe-inline'`, so any `style="..."` attribute on the
+ *           rendered output would be blocked at runtime.
+ *
+ * Sprint 3 retro audit found that /dashboard/studies/[id] used inline
+ * `style={{ width: ... }}` on the visit-progress bar. This suite locks in:
+ *
+ *   1. The pure `progressClass` helper rounds to the nearest twelfth and
+ *      maps to a fixed-set Tailwind width class.
+ *   2. `<ProgressBar/>`'s rendered HTML uses the right `w-N/M` class for
+ *      various fixture progress values.
+ *   3. `<ProgressBar/>`'s rendered HTML contains NO `style=` attribute, so
+ *      the page is CSP-clean under `style-src 'self'`.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import {
+  ProgressBar,
+  progressClass,
+  PROGRESS_CLASSES,
+} from '../app/dashboard/studies/[id]/page';
+
+describe('progressClass helper (issue #111)', () => {
+  it('maps 0% to w-0', () => {
+    expect(progressClass(0)).toBe('w-0');
+  });
+
+  it('maps 100% to w-full', () => {
+    expect(progressClass(100)).toBe('w-full');
+  });
+
+  it('maps 50% to w-1/2', () => {
+    expect(progressClass(50)).toBe('w-1/2');
+  });
+
+  it('maps 25% to w-1/4', () => {
+    // 25% / (100/12) = 3.0 → idx 3 → 'w-1/4'
+    expect(progressClass(25)).toBe('w-1/4');
+  });
+
+  it('maps 75% to w-3/4', () => {
+    // 75% / (100/12) = 9.0 → idx 9 → 'w-3/4'
+    expect(progressClass(75)).toBe('w-3/4');
+  });
+
+  it('rounds to the nearest twelfth (70% → w-2/3)', () => {
+    // 70% / (100/12) = 8.4 → round → idx 8 → 'w-2/3' (~66.67%).
+    expect(progressClass(70)).toBe('w-2/3');
+  });
+
+  it('clamps negative values to w-0', () => {
+    expect(progressClass(-10)).toBe('w-0');
+  });
+
+  it('clamps values above 100 to w-full', () => {
+    expect(progressClass(150)).toBe('w-full');
+  });
+
+  it('always returns a class from the safelist (no JIT drops)', () => {
+    for (let pct = -5; pct <= 105; pct += 1) {
+      expect(PROGRESS_CLASSES).toContain(progressClass(pct) as never);
+    }
+  });
+});
+
+describe('<ProgressBar/> rendered HTML (issue #111)', () => {
+  it('renders the right Tailwind width class for a 70%/10% split', () => {
+    const html = renderToStaticMarkup(
+      <ProgressBar ok={7} failed={1} total={10} />,
+    );
+    // 70% → nearest twelfth → w-2/3.   10% → nearest twelfth → w-1/12.
+    expect(html).toContain('w-2/3');
+    expect(html).toContain('w-1/12');
+    // Sanity: original Tailwind utility classes are still there.
+    expect(html).toContain('bg-green-500');
+    expect(html).toContain('bg-red-400');
+    // Status text rendered.
+    expect(html).toContain('7 / 10 visitors complete (1 failed)');
+    expect(html).toContain('70%');
+  });
+
+  it('renders w-full for a fully-complete study', () => {
+    const html = renderToStaticMarkup(
+      <ProgressBar ok={30} failed={0} total={30} />,
+    );
+    expect(html).toContain('w-full');
+    expect(html).toContain('30 / 30 visitors complete');
+    // No "failed" annotation when failed=0.
+    expect(html).not.toContain('failed)');
+  });
+
+  it('renders w-0 for a zero-progress study', () => {
+    const html = renderToStaticMarkup(
+      <ProgressBar ok={0} failed={0} total={20} />,
+    );
+    expect(html).toContain('w-0');
+    expect(html).toContain('0 / 20 visitors complete');
+  });
+
+  it('returns null when total is zero (no bar to draw)', () => {
+    const html = renderToStaticMarkup(
+      <ProgressBar ok={0} failed={0} total={0} />,
+    );
+    expect(html).toBe('');
+  });
+
+  // -------------------------------------------------------------------------
+  // The CSP-compliance assertion. This is the regression test for #111.
+  // -------------------------------------------------------------------------
+  it('emits NO inline style attribute (CSP §5.10 — no `unsafe-inline`)', () => {
+    const fixtures = [
+      { ok: 0, failed: 0, total: 10 },
+      { ok: 1, failed: 0, total: 10 },
+      { ok: 5, failed: 1, total: 10 },
+      { ok: 7, failed: 3, total: 10 },
+      { ok: 10, failed: 0, total: 10 },
+      { ok: 100, failed: 50, total: 200 },
+    ];
+    for (const f of fixtures) {
+      const html = renderToStaticMarkup(<ProgressBar {...f} />);
+      // The exact failure mode of the pre-fix code: a `style="width:..."` attr.
+      expect(html).not.toMatch(/\sstyle=/);
+      expect(html).not.toContain('width:');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

- Fixes #111: `/dashboard/studies/[id]` used `style={{ width: ... }}` on the visit-progress bar. The CSP middleware does not allow `'unsafe-inline'` in `style-src` (SPEC §5.10), so browsers silently dropped the styles and the bar rendered invisible after Sprint 3's CSP hardening.
- Replaces the two inline-styled `<div>`s with a static Tailwind width-class lookup (`progressClass(pct)`), rounding to the nearest twelfth — 13 fixed values (`w-0`, `w-1/12`, `w-1/6`, `w-1/4`, `w-1/3`, `w-5/12`, `w-1/2`, `w-7/12`, `w-2/3`, `w-3/4`, `w-5/6`, `w-11/12`, `w-full`). All from Tailwind's stock width scale, so no `tailwind.config.ts` changes.
- Adds a SAFELIST comment so JIT keeps every class even when the runtime doesn't reference them all literally.
- New test file `apps/web/test/study-status.test.tsx` (14 cases) covers the helper, the rendered class names, and a regression assertion that the rendered HTML contains no `style=` attribute.

## Before / after rendered HTML

Fixture: `<ProgressBar ok={7} failed={1} total={10} />`

**Before** (inline style — blocked by CSP):
```html
<div class="mt-4">
  <div class="flex justify-between text-xs text-gray-500 mb-1">
    <span>7 / 10 visitors complete (1 failed)</span><span>70%</span>
  </div>
  <div class="h-2 w-full overflow-hidden rounded-full bg-gray-100">
    <div class="h-full bg-green-500 float-left" style="width:70%"></div>
    <div class="h-full bg-red-400 float-left" style="width:10%"></div>
  </div>
</div>
```

**After** (CSP-clean):
```html
<div class="mt-4">
  <div class="flex justify-between text-xs text-gray-500 mb-1">
    <span>7 / 10 visitors complete (1 failed)</span><span>70%</span>
  </div>
  <div class="h-2 w-full overflow-hidden rounded-full bg-gray-100">
    <div class="h-full bg-green-500 float-left w-2/3"></div>
    <div class="h-full bg-red-400 float-left w-1/12"></div>
  </div>
</div>
```

(70% → nearest twelfth → `w-2/3` ≈ 66.67%; 10% → nearest twelfth → `w-1/12` ≈ 8.33%. Resolution loss ~4% — fine for a progress indicator.)

## Test plan

- [x] `bun --cwd apps/web test study` — 14/14 pass.
- [x] `bun --cwd apps/web typecheck` — clean.
- [ ] Manual: load `/dashboard/studies/<id>` for an in-flight study with the production CSP middleware enabled and confirm the green bar is visible (no inline-style violations in the console).
- [ ] Visual regression: confirm the Tailwind safelist comment kept all 13 width classes in the JIT bundle (build + grep `.next/static/css/*.css` for each class).

## Why option (a) of the three discussed

- (a) Tailwind class lookup — taken. Pure HTML, fully CSP-clean, no extra plumbing.
- (b) CSS custom property + Tailwind arbitrary value — still requires `'unsafe-inline'` for the property declaration, so it doesn't actually fix the CSP violation.
- (c) Static stylesheet with `.progress-NN` classes — works, but adds CSS plumbing and a separate file to maintain. The Tailwind helper has no extra surface area.

🤖 Generated with [Claude Code](https://claude.com/claude-code)