### PR TITLE
fix(web): allow 'unsafe-inline' for style-src so Recharts can draw (#133)

### DIFF
--- a/.samo/spec/willbuy/SPEC.willbuy.amendments.md
+++ b/.samo/spec/willbuy/SPEC.willbuy.amendments.md
@@ -316,3 +316,35 @@ The spec's `(1,000 credits)` / `(4,000 credits)` / `(15,000 credits)` parentheti
 **Constraints.** (a) Three names are stable for v0.1; new tiers go through a fresh amendment + Stripe dashboard update. (b) The display-credit-count label is the only place the user sees a non-monetary number — keep that math consistent in `BuyCredits.tsx` (currently a known minor display bug per issue #73). (c) Stripe price IDs are environment-specific (test-mode vs live-mode); `STRIPE_PRICE_ID_*` env vars are sourced via `op inject` from the `willbuy` 1Password vault.
 
 **Tracking.** PR #71 (issue #36 close).
+
+---
+
+## 2026-04-26 — A8: CSP `style-src` includes `'unsafe-inline'` (Recharts compatibility)
+
+**Affects:** §5.10 (Content-Security-Policy on `/dashboard/*` and `/r/*`).
+
+**Driver:** Issue #133. The strict CSP from PR #13 set `style-src 'self'` (no `'unsafe-inline'`). Recharts' `<ResponsiveContainer>` emits inline `style="width:100%;height:256px"` attributes for chart dimensions; the browser silently rejected them, the container's computed height collapsed to 0px, and Recharts drew zero SVG. Result: all 7 §5.18 chart sections (paired-dots, both histograms, next-actions, tier-picked, theme-board, persona grid) rendered as empty divs in production.
+
+**Amendment.** The CSP `style-src` directive becomes `style-src 'self' 'unsafe-inline'` (was `style-src 'self'`). Verbatim CSP string after this amendment:
+
+```
+default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'
+```
+
+**Rationale.** §5.10 does not mandate strict `style-src`; the `script-src` strictness is what defends against XSS. Inline styles cannot execute JavaScript. The conventional Next.js + Recharts pattern relaxes `style-src` and keeps `script-src` strict — that is what we adopt. The `dangerouslySetInnerHTML` lint (`react/no-danger` in `eslint.config.mjs`) independently forbids inline-JS injection paths, so this CSP relaxation does not regress the §5.10 XSS posture.
+
+**What is NOT changed.**
+
+- `script-src 'self'` (the XSS-relevant directive) — still strict, no `'unsafe-inline'`, no `'unsafe-eval'`.
+- `default-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'none'`, `form-action 'self'`, `require-trusted-types-for 'script'` — unchanged.
+- The middleware matcher (`/dashboard/:path*`, `/r/:path*`) — unchanged. Marketing routes are still out of scope per the §5.10 scope-narrowing comment in `apps/web/middleware.ts`.
+- Permissions-Policy, X-Content-Type-Options, Referrer-Policy headers — unchanged.
+- The `react/no-danger` lint rule in `eslint.config.mjs` — still `error`. It still forbids `dangerouslySetInnerHTML` in `apps/web/**`.
+
+**Constraints.**
+
+- (a) Any future inline-style additions must NOT involve untrusted-data interpolation. Server-rendered styles (Recharts dimensions, Tailwind-generated class output, etc.) only. If a future feature needs to interpolate user-supplied values into a style attribute, that feature MUST sanitize at the boundary or use a class-lookup pattern (cf. PR #128 / issue #111 for the progress-bar precedent).
+- (b) `script-src` MUST stay strict. If a future change adds `'unsafe-inline'` or `'unsafe-eval'` to `script-src`, that requires its own amendment (and a strong reason — adding `'unsafe-inline'` to `script-src` defeats §5.10 entirely).
+- (c) The middleware test (`apps/web/test/middleware.test.ts`) asserts both invariants: `style-src` contains `'unsafe-inline'` AND `script-src` does NOT. Both assertions guard the directive split.
+
+**Tracking.** PR #N (set on merge), issue #133.

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,9 +1,19 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-// SPEC §5.10 — verbatim. The string compare in apps/web/test/middleware.test.ts
-// guards against drift; do NOT reformat or rebuild this from parts.
+// SPEC §5.10 + amendment A8 — verbatim. The string compare in
+// apps/web/test/middleware.test.ts guards against drift; do NOT reformat
+// or rebuild this from parts.
+//
+// `style-src 'self' 'unsafe-inline'`: Recharts (and similar visualization
+// libraries) emit inline `style` attributes for chart dimensions. The
+// strict `style-src 'self'` caused chart SVGs to render at 0px height
+// (issue #133, all 7 §5.18 chart sections rendered as empty divs).
+// `script-src` remains strict (`'self'` only) — that is the actual XSS
+// surface; styles cannot execute JS. Inline-JS injection is independently
+// forbidden by the `react/no-danger` lint rule in `eslint.config.mjs`.
+// See amendment A8 for the full rationale and constraints.
 const CSP =
-  "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'";
+  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'";
 
 const PERMISSIONS_POLICY =
   'camera=(), microphone=(), geolocation=(), clipboard-read=(), clipboard-write=()';

--- a/apps/web/test/middleware.test.ts
+++ b/apps/web/test/middleware.test.ts
@@ -2,9 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { NextRequest } from 'next/server';
 import { middleware } from '../middleware';
 
-// SPEC §5.10 — verbatim CSP string. Tests assert string equality.
+// SPEC §5.10 + amendment A8 — verbatim CSP string. Tests assert string
+// equality. Amendment A8 adds `style-src 'self' 'unsafe-inline'` so
+// Recharts inline-style attributes are not blocked (issue #133).
 const EXPECTED_CSP =
-  "default-src 'self'; script-src 'self'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'";
+  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'";
 
 const EXPECTED_PERMISSIONS_POLICY =
   'camera=(), microphone=(), geolocation=(), clipboard-read=(), clipboard-write=()';
@@ -45,5 +47,34 @@ describe('SPEC §5.10 — CSP middleware', () => {
     // We model that here by asserting the middleware function, when called
     // on /, returns a response without the strict CSP.
     expect(res.headers.get('content-security-policy')).toBeNull();
+  });
+
+  // Amendment A8 (issue #133) — Recharts emits inline `style` attributes
+  // for chart dimensions. `style-src` must include `'unsafe-inline'` or
+  // chart SVGs render at 0px height. `script-src` MUST stay strict
+  // (no `'unsafe-inline'`) because that is the XSS-relevant directive.
+  describe('amendment A8 — style-src vs script-src laxity (issue #133)', () => {
+    it("style-src contains 'unsafe-inline' (Recharts compatibility)", () => {
+      const res = middleware(reqFor('/r/abc'));
+      const csp = res.headers.get('content-security-policy') ?? '';
+      const styleDirective = csp
+        .split(';')
+        .map((d) => d.trim())
+        .find((d) => d.startsWith('style-src'));
+      expect(styleDirective, 'CSP must declare a style-src directive').toBeTruthy();
+      expect(styleDirective).toContain("'unsafe-inline'");
+    });
+
+    it("script-src does NOT contain 'unsafe-inline' (XSS surface stays strict)", () => {
+      const res = middleware(reqFor('/r/abc'));
+      const csp = res.headers.get('content-security-policy') ?? '';
+      const scriptDirective = csp
+        .split(';')
+        .map((d) => d.trim())
+        .find((d) => d.startsWith('script-src'));
+      expect(scriptDirective, 'CSP must declare a script-src directive').toBeTruthy();
+      expect(scriptDirective).not.toContain("'unsafe-inline'");
+      expect(scriptDirective).not.toContain("'unsafe-eval'");
+    });
   });
 });

--- a/apps/web/test/report-viz.test.tsx
+++ b/apps/web/test/report-viz.test.tsx
@@ -12,6 +12,7 @@
 
 // @vitest-environment jsdom
 
+import { act } from 'react';
 import { describe, expect, it, beforeAll, afterEach, vi } from 'vitest';
 import { cleanup, render, screen, fireEvent, within } from '@testing-library/react';
 import { Report, type ReportT } from '@willbuy/shared/report';
@@ -241,6 +242,27 @@ describe('§5.18 — report visualization', () => {
         value: origGBCR,
       });
     }
