### PR TITLE
chore: Sprint 3 carryover review-nit sweep (#67 #68 #74 #93 #99)

### DIFF
--- a/apps/api/test/auth.test.ts
+++ b/apps/api/test/auth.test.ts
@@ -367,6 +367,51 @@ describeIfDocker('auth magic-link (issue #79, real DB)', () => {
   });
 
   // -------------------------------------------------------------------------
+  // AC2-regression (issue #99 N3): idempotent re-request of magic-link keeps
+  // the FIRST token usable. Two POSTs for the same email within 30 min must
+  // not invalidate the earlier token; the first token still verifies → 302.
+  // -------------------------------------------------------------------------
+  it('AC2-regression: re-requesting magic-link does not invalidate the first token (issue #99)', async () => {
+    const email = 'ac2-regression@example.com';
+
+    // First request — capture the first verifyUrl/token.
+    const first = await app.inject({
+      method: 'POST',
+      url: '/api/auth/magic-link',
+      payload: { email },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(first.statusCode).toBe(202);
+    const firstVerifyUrl = resendStub.lastCall?.verifyUrl ?? '';
+    const firstMatch = /[?&]token=([^&]+)/.exec(firstVerifyUrl);
+    const firstToken = firstMatch?.[1] ?? '';
+    expect(firstToken).toBeTruthy();
+
+    // Second request for the same email (within the 30-min expiry window).
+    const second = await app.inject({
+      method: 'POST',
+      url: '/api/auth/magic-link',
+      payload: { email },
+      headers: { 'content-type': 'application/json' },
+    });
+    expect(second.statusCode).toBe(202);
+    const secondVerifyUrl = resendStub.lastCall?.verifyUrl ?? '';
+    const secondMatch = /[?&]token=([^&]+)/.exec(secondVerifyUrl);
+    const secondToken = secondMatch?.[1] ?? '';
+    expect(secondToken).toBeTruthy();
+
+    // The two tokens may or may not be equal (current impl issues a fresh
+    // row each time); the spec only requires that the FIRST token remains
+    // valid. That's the AC2 invariant we're regression-locking here.
+    const verifyFirst = await app.inject({
+      method: 'GET',
+      url: `/api/auth/verify?token=${firstToken}`,
+    });
+    expect(verifyFirst.statusCode).toBe(302);
+    expect(verifyFirst.headers.location).toBe('/dashboard');
+  });
+
+  // -------------------------------------------------------------------------
   // AC9: Dev mode (WILLBUY_DEV_SESSION set) — verify URL in body, no email sent.
   // -------------------------------------------------------------------------
   it('AC9: WILLBUY_DEV_SESSION set → verifyUrl in body, Resend NOT called', async () => {

--- a/apps/capture-worker/src/capture.ts
+++ b/apps/capture-worker/src/capture.ts
@@ -85,6 +85,11 @@ export async function captureUrl(url: string, opts?: CaptureOpts): Promise<Captu
     // Total-bytes listener — accumulates response body sizes (spec §2 #6).
     // Aborts as soon as the running total crosses the ceiling so we don't
     // buffer an unbounded response into memory before we can check.
+    //
+    // Caveat (issue #67): chunked-encoding responses (no Content-Length
+    // header) are silently NOT counted here — this is best-effort. The
+    // deeper boundary is the iptables egress + host-budget enforcement
+    // (PR #42 / spec §2 #5), which still caps the host-budget regardless.
     page.on('response', (resp) => {
       const contentLength = resp.headers()['content-length'];
       if (contentLength) {

--- a/apps/capture-worker/test/server/fixtureServer.ts
+++ b/apps/capture-worker/test/server/fixtureServer.ts
@@ -48,8 +48,7 @@ export async function startFixtureServer(): Promise<FixtureServer> {
       if (url.pathname === '/__big-body') {
         // Returns a response body of configurable size (default 30 MB) with
         // an explicit content-length header so the total_bytes listener can
-        // tally it before the body is fully buffered. The body is repeated
-        // ASCII so it never compresses down to nothing if gzip is applied.
+        // tally it before the body is fully buffered.
         const bytes = parseInt(url.searchParams.get('bytes') ?? String(30 * 1024 * 1024), 10);
         const chunk = Buffer.alloc(65536, 'x');
         res.setHeader('content-type', 'text/html; charset=utf-8');

--- a/apps/web/app/dashboard/studies/[id]/page.tsx
+++ b/apps/web/app/dashboard/studies/[id]/page.tsx
@@ -87,7 +87,6 @@ function StudyStatusInner({ id }: { id: string }) {
   // Fetch once on mount, then poll every 5 s until terminal.
   useEffect(() => {
     let cancelled = false;
-    let interval: ReturnType<typeof setInterval> | undefined;
 
     async function fetchStudy() {
       const result = await getStudy(id);
@@ -101,7 +100,7 @@ function StudyStatusInner({ id }: { id: string }) {
         // forever as long as the tab stays open.
         const s = result.data.status;
         if (s === 'ready' || s === 'failed') {
-          if (interval !== undefined) clearInterval(interval);
+          clearInterval(interval);
         }
       } else {
         setLoadError(result.error);
@@ -111,14 +110,15 @@ function StudyStatusInner({ id }: { id: string }) {
     // Initial fetch.
     void fetchStudy();
 
-    // Set up polling interval.
-    interval = setInterval(() => {
+    // Set up polling interval (declared after fetchStudy so it's referenceable
+    // inside the closure without `let` — Issue #74 MINOR-1).
+    const interval = setInterval(() => {
       void fetchStudy();
     }, POLL_INTERVAL_MS);
 
     return () => {
       cancelled = true;
-      if (interval !== undefined) clearInterval(interval);
+      clearInterval(interval);
     };
   }, [id]);
 

--- a/apps/web/app/dashboard/studies/[id]/page.tsx
+++ b/apps/web/app/dashboard/studies/[id]/page.tsx
@@ -87,6 +87,7 @@ function StudyStatusInner({ id }: { id: string }) {
   // Fetch once on mount, then poll every 5 s until terminal.
   useEffect(() => {
     let cancelled = false;
+    let interval: ReturnType<typeof setInterval> | undefined;
 
     async function fetchStudy() {
       const result = await getStudy(id);
@@ -95,6 +96,13 @@ function StudyStatusInner({ id }: { id: string }) {
       if (result.ok) {
         setStudy(result.data);
         setLoadError(null);
+        // Issue #74 MINOR-1: stop polling once terminal status is reached.
+        // Without this, the page keeps hitting GET /studies/:id every 5 s
+        // forever as long as the tab stays open.
+        const s = result.data.status;
+        if (s === 'ready' || s === 'failed') {
+          if (interval !== undefined) clearInterval(interval);
+        }
       } else {
         setLoadError(result.error);
       }
@@ -104,13 +112,13 @@ function StudyStatusInner({ id }: { id: string }) {
     void fetchStudy();
 
     // Set up polling interval.
-    const interval = setInterval(() => {
+    interval = setInterval(() => {
       void fetchStudy();
     }, POLL_INTERVAL_MS);
 
     return () => {
       cancelled = true;
-      clearInterval(interval);
+      if (interval !== undefined) clearInterval(interval);
     };
   }, [id]);
 
@@ -165,8 +173,13 @@ function StudyStatusInner({ id }: { id: string }) {
           <p className="text-sm font-medium text-green-800">
             Your study is ready! View the report to see results.
           </p>
+          {/* Issue #74 MINOR-2: GET /studies/:id returns the study's slug
+              field (per PR #102 dashboard-summary endpoint pattern). Use it
+              when available; fall back to /r/${s.id} (matches the bare-id
+              shape used by /dashboard/studies/StudiesListView). The previous
+              fallback (/r/study-${s.id}) would 404. */}
           <a
-            href={s.slug ? `/r/${s.slug}` : `/r/study-${s.id}`}
+            href={s.slug ? `/r/${s.slug}` : `/r/${s.id}`}
             className="mt-3 inline-block rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
           >
             View report


### PR DESCRIPTION
## Summary

Sprint 3 carryover sweep: five small review-nit cleanups from rev-pr64 / rev-pr72 / rev-pr91 / rev-pr95 that don't individually justify a PR. Issue #126.

One commit per closed issue (four code commits; #93 was already addressed by PR #108 and is closed by reference here):

- **#67** `chore(capture-worker): document chunked-encoding gap in TOTAL_BYTES` — 5-line inline comment near the `page.on('response')` listener acknowledging that chunked-encoding responses (no `Content-Length`) are silently not counted by the total-bytes ceiling. Documents that the iptables egress + host-budget enforcement (PR #42 / spec §2 #5) is the deeper boundary that catches this case. No behavior change.
- **#68** `test(capture-worker): remove misleading gzip comment in fixtureServer` — `apps/capture-worker/test/server/fixtureServer.ts` had a comment about gzip (\"so it never compresses down to nothing if gzip is applied\") but the server never enables gzip. Comment removed; no behavior change.
- **#74** `chore(web): clear poll on terminal status + fix /r/:slug fallback URL`
  - MINOR-1: `apps/web/app/dashboard/studies/[id]/page.tsx`'s polling effect now clears the interval inside the fetch handler when `status === 'ready' || 'failed'`, instead of only on unmount.
  - MINOR-2: The `/r/:slug` fallback was `/r/study-${s.id}` (would 404). Fixed to `/r/${s.id}` to match `/dashboard/studies/StudiesListView`. `s.slug` is still preferred when present.
- **#93** — already addressed by PR #108 (merged). Closed via reference here. No code change in this PR.
- **#99** `chore(auth): document rev-pr95 N1 mount strategy + AC2 regression test`
  - N1: `apps/api/src/routes/dashboard.ts` already documents the strict-401 decision (web layer turns 401 into 302 → /sign-in). No code change; decision is locked in.
  - N3: Added the missing AC2 regression test in `apps/api/test/auth.test.ts` asserting that re-requesting a magic link for the same email within the 30-min window does NOT invalidate the first token. 10/10 auth tests pass.

## Diff summary

- `apps/capture-worker/src/capture.ts` — 5 lines added (comment).
- `apps/capture-worker/test/server/fixtureServer.ts` — 1 line removed (comment).
- `apps/web/app/dashboard/studies/[id]/page.tsx` — polling early-clear + slug fallback fix (~16 line diff).
- `apps/api/test/auth.test.ts` — +45 lines (one new test).

No migrations. No production-behavior change beyond the slug-URL bug fix in #74 and the polling-fix in #74 (both purely client-side).

## Test plan

- [x] `bun --cwd apps/capture-worker typecheck` — clean.
- [x] `bun --cwd apps/web typecheck` — clean.
- [x] `bun --cwd apps/web test studies` — 14/14 pass.
- [x] `bun --cwd apps/api test auth` — 10/10 pass (was 9, +1 new AC2 regression test).
- [ ] CI: lint + typecheck + tests across all packages.

## Closes

Closes #67
Closes #68
Closes #74
Closes #93
Closes #99

Closes #126

🤖 Generated with [Claude Code](https://claude.com/claude-code)