### PR TITLE
fix(web): per-request CSP nonce for script-src so App Router hydrates (#135)

### DIFF
--- a/.samo/spec/willbuy/SPEC.willbuy.amendments.md
+++ b/.samo/spec/willbuy/SPEC.willbuy.amendments.md
@@ -348,3 +348,44 @@ default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-
 - (c) The middleware test (`apps/web/test/middleware.test.ts`) asserts both invariants: `style-src` contains `'unsafe-inline'` AND `script-src` does NOT. Both assertions guard the directive split.
 
 **Tracking.** PR #N (set on merge), issue #133.
+
+---
+
+## 2026-04-25 — A9: CSP `script-src` carries a per-request nonce + `'strict-dynamic'` (Next.js 14 App Router hydration)
+
+**Affects:** §5.10 (Content-Security-Policy on `/dashboard/*` and `/r/*`); follows on amendment A8 which relaxed `style-src` only.
+
+**Driver:** Issue #135 — CSP blocks Next 14 inline bootstrap scripts, breaks all client hydration. The strict `script-src 'self'` shipped in PR #13 silently blocked the inline `<script>` tags Next.js 14 App Router emits during SSR (the `(self.__next_f = self.__next_f || []).push([1, "..."])` payloads that deliver the React Server Components flight tree to the client). Without those inline scripts, `window.__next_f.length === 0`, React never receives the RSC tree, no fiber attaches to any DOM node, no client component effect runs, and Recharts' `ResponsiveContainer` never measures + draws — the §5.18 chart container divs SSR with proper dimensions but render zero SVG. This blocked the launch dogfood (issue #86) because the public report `/r/test-fixture` was the demo target.
+
+`'unsafe-inline'` is FORBIDDEN for `script-src` per §5.10 (it would defeat the XSS defence entirely; cf. amendment A8 constraint (b) and amendment A8 "What is NOT changed" line 1). The correct fix is the canonical Next.js 14 nonce pattern.
+
+**Amendment.** The CSP `script-src` directive becomes `script-src 'self' 'nonce-<value>' 'strict-dynamic'` (was `script-src 'self'`). The `<value>` is a per-request nonce: 16 random bytes produced by `crypto.getRandomValues` (Edge runtime) and base64-encoded. The same nonce is forwarded on the request via the `x-nonce` header (the `NextResponse.next({ request: { headers } })` mutation), which Next.js 14's RSC renderer reads and stamps on its own inline bootstrap `<script>` tags. The CSP header is therefore non-deterministic across requests; `apps/web/test/middleware.test.ts` asserts directive shape (presence of `'self'`, `'nonce-...'`, `'strict-dynamic'`; absence of `'unsafe-inline'` / `'unsafe-eval'`) instead of string-equality on the full CSP.
+
+`'strict-dynamic'` allows the nonce'd bootstrap scripts to authorize their chunk `<script src=".../_next/static/chunks/...">` loads transitively, so newer browsers (CSP3) ignore the `'self'` whitelist. `'self'` is kept as a defensive fallback for older browsers that ignore `'strict-dynamic'`.
+
+Verbatim CSP string template after this amendment (where `<NONCE>` is the 24-character base64 of 16 random bytes, distinct per request):
+
+```
+default-src 'self'; script-src 'self' 'nonce-<NONCE>' 'strict-dynamic'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'
+```
+
+**What is NOT changed.**
+
+- The forbidden `'unsafe-inline'` / `'unsafe-eval'` rule for `script-src` — still forbidden, asserted in `apps/web/test/middleware.test.ts`. The nonce + `'strict-dynamic'` pattern is materially different from `'unsafe-inline'`: an attacker who injects a bare `<script>foo()</script>` cannot guess the per-request nonce, so the script does not execute. `'unsafe-inline'` would let any injected inline script run.
+- `default-src 'self'`, `object-src 'none'`, `base-uri 'self'`, `frame-ancestors 'none'`, `form-action 'self'`, `require-trusted-types-for 'script'` — unchanged.
+- `style-src 'self' 'unsafe-inline'` (amendment A8) — unchanged.
+- The middleware matcher (`/dashboard/:path*`, `/r/:path*`) — unchanged.
+- Permissions-Policy, X-Content-Type-Options, Referrer-Policy headers — unchanged.
+- The `react/no-danger` lint rule in `eslint.config.mjs` — still `error`.
+- The `CSP` module-scope constant in `apps/web/middleware.ts` is replaced by a `buildCsp(nonce)` helper because the directive string is now request-scoped. The string-equality test from before A8 is replaced by per-directive shape assertions (extracted via a small `getCspDirective` helper in the test file).
+
+**Constraints.**
+
+- (a) Nonce entropy: at least 16 bytes (128 bits) per CSP3 SHOULD; the implementation uses exactly 16 bytes via `crypto.getRandomValues`. Any future change MUST keep the entropy at or above 128 bits.
+- (b) The nonce MUST be generated per request inside the middleware function, never at module scope (which would memoize a single nonce across the lifetime of the Edge worker, defeating the protection). Test `successive requests get distinct nonces (no module-scope memoization)` guards this.
+- (c) The nonce MUST be forwarded on the *request* headers via `NextResponse.next({ request: { headers } })`, not just on the response. The Next.js 14 internal RSC renderer reads the request-side `x-nonce` header to stamp its own inline scripts. Setting it only on the response would leave the rendered HTML un-nonced and hydration would still fail.
+- (d) Adding any third-party script source (analytics, tag manager, etc.) is OUT OF SCOPE for this amendment. If it ever becomes necessary, prefer continuing to rely on `'strict-dynamic'` (load the third-party loader from a nonce'd bootstrap) over re-introducing host-based whitelisting, which `'strict-dynamic'` makes ineffective in CSP3.
+- (e) CSP `report-uri` / `report-to` are NOT added in this PR. Reporting can be added in a follow-on amendment if needed; it is unrelated to the hydration fix.
+- (f) The middleware test (`apps/web/test/middleware.test.ts`) asserts: `script-src` contains `'self'` + `'nonce-<value>'` + `'strict-dynamic'`; `script-src` does NOT contain `'unsafe-inline'` / `'unsafe-eval'`; `x-nonce` is exposed on the response; `x-nonce` is forwarded on the request via the Next 14 `x-middleware-request-x-nonce` shadow header; successive requests get distinct nonces; nonce is URL-safe-base64. All six assertions guard the A9 invariants.
+
+**Tracking.** PR #N (set on merge), issue #135. Future spec rev folds nonce + `'strict-dynamic'` into §5.10 directly and drops the verbatim string-form there (now request-scoped).

--- a/apps/web/middleware.ts
+++ b/apps/web/middleware.ts
@@ -1,22 +1,68 @@
 import { NextResponse, type NextRequest } from 'next/server';
 
-// SPEC §5.10 + amendment A8 — verbatim. The string compare in
-// apps/web/test/middleware.test.ts guards against drift; do NOT reformat
-// or rebuild this from parts.
+// SPEC §5.10 + amendments A8 + A9. Drift in this directive set is
+// guarded by apps/web/test/middleware.test.ts; do NOT reformat or
+// rebuild the directive list from parts without updating that file.
 //
-// `style-src 'self' 'unsafe-inline'`: Recharts (and similar visualization
-// libraries) emit inline `style` attributes for chart dimensions. The
-// strict `style-src 'self'` caused chart SVGs to render at 0px height
-// (issue #133, all 7 §5.18 chart sections rendered as empty divs).
-// `script-src` remains strict (`'self'` only) — that is the actual XSS
-// surface; styles cannot execute JS. Inline-JS injection is independently
-// forbidden by the `react/no-danger` lint rule in `eslint.config.mjs`.
-// See amendment A8 for the full rationale and constraints.
-const CSP =
-  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'";
+// `script-src 'self' 'nonce-<value>' 'strict-dynamic'` (amendment A9,
+// issue #135): Next.js 14 App Router emits inline `<script>` tags
+// during SSR that drive client hydration (the
+// `(self.__next_f = ...).push([1, "..."])` RSC flight payloads). The
+// strict `script-src 'self'` we shipped in PR #13 silently blocked
+// them, so the client never received the RSC tree and Recharts
+// never mounted. The fix is the canonical Next.js 14 nonce pattern:
+//   1. Generate a per-request nonce (16 random bytes, base64).
+//   2. Forward it on the *request* via `x-nonce` so Next.js stamps
+//      the same value on its own inline scripts (Next 14 reads this
+//      header convention internally).
+//   3. Add it to CSP `script-src` together with `'strict-dynamic'`
+//      so the nonce'd bootstrap scripts can authorize their chunk
+//      `<script src=".../_next/static/chunks/...">` loads via the
+//      transitive-trust mechanism.
+// `'self'` stays in the directive as a belt-and-suspenders fallback
+// for browsers that ignore `'strict-dynamic'` (CSP3 mandates that
+// `'self'` be ignored when `'strict-dynamic'` is present, but older
+// engines fall back to `'self'` whitelisting).
+//
+// `style-src 'self' 'unsafe-inline'` (amendment A8, issue #133):
+// Recharts' <ResponsiveContainer> emits inline `style` attributes
+// for chart dimensions; the strict `style-src 'self'` collapsed
+// charts to 0px height. Inline-JS injection paths are forbidden by
+// the `react/no-danger` lint rule independent of CSP, so this
+// loosening does not regress §5.10's XSS posture.
+//
+// `require-trusted-types-for 'script'` is preserved verbatim
+// (out-of-scope for both A8 and A9).
 
 const PERMISSIONS_POLICY =
   'camera=(), microphone=(), geolocation=(), clipboard-read=(), clipboard-write=()';
+
+// 16 random bytes -> 24-character base64; comfortably above the
+// "sufficiently random" bar (CSP3 SHOULD be >= 128 bits of entropy).
+function generateNonce(): string {
+  const buf = new Uint8Array(16);
+  crypto.getRandomValues(buf);
+  // Build a binary string for btoa without spreading into
+  // String.fromCharCode(...) (defensive against future-larger
+  // buffers — at 16 bytes the spread would be fine, but the
+  // explicit loop reads the same as the canonical Edge example).
+  let bin = '';
+  for (let i = 0; i < buf.length; i++) bin += String.fromCharCode(buf[i] as number);
+  return btoa(bin);
+}
+
+function buildCsp(nonce: string): string {
+  return [
+    "default-src 'self'",
+    `script-src 'self' 'nonce-${nonce}' 'strict-dynamic'`,
+    "style-src 'self' 'unsafe-inline'",
+    "object-src 'none'",
+    "base-uri 'self'",
+    "frame-ancestors 'none'",
+    "form-action 'self'",
+    "require-trusted-types-for 'script'",
+  ].join('; ');
+}
 
 // Marketing routes (e.g. /) intentionally fall outside this matcher and
 // therefore receive Next.js's default (relaxed) header set. SPEC §5.10
@@ -26,16 +72,32 @@ const PERMISSIONS_POLICY =
 // fonts/analytics with no benefit since no untrusted content lands there.
 export function middleware(req: NextRequest): NextResponse {
   const { pathname } = req.nextUrl;
-  const res = NextResponse.next();
 
   if (pathname.startsWith('/dashboard') || pathname.startsWith('/r/')) {
-    res.headers.set('Content-Security-Policy', CSP);
+    const nonce = generateNonce();
+    const csp = buildCsp(nonce);
+
+    // Forward x-nonce on the *request* headers so the Next.js
+    // RSC renderer reads it and stamps it on its own inline
+    // bootstrap <script> tags. This is the documented Next 14
+    // convention. See
+    // https://nextjs.org/docs/app/building-your-application/configuring/content-security-policy
+    const requestHeaders = new Headers(req.headers);
+    requestHeaders.set('x-nonce', nonce);
+
+    const res = NextResponse.next({
+      request: { headers: requestHeaders },
+    });
+
+    res.headers.set('Content-Security-Policy', csp);
+    res.headers.set('x-nonce', nonce);
     res.headers.set('X-Content-Type-Options', 'nosniff');
     res.headers.set('Referrer-Policy', 'no-referrer');
     res.headers.set('Permissions-Policy', PERMISSIONS_POLICY);
+    return res;
   }
 
-  return res;
+  return NextResponse.next();
 }
 
 export const config = {

--- a/apps/web/test/middleware.test.ts
+++ b/apps/web/test/middleware.test.ts
@@ -25,7 +25,7 @@ function getCspDirective(csp: string, name: string): string | undefined {
 function extractNonce(csp: string): string | null {
   const scriptDirective = getCspDirective(csp, 'script-src') ?? '';
   const m = scriptDirective.match(/'nonce-([A-Za-z0-9+/=_-]+)'/);
-  return m ? m[1] : null;
+  return m && m[1] !== undefined ? m[1] : null;
 }
 
 describe('SPEC §5.10 — CSP middleware', () => {

--- a/apps/web/test/middleware.test.ts
+++ b/apps/web/test/middleware.test.ts
@@ -2,11 +2,11 @@ import { describe, expect, it } from 'vitest';
 import { NextRequest } from 'next/server';
 import { middleware } from '../middleware';
 
-// SPEC §5.10 + amendment A8 — verbatim CSP string. Tests assert string
-// equality. Amendment A8 adds `style-src 'self' 'unsafe-inline'` so
-// Recharts inline-style attributes are not blocked (issue #133).
-const EXPECTED_CSP =
-  "default-src 'self'; script-src 'self'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'";
+// SPEC §5.10 + amendments A8 + A9 — CSP header. The script-src now
+// carries a per-request nonce + 'strict-dynamic' (A9, issue #135) so
+// Next.js 14 App Router inline bootstrap scripts can hydrate the
+// client. The style-src laxity from A8 stays untouched. We extract
+// the nonce dynamically per request and check directive shape.
 
 const EXPECTED_PERMISSIONS_POLICY =
   'camera=(), microphone=(), geolocation=(), clipboard-read=(), clipboard-write=()';
@@ -15,10 +15,32 @@ function reqFor(path: string): NextRequest {
   return new NextRequest(new URL(`http://localhost:3000${path}`));
 }
 
+function getCspDirective(csp: string, name: string): string | undefined {
+  return csp
+    .split(';')
+    .map((d) => d.trim())
+    .find((d) => d.startsWith(`${name} `) || d === name);
+}
+
+function extractNonce(csp: string): string | null {
+  const scriptDirective = getCspDirective(csp, 'script-src') ?? '';
+  const m = scriptDirective.match(/'nonce-([A-Za-z0-9+/=_-]+)'/);
+  return m ? m[1] : null;
+}
+
 describe('SPEC §5.10 — CSP middleware', () => {
-  it('GET /dashboard/anything carries the exact CSP header (string equality)', () => {
+  it('GET /dashboard/anything carries a CSP header with all required directives', () => {
     const res = middleware(reqFor('/dashboard/anything'));
-    expect(res.headers.get('content-security-policy')).toBe(EXPECTED_CSP);
+    const csp = res.headers.get('content-security-policy');
+    expect(csp).toBeTruthy();
+    expect(getCspDirective(csp!, 'default-src')).toBe("default-src 'self'");
+    expect(getCspDirective(csp!, 'object-src')).toBe("object-src 'none'");
+    expect(getCspDirective(csp!, 'base-uri')).toBe("base-uri 'self'");
+    expect(getCspDirective(csp!, 'frame-ancestors')).toBe("frame-ancestors 'none'");
+    expect(getCspDirective(csp!, 'form-action')).toBe("form-action 'self'");
+    // Trusted Types directive must be preserved verbatim — explicitly
+    // out-of-scope for amendment A9 (issue #135).
+    expect(csp).toContain("require-trusted-types-for 'script'");
   });
 
   it('GET /dashboard/* carries the additional security headers', () => {
@@ -28,9 +50,9 @@ describe('SPEC §5.10 — CSP middleware', () => {
     expect(res.headers.get('permissions-policy')).toBe(EXPECTED_PERMISSIONS_POLICY);
   });
 
-  it('GET /r/abc carries the exact CSP header (string equality)', () => {
+  it('GET /r/abc carries a CSP header', () => {
     const res = middleware(reqFor('/r/abc'));
-    expect(res.headers.get('content-security-policy')).toBe(EXPECTED_CSP);
+    expect(res.headers.get('content-security-policy')).toBeTruthy();
   });
 
   it('GET /r/* carries the additional security headers', () => {
@@ -51,30 +73,90 @@ describe('SPEC §5.10 — CSP middleware', () => {
 
   // Amendment A8 (issue #133) — Recharts emits inline `style` attributes
   // for chart dimensions. `style-src` must include `'unsafe-inline'` or
-  // chart SVGs render at 0px height. `script-src` MUST stay strict
-  // (no `'unsafe-inline'`) because that is the XSS-relevant directive.
-  describe('amendment A8 — style-src vs script-src laxity (issue #133)', () => {
+  // chart SVGs render at 0px height.
+  describe('amendment A8 — style-src laxity (issue #133)', () => {
     it("style-src contains 'unsafe-inline' (Recharts compatibility)", () => {
       const res = middleware(reqFor('/r/abc'));
       const csp = res.headers.get('content-security-policy') ?? '';
-      const styleDirective = csp
-        .split(';')
-        .map((d) => d.trim())
-        .find((d) => d.startsWith('style-src'));
+      const styleDirective = getCspDirective(csp, 'style-src');
       expect(styleDirective, 'CSP must declare a style-src directive').toBeTruthy();
       expect(styleDirective).toContain("'unsafe-inline'");
+      expect(styleDirective).toContain("'self'");
     });
+  });
 
-    it("script-src does NOT contain 'unsafe-inline' (XSS surface stays strict)", () => {
+  // Amendment A9 (issue #135) — Next.js 14 App Router emits inline
+  // bootstrap <script> tags that drive client hydration (the
+  // `self.__next_f.push(...)` payloads delivering the RSC flight tree).
+  // CSP must permit them via a per-request nonce; `'unsafe-inline'`
+  // remains FORBIDDEN in script-src per §5.10.
+  describe('amendment A9 — script-src nonce + strict-dynamic (issue #135)', () => {
+    it("script-src contains 'self', a 'nonce-<value>', and 'strict-dynamic'", () => {
       const res = middleware(reqFor('/r/abc'));
       const csp = res.headers.get('content-security-policy') ?? '';
-      const scriptDirective = csp
-        .split(';')
-        .map((d) => d.trim())
-        .find((d) => d.startsWith('script-src'));
+      const scriptDirective = getCspDirective(csp, 'script-src');
       expect(scriptDirective, 'CSP must declare a script-src directive').toBeTruthy();
+      expect(scriptDirective).toContain("'self'");
+      expect(scriptDirective).toMatch(/'nonce-[A-Za-z0-9+/=_-]+'/);
+      expect(scriptDirective).toContain("'strict-dynamic'");
+    });
+
+    it("script-src does NOT contain 'unsafe-inline' or 'unsafe-eval' (XSS surface stays strict)", () => {
+      const res = middleware(reqFor('/r/abc'));
+      const csp = res.headers.get('content-security-policy') ?? '';
+      const scriptDirective = getCspDirective(csp, 'script-src') ?? '';
       expect(scriptDirective).not.toContain("'unsafe-inline'");
       expect(scriptDirective).not.toContain("'unsafe-eval'");
+    });
+
+    it('middleware exposes a same-request nonce on x-nonce response header', () => {
+      const res = middleware(reqFor('/r/abc'));
+      // The nonce is mirrored on the response headers so downstream
+      // tests + (theoretically) edge consumers can read it without a
+      // fresh randomUUID call. Same nonce must appear in the CSP
+      // script-src directive.
+      const responseNonce = res.headers.get('x-nonce');
+      expect(responseNonce, 'middleware must expose x-nonce on response').toBeTruthy();
+      expect(responseNonce!.length, 'nonce must be sufficiently random').toBeGreaterThanOrEqual(16);
+      const csp = res.headers.get('content-security-policy') ?? '';
+      const cspNonce = extractNonce(csp);
+      expect(cspNonce, 'CSP script-src must contain the same nonce as x-nonce').toBe(
+        responseNonce
+      );
+    });
+
+    it('middleware sets x-nonce on the forwarded request headers (Next.js auto-nonce convention)', () => {
+      // Next.js 14 reads `x-nonce` from the *request* headers it
+      // forwards to the route handler so it can stamp the same value
+      // on its own inline RSC bootstrap scripts. We test the contract
+      // by inspecting the response's `x-middleware-request-x-nonce`
+      // shadow header that Next.js mirrors when middleware mutates
+      // request headers via `NextResponse.next({ request: { headers } })`.
+      const res = middleware(reqFor('/r/abc'));
+      const forwardedNonce = res.headers.get('x-middleware-request-x-nonce');
+      expect(
+        forwardedNonce,
+        'middleware must forward x-nonce on the request via NextResponse.next({ request })'
+      ).toBeTruthy();
+      const responseNonce = res.headers.get('x-nonce');
+      expect(forwardedNonce).toBe(responseNonce);
+    });
+
+    it('successive requests get distinct nonces (no module-scope memoization)', () => {
+      const a = middleware(reqFor('/r/abc'));
+      const b = middleware(reqFor('/r/abc'));
+      const nonceA = extractNonce(a.headers.get('content-security-policy') ?? '');
+      const nonceB = extractNonce(b.headers.get('content-security-policy') ?? '');
+      expect(nonceA).toBeTruthy();
+      expect(nonceB).toBeTruthy();
+      expect(nonceA).not.toBe(nonceB);
+    });
+
+    it('nonce uses URL-safe base64 / hex characters only', () => {
+      const res = middleware(reqFor('/r/abc'));
+      const nonce = res.headers.get('x-nonce') ?? '';
+      // Base64 (with `=` padding allowed), base64url (`-`, `_`), or hex.
+      expect(nonce).toMatch(/^[A-Za-z0-9+/=_-]+$/);
     });
   });
 });


### PR DESCRIPTION
## Summary

- Strict `script-src 'self'` silently blocked Next.js 14's inline RSC bootstrap scripts (the `(self.__next_f = ...).push([1, ...])` payloads), so the client never received the RSC flight tree and Recharts never mounted — public report `/r/test-fixture` rendered 9 chart shells with 0 SVG.
- Fix follows the canonical Next.js 14 nonce pattern: middleware generates a per-request 16-byte base64 nonce, forwards it on the request via `x-nonce` so Next 14 stamps its own inline scripts, and adds `'nonce-<value>' 'strict-dynamic'` to CSP `script-src`. `'unsafe-inline'` / `'unsafe-eval'` remain FORBIDDEN per §5.10 (closes #135).
- `require-trusted-types-for 'script'` and `style-src 'self' 'unsafe-inline'` (A8) preserved verbatim — out of scope.

## Spec amendment

Appends **A9** to `.samo/spec/willbuy/SPEC.willbuy.amendments.md` (same shape as A8): nonce + `'strict-dynamic'`; `'unsafe-inline'` still forbidden in `script-src`; nonce MUST be per-request (no module-scope memoization); MUST be forwarded on request headers via `NextResponse.next({ request: { headers } })`.

## Tests added (apps/web/test/middleware.test.ts)

The previous string-equality assertion on the full CSP could not survive a request-scoped nonce, so it was replaced by per-directive shape probes (helper `getCspDirective`). New A9-specific assertions:

- `script-src` contains `'self'` + `'nonce-<value>'` + `'strict-dynamic'`
- `script-src` does NOT contain `'unsafe-inline'` or `'unsafe-eval'`
- middleware exposes `x-nonce` on the response (≥16 chars, matches CSP)
- middleware forwards `x-nonce` on the request (Next 14 `x-middleware-request-x-nonce` shadow header)
- successive requests get distinct nonces (no module-scope memoization)
- nonce is URL-safe base64 / hex
- `style-src` (A8) and `require-trusted-types-for` invariants still asserted

`bunx vitest run middleware` → 12/12 passed; full `apps/web` suite → 87/87 passed; `bunx tsc --noEmit` clean; `bunx eslint .` clean.

## Manual test evidence

Built and started the prod server in the worktree:

```
cd apps/web && bun run build
PORT=3014 WILLBUY_REPORT_FIXTURE=enabled bun run start
```

CSP header carries nonce + strict-dynamic:

```
$ curl -sI http://127.0.0.1:3014/r/test-fixture | grep -iE '^(content-security-policy|x-nonce):'
content-security-policy: default-src 'self'; script-src 'self' 'nonce-wlsHs65fI0MEFkzmkHrusA==' 'strict-dynamic'; style-src 'self' 'unsafe-inline'; object-src 'none'; base-uri 'self'; frame-ancestors 'none'; form-action 'self'; require-trusted-types-for 'script'
x-nonce: wlsHs65fI0MEFkzmkHrusA==
```

Same-request HTML body has 14 inline `<script>` tags all carrying the same nonce as the CSP:

```
$ curl -s -D /tmp/h http://127.0.0.1:3014/r/test-fixture > /tmp/body
$ grep -i content-security-policy /tmp/h
content-security-policy: ...'nonce-wlsHs65fI0MEFkzmkHrusA=='...
$ grep -o 'nonce="[^"]*"' /tmp/body | sort -u
nonce="wlsHs65fI0MEFkzmkHrusA=="
$ grep -o 'nonce="[^"]*"' /tmp/body | wc -l
      15      # 14 inline + 1 stamped on chunk loaders, all matching CSP
```

### Browser-verifying hydration (recipe)

1. `cd apps/web && bun run build && PORT=3014 WILLBUY_REPORT_FIXTURE=enabled bun run start`
2. Open `http://127.0.0.1:3014/r/test-fixture` in Chrome with DevTools Console open.
3. Paste:
   ```js
   JSON.stringify({
     nextfLen: window.__next_f?.length,
     reactKeys: Object.keys(document.querySelector('main')||{}).filter(k=>k.startsWith('__react')),
     svgs: document.querySelectorAll('svg').length,
     responsiveContainers: document.querySelectorAll('.recharts-responsive-container').length
   })
   ```
4. Expected (post-fix): `nextfLen` > 0, `reactKeys` non-empty, `svgs` > 0 (≥9 chart SVGs per #135 acceptance), `responsiveContainers` ≥ 9.
5. Console should be free of `Refused to execute inline script because it violates the following Content Security Policy directive` errors.

## Test plan

- [x] new middleware tests pass locally (`bunx vitest run middleware` → 12/12)
- [x] full `apps/web` suite passes locally (87/87)
- [x] `bunx tsc --noEmit` clean for `apps/web`
- [x] `bunx eslint .` clean for `apps/web`
- [x] `curl -sI` shows CSP with nonce + strict-dynamic, `x-nonce` response header
- [x] `curl -s` shows nonce'd inline scripts matching CSP nonce of same request
- [ ] CI green
- [ ] (REV / manager) browser smoke: 9 SVG charts visible at `/r/test-fixture`

Closes #135.

🤖 Generated with [Claude Code](https://claude.com/claude-code)