+  });
+
+  it('issue #133 smoke — report fixture renders Recharts SVGs (CSP A8 regression)', async () => {
+    // Regression guard for issue #133: with the strict `style-src 'self'`
+    // CSP from PR #13, Recharts' ResponsiveContainer emits inline
+    // style="width:..;height:.." that the browser silently rejects, the
+    // measured container height collapses to 0, and Recharts draws no
+    // SVG. The fix is amendment A8 (`style-src 'self' 'unsafe-inline'`).
+    //
+    // Note: jsdom does not enforce CSP — this test cannot reproduce the
+    // browser's silent rejection. What it CAN guarantee is the
+    // end-to-end DOM shape: rendering the full report fixture must yield
+    // > 0 SVG elements. The CSP-string contract itself is asserted in
+    // apps/web/test/middleware.test.ts (also added in this PR).
+    const { container } = render(<ReportView report={fixture} mode="public" />);
+    // Flush effects so Recharts' ResizeObserver-driven layout completes.
+    await act(async () => {
+      await Promise.resolve();
+    });
+    const svgs = container.querySelectorAll('svg');
+    expect(svgs.length, 'expected ReportView to render at least one Recharts SVG').toBeGreaterThan(0);
   });
 
   it('F1 — paired-dot plot renders one SVG <line> connector per backstory (§5.18 #2)', () => {


### PR DESCRIPTION
## Root cause

Recharts' `<ResponsiveContainer>` emits inline `style="width:100%;height:256px"` attributes on its wrapping `<div>`. PR #13 set the CSP `style-src 'self'` (no `'unsafe-inline'`). The browser silently rejects the inline style; the container's computed height collapses to 0px; Recharts emits zero SVG. Result: in production, all 7 §5.18 chart sections (paired-dots, both histograms, next-actions, tier-picked, theme-board, persona grid) rendered as empty divs.

## Before / after

`getComputedStyle($('[data-testid="paired-dots"] .recharts-responsive-container')).height` on `/r/<slug>`:

- **Before** (this branch's parent, `style-src 'self'` only): `0px` — inline `style="height:256px"` rejected by CSP, container collapses, Recharts skips rendering.
- **After** (this branch, `style-src 'self' 'unsafe-inline'`): `256px` — inline style applied, container reports 256px to ResizeObserver, Recharts draws the SVG.

End-to-end smoke verification of the served CSP header:
```
$ curl -sSI http://localhost:3014/r/test-fixture | grep -i 'content-security-policy'
content-security-policy: default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'
```

## Why this is safe

§5.10 doesn't mandate strict `style-src`; the `script-src` strictness is the XSS-relevant directive (inline styles cannot execute JS). `script-src` stays strict (`'self'` only — no `'unsafe-inline'`, no `'unsafe-eval'`). The `react/no-danger` lint rule in `eslint.config.mjs` independently forbids `dangerouslySetInnerHTML` in `apps/web/**`, so the inline-JS injection surface stays closed.

The middleware test asserts both invariants in this PR:
- `style-src` contains `'unsafe-inline'`.
- `script-src` does NOT contain `'unsafe-inline'` (or `'unsafe-eval'`).

## Amendment A8 (recorded in `SPEC.willbuy.amendments.md`)

> **2026-04-26 — A8: CSP `style-src` includes `'unsafe-inline'` (Recharts compatibility)**
>
> **Affects:** §5.10. **Driver:** issue #133 — Recharts emits inline `style` for chart dimensions; strict `style-src` blocks them and SVGs render at 0px height.
>
> **Amendment:** `style-src 'self' 'unsafe-inline'` (was `style-src 'self'`).
>
> **What is NOT changed:** `script-src 'self'` (the XSS-relevant directive); `default-src`, `object-src 'none'`, `base-uri`, `frame-ancestors`, `form-action`, `require-trusted-types-for`. The `react/no-danger` lint rule in `eslint.config.mjs` still forbids `dangerouslySetInnerHTML` in `apps/web/**`.
>
> **Constraints:** Any future inline-style additions must NOT involve untrusted-data interpolation (server-rendered styles only). `script-src` MUST stay strict.

Full text in `.samo/spec/willbuy/SPEC.willbuy.amendments.md` (the diff in this PR appends it).

## Tests

- `apps/web/test/middleware.test.ts` — updated the verbatim-CSP string-equality assertion to match the new directive list. Added a sub-`describe('amendment A8')` with two new tests that assert (a) `style-src` contains `'unsafe-inline'` and (b) `script-src` does NOT contain `'unsafe-inline'` or `'unsafe-eval'`.
- `apps/web/test/report-viz.test.tsx` — added an issue-#133 regression smoke test that renders `<ReportView />` against the fixture, flushes effects, and asserts `container.querySelectorAll('svg').length > 0`. (jsdom does not enforce CSP — that contract is asserted in `middleware.test.ts`. This test guards the end-to-end DOM shape.)

## Test outputs

```
$ bun --cwd apps/web typecheck
(clean — no diagnostics)

$ bun --cwd apps/web test middleware
Test Files  1 passed (1)
     Tests  7 passed (7)         (was 5; +2 from amendment A8 sub-describe)

$ bun --cwd apps/web test report-viz
Test Files  1 passed (1)
     Tests  10 passed (10)        (was 9; +1 issue-#133 smoke test)

$ bun --cwd apps/web lint
(clean)

$ bun --cwd apps/web run build
✓ Generating static pages (13/13)   (build green)
```

## Files touched

- `apps/web/middleware.ts` — CSP string updated; rationale comment links A8 + #133.
- `apps/web/test/middleware.test.ts` — verbatim CSP updated; A8 sub-describe added.
- `apps/web/test/report-viz.test.tsx` — issue-#133 smoke test added.
- `.samo/spec/willbuy/SPEC.willbuy.amendments.md` — amendment A8 appended.

No Recharts component changes. No other surface area touched.

Closes #133