### PR TITLE
docs(launch): Show HN draft + AWS Marketplace scoping + pricing CTA audit (#125)

### DIFF
--- a/docs/launch/aws-marketplace-scoping.md
+++ b/docs/launch/aws-marketplace-scoping.md
@@ -1,0 +1,175 @@
+# AWS Marketplace listing — scoping
+
+Status: SCOPING ONLY. This document does NOT submit a listing, file any
+AWS forms, or commit us to a launch date. Per issue #125 and SPEC §8 the
+Marketplace listing is post-v0.2 (target Q3 2026); the goal here is to know
+what's in front of us before we start.
+
+## 1. Listing-type decision
+
+**Decision: SaaS Subscriptions (default).** Recommendation, not yet ratified.
+
+| Option              | Fit for willbuy v0.1                                                                                            |
+| ------------------- | --------------------------------------------------------------------------------------------------------------- |
+| SaaS Subscriptions  | Best fit. Buyer subscribes via Marketplace; AWS bills per-unit usage we report against published dimensions. We already have a `provider_attempts` ledger and a `credit_ledger` that can emit usage records. Self-serve. |
+| SaaS Contracts      | Annual / multi-year prepaid contracts. Indie-hacker ICP doesn't sign annual contracts up front; we'd lose the "one $29 pack and try it" loop. Revisit when we land a fintech buyer (post-SOC 2, per §9 of the spec). |
+| Free + Pay-go (BYOL)| Not applicable — we don't ship infra into the buyer's AWS account.                                              |
+| Professional Services / AMI / Container | Not applicable. We're a SaaS, not a deployable artifact.                                          |
+
+The default-to-Subscriptions recommendation aligns with the spec's
+v0.1 credit-pack pricing (A7: `starter` $29 / `growth` $99 / `scale` $299)
+without forcing a tier rename. Mapping to Marketplace dimensions:
+
+- One usage dimension per pack tier, billed monthly via `MeterUsage` /
+  `BatchMeterUsage` with idempotency keys derived from
+  `credit_ledger.id` (re-using our existing webhook idempotency pattern).
+- Alternative we considered and rejected for v0.2: a single "credits"
+  dimension with variable quantity. AWS reporting docs are happier with
+  fixed-name dimensions, and our packs are already discrete.
+
+Open question for the AWS partner team (see §5): can we reuse the same
+Stripe-style pack semantics in Marketplace, or does Marketplace expect
+recurring-subscription semantics that would force us to introduce a
+v0.2 subscription tier?
+
+## 2. Required listing fields (initial inventory)
+
+Sourced from AWS Marketplace Management Portal docs as of 2026-04. Confirm
+with partner team before submission.
+
+**Product metadata:**
+
+- Product title, short description (≤150 chars), long description.
+- Logo (`.png`, transparent, ≥300×300).
+- Highlights (3 short bullets) and product video (optional but recommended).
+- Categories: `DevOps Tools`, `Productivity`, possibly `Marketing`.
+- Search keywords.
+
+**Pricing & dimensions:**
+
+- One Subscriptions dimension per pack (`starter`, `growth`, `scale`),
+  USD price matching A7.
+- Free trial policy (none in v0.1; flagged as open question — Marketplace
+  buyers may expect one).
+- Refund policy URL.
+
+**Buyer-facing legal:**
+
+- End User License Agreement (EULA) — either AWS Standard Contract for
+  Marketplace (SCMP) or our own. **Recommendation:** start with SCMP to
+  ship; switch to a custom EULA only if Marketplace buyer requests force
+  changes (e.g. data-residency commitments).
+- Privacy notice URL (`willbuy.dev/privacy`).
+- Refund / cancellation policy URL.
+- Support contact (`support@willbuy.dev`).
+
+**Technical integration:**
+
+- Marketplace fulfillment URL (the post-purchase landing page that
+  receives the AWS-issued `x-amzn-marketplace-token`).
+- AWS account ID for the seller account.
+- IAM role for `aws-marketplace:MeterUsage` / `BatchMeterUsage` /
+  `ResolveCustomer`.
+- SNS topic ARN for entitlement / subscription notifications
+  (`aws-marketplace-entitlement-notification` and
+  `aws-marketplace-subscription-notification`).
+
+**Compliance:**
+
+- Tax registration (US states + EU VAT if applicable).
+- AWS Foundational Technical Review (FTR) — flagged as a likely
+  prerequisite, especially for Subscriptions listings; need the AWS
+  Partner team to confirm.
+- Data-handling disclosures (we ALREADY have a redaction policy per
+  §5.9; this maps directly).
+
+## 3. Customer onboarding flow — integration points
+
+The buyer journey for SaaS Subscriptions is well documented; the four
+integration points we have to build are:
+
+1. **Marketplace fulfillment landing.** A new route, e.g.
+   `apps/web/app/aws-marketplace/fulfill/page.tsx`, that receives the
+   POST from Marketplace with `x-amzn-marketplace-token`. We call
+   `ResolveCustomer` to exchange the token for a `CustomerIdentifier`
+   and `ProductCode`, then either:
+   - **Sign in with AWS path (preferred for SaaS Subscriptions):** redirect
+     the buyer to our sign-in page with a one-time `marketplace_link_token`
+     cookie; on first sign-in (magic link per spec §2 #25 / §8) we attach
+     the AWS `CustomerIdentifier` to their willbuy account.
+   - **Contract-redirect handshake (fallback):** if the buyer is already
+     signed in (existing willbuy account upgrading via Marketplace),
+     attach immediately and redirect to `/dashboard?marketplace=linked`.
+2. **Entitlement / subscription notifications.** SNS-subscribed Lambda (or
+   a dedicated webhook on our API) consumes `subscribe-success`,
+   `unsubscribe-pending`, `unsubscribe-success`. Each event writes to a
+   new `aws_marketplace_events` table (mirrors our existing Stripe
+   webhook pattern with `event.id` as ledger idempotency key per §5.8).
+3. **Usage metering.** A scheduled job (hourly) reads
+   `credit_ledger.kind = 'top_up'` rows tagged `source = 'aws_marketplace'`
+   and emits `BatchMeterUsage` records with idempotency keys derived from
+   `credit_ledger.id`. We do NOT meter live spend per-visit — the
+   Marketplace dimension is "pack purchased," not "credits consumed,"
+   matching our Stripe model.
+4. **Account model changes.** `accounts` table gets two nullable columns:
+   `aws_marketplace_customer_identifier` (encrypted, KMS envelope per
+   §2 #32) and `aws_marketplace_product_code`. Each account can have AT
+   MOST ONE Marketplace linkage in v1; multi-link is a future-us problem.
+
+## 4. What we do NOT have today
+
+(This is the gap list — the actual scoping value of this doc.)
+
+- A Marketplace seller account (creation requires US tax + bank info; the
+  founder needs to file).
+- AWS Partner Network (APN) registration.
+- An EULA, even SCMP, signed off by counsel (we have a stub `terms.md`
+  in the repo that is NOT production-grade).
+- The Sign in with AWS / fulfillment endpoint (no app code yet).
+- A FTR submission. Likely 2–4 weeks of back-and-forth.
+- Tax registration in US states beyond our current footprint.
+- Data-residency stance (Marketplace buyers in EU may ask for EU-region
+  hosting; we are Hetzner Ashburn today per the spec's `/infra/README.md`).
+- A documented refund policy (we have the credit-pack model but no SLA
+  on refunds; needs to align with spec §5.4 reconcile job).
+
+## 5. Open questions for the AWS partner team
+
+1. Does our credit-pack pricing model (one-time pack purchase, no
+   recurrence) fit the SaaS Subscriptions billing model, or does
+   Subscriptions require recurring billing? If it requires recurrence,
+   should we introduce a "subscription credit pack" (e.g. monthly
+   auto-top-up) for the Marketplace SKU only, or move to SaaS Contracts?
+2. Is the Foundational Technical Review (FTR) a hard prerequisite for a
+   SaaS Subscriptions listing, or only for AMI / Container listings?
+3. Are there partner-team-recommended SCMP carve-outs for vendors that
+   handle third-party-page captures (relevant to our §5.9 data classification)?
+4. Listing-page best practices for indie / single-founder vendors —
+   any minimum-viable trust signals (e.g. AWS Partner Tier) that buyers
+   filter by, that would block visibility for an unaffiliated seller?
+5. SLA expectations on Marketplace listings: do buyers expect 99.9% / 99.95%,
+   and is a missing SLA disclosure a launch blocker?
+6. Multi-region listing (AWS Marketplace per-region pricing) — is single-region
+   USD-only acceptable for v1?
+7. Cancellation flow: when a buyer unsubscribes mid-month, do we still
+   meter the unused capacity, or is the contract closed at
+   `unsubscribe-success`? Affects how we handle leftover credits.
+
+## 6. Rough timeline
+
+Out of scope for v0.2 launch. Indicative only:
+
+- T+0 (post-v0.2 launch): file APN registration + Marketplace seller account.
+- T+2–4 weeks: FTR submission + EULA / privacy / refund policy review.
+- T+4–8 weeks: implement fulfillment endpoint + SNS handler + metering job
+  on a feature branch behind a flag.
+- T+8–10 weeks: submit listing draft, iterate with AWS partner team.
+- Target go-live: Q3 2026, conditional on the v0.2 SOC 2 / fintech-buyer
+  expansion track per spec §9.
+
+## 7. Explicit non-goals (this doc)
+
+- We are not creating the Marketplace listing in this PR.
+- We are not making the FTR submission in this PR.
+- We are not changing pricing tiers (Nik decides those; A7 stands).
+- We are not renaming the existing Stripe price IDs.

--- a/docs/launch/pricing-cta-audit.md
+++ b/docs/launch/pricing-cta-audit.md
@@ -1,0 +1,158 @@
+# Pricing-page CTA audit
+
+Status: AUDIT only. Per the v0.2 launch checklist (issue #125), CTA wiring
+is the deliverable for a separate web-engineer issue. This document enumerates
+the current state, flags every CTA against our paid-conversion goal, and
+recommends the wiring change in TEXT only — no application code touched.
+
+**Audit goal (manager memory, repeated here so reviewers don't have to dig):**
+> The pricing page optimizes for **paid conversion**, not free signups.
+> A CTA that funnels to "start_free" without first surfacing the paid
+> tiers is a defect, not a win.
+
+This audit covers:
+
+1. The willbuy.dev landing page (`apps/web/app/page.tsx`).
+2. The pricing page at `/pricing` (currently DOES NOT EXIST in the
+   repository as of `main` @ 0d2b63a; called out below as the primary gap).
+3. The `BuyCredits` component (`apps/web/components/credits/BuyCredits.tsx`),
+   today reachable only behind dashboard auth.
+4. Any sign-in or sign-up CTA on public surfaces.
+
+## 1. Inventory
+
+### 1a. Landing page (`/`, `apps/web/app/page.tsx`)
+
+| # | CTA text         | Element            | Destination                          | Captures                      | Notes                                                                                                  |
+| - | ---------------- | ------------------ | ------------------------------------ | ----------------------------- | ------------------------------------------------------------------------------------------------------ |
+| 1 | "Read the spec"  | inline `<a>` link  | `https://github.com/NikolayS/willbuy` | nothing (external nav)        | Only CTA on the page. Sends a prospective buyer OUT of our domain to a GitHub repo that does NOT make a buying case. |
+
+That is the entirety of `/` today. There is no "Buy", "Try", "Start free",
+"Sign in", "See pricing", or "See sample report" CTA on the landing page.
+
+### 1b. Pricing page (`/pricing`)
+
+DOES NOT EXIST. `apps/web/app/pricing/` is not present on `main`. The issue
+(#125) calls for one to be built; that is a separate engineering task and
+is OUT OF SCOPE FOR THIS DOC. Wiring recommendations below are written so
+that whoever lands the pricing page can implement them as a checklist.
+
+### 1c. `BuyCredits` (`apps/web/components/credits/BuyCredits.tsx`)
+
+Reachable only inside the authenticated dashboard. Three CTAs (one per
+pack) plus a confirm button:
+
+| # | CTA text                           | Destination                         | Captures                                       | Notes                                                                          |
+| - | ---------------------------------- | ----------------------------------- | ---------------------------------------------- | ------------------------------------------------------------------------------ |
+| 2 | Pack tile: `starter` $29           | sets local `selected = 'starter'`   | client-side state only                         | Three tiles; clicking sets selection but does NOT initiate Checkout.           |
+| 3 | Pack tile: `growth` $99            | sets local `selected = 'growth'`    | client-side state only                         | Same shape.                                                                    |
+| 4 | Pack tile: `scale` $299            | sets local `selected = 'scale'`     | client-side state only                         | Same shape.                                                                    |
+| 5 | Confirm button ("Buy credits")     | `POST {apiBaseUrl}/checkout/sessions` with `pack_id` in body, then redirects to Stripe Checkout `url` from the response | Account API key (header), `pack_id`, and downstream Stripe Checkout collects card | Wiring is correct for paid conversion. Defaults to `growth` per the component file (re-confirm in code review). |
+
+### 1d. Sign-in (`/sign-in`)
+
+`apps/web/app/sign-in/page.tsx`. Magic-link only per spec §2 #25. No "Sign
+up" surface — the magic-link flow auto-creates an account. Captures: email
+address. Public, indexable.
+
+### 1e. Other public surfaces
+
+- `/r/[slug]` — public report viewer. No buy CTA today. **Recommendation
+  in §3 below**: add a single tasteful "Run a study on your own page →
+  see pricing" CTA on `/r/*` since these pages are share-link traffic
+  from CRO consultants and their clients (highest-intent visitors we have).
+
+## 2. Flagged CTAs (current state)
+
+Against the manager-memory rule:
+
+| Flag | Issue                                                                                                                                                                                                  |
+| ---- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| F1   | Landing page has ZERO buying CTAs. The single CTA sends prospects to GitHub.                                                                                                                           |
+| F2   | No `/pricing` page exists on a public surface. Buyers cannot see the three packs without first creating an account and reaching the dashboard. This is a paid-conversion defect, not a free-signup one. |
+| F3   | Sign-in is the only writable public surface. Because magic-link doubles as signup (no card required), the implicit funnel today is `landing → sign-in → free dashboard → maybe buy`. That is exactly the "start_free funnel before the buyer has seen paid tiers" anti-pattern. |
+| F4   | `/r/*` (the highest-intent public surface — someone is reading a real report) has no path to purchase.                                                                                                  |
+
+There is no CTA literally named `start_free` in the codebase (we don't ship
+a free tier per A7). But the *effective* funnel today behaves like one.
+The fix is to surface the paid tiers BEFORE the magic-link sign-in, and to
+make the sign-in CTA secondary to the buy CTA on the landing page.
+
+## 3. Wiring recommendations (text only)
+
+These are recommendations for the separate web-engineer issue. **Do not
+land them in this PR.**
+
+### 3a. `/` landing page
+
+- Add primary CTA: **"See pricing →"** linking to `/pricing` (anchor link
+  to `#packs` once that page exists).
+- Add secondary CTA: **"See a sample report"** linking to a known-public
+  `/r/<slug>` from the dogfood study (issue #86).
+- Add tertiary CTA: **"Sign in"** linking to `/sign-in`. Tertiary, NOT
+  primary, because we want the buyer to see paid tiers before the free
+  account creation path.
+- Keep a single small "Read the technical spec" link in the footer for
+  the engineer audience; do NOT make it a primary CTA.
+
+### 3b. `/pricing`
+
+- Above-fold: one-line claim, three pack tiles (`starter` / `growth` /
+  `scale` per A7) with USD prices + display-credit counts (per A7
+  amendment, the parenthetical credit counts are display-only labels —
+  do not let them drift from the canonical 1000 / 4000 / 15000 values).
+- Each tile has a buy CTA wired to `POST /api/credits/checkout?pack=<id>`
+  (the route from PR #71). Per the issue body, the route returns a 303
+  redirect to Stripe Checkout — the front-end follows it.
+- ABOVE the buy CTA on each tile: a link to a sample report (`/r/<slug>`)
+  for that price point's likely use case, so the buyer sees value
+  before checkout.
+- BELOW the three tiles: "Sign in" for returning customers (secondary).
+- DO NOT add a "Start free" CTA. We do not have a free tier; surfacing
+  one would mis-set expectations and pull conversion away from paid.
+- DO NOT add a sign-up form on this page. Sign-in / signup happens
+  AFTER Stripe Checkout (the magic-link flow attaches credits to the
+  email address Stripe captures).
+
+### 3c. `BuyCredits` component
+
+No CTA-text changes needed today. Two follow-ups for the web engineer:
+
+- Confirm the default `selected` value is `growth` (the middle tier);
+  per CRO orthodoxy the middle tier is the anchor and we should not
+  default to `starter`.
+- Verify the display-credit count math matches A7 (issue #73 was filed
+  against this; if still open, fold the fix into the pricing-page work).
+
+### 3d. `/r/*` report pages
+
+- Add ONE tasteful CTA in a fixed footer-bar: "Run a study on your own
+  page → see pricing" → `/pricing`. Do NOT autoplay, do NOT modal.
+  The report is the value; the CTA is permission to buy.
+- Do NOT capture any data on `/r/*` beyond what the share-token cookie
+  already does. No tracking pixels, no email-capture popups. The
+  spec's CSP and field-level logging policy (§5.10, §5.12) implicitly
+  forbid most of these anyway.
+
+## 4. What this audit does NOT do
+
+- It does NOT propose pricing-tier changes. A7 stands.
+- It does NOT modify `apps/web/app/page.tsx`, `apps/web/components/credits/BuyCredits.tsx`,
+  or any other application code.
+- It does NOT create `apps/web/app/pricing/page.tsx`. That page is
+  the deliverable for a separate engineering issue, with the wiring
+  recommendations in §3 as input.
+- It does NOT speak to subscriptions vs packs. Packs stand for v0.1
+  (per A7 and §5.6); the AWS-Marketplace-driven question of whether
+  to add a recurring SKU is in `aws-marketplace-scoping.md` §5.
+
+## 5. Cross-references
+
+- `docs/launch/show-hn.md` — "pricing is three credit packs, no
+  subscription, $29 / $99 / $299" must match the live `/pricing` page
+  copy at launch. If pricing changes, the Show HN draft changes too.
+- `docs/launch/aws-marketplace-scoping.md` §1 — keep tier names
+  (`starter` / `growth` / `scale`) consistent across web, Stripe,
+  and any future Marketplace dimension.
+- Spec §1 (positioning), §2 #18 (`next_action` enum), A1 (growth-rubric
+  `next_action` adoption), A7 (pack tier names + amounts).

--- a/docs/launch/show-hn.md
+++ b/docs/launch/show-hn.md
@@ -1,0 +1,86 @@
+# Show HN draft — willbuy.dev
+
+Status: DRAFT, not yet posted. Posting is a manager-action, gated on the v0.2
+launch checklist (issue #125) going green. Word count below excludes the title
+and the first-comment template.
+
+---
+
+## Title
+
+> Show HN: Willbuy.dev – paste a pricing page, get N synthetic visitors who tell you why they didn't buy
+
+(70 chars, no buzzwords, frames the wedge in the title. Alternates kept below.)
+
+Alternates:
+
+- Show HN: A synthetic visitor panel for your pricing page
+- Show HN: Willbuy – paired-A/B for landing pages with LLM visitors
+
+## Body
+
+I burned three months on a pricing page that converted at 0.4% and I never
+figured out why, because I didn't have enough traffic to A/B test it. So I
+built the thing I wanted.
+
+Willbuy.dev is a synthetic visitor panel for conversion pages. You verify your
+domain by DNS TXT, paste one URL (or two for paired A/B), pick a preset ICP
+or write your own, and N independent fresh-context LLM "visitors" each render
+the page and return a structured verdict: first impression, will-to-buy 0–10,
+the questions they couldn't answer, the objections that stopped them, the
+tier they'd pick if they were buying today, and a conversion-weighted next
+action. The output is a shareable report, not a chat transcript.
+
+The wedge is paired A/B. The same sampled backstory visits both variants in
+two independent fresh-context calls — no shared `conversation_id`,
+`session_id`, `thread_id`, or `previous_response_id`; an AST lint enforces
+that across the adapter layer. Pairing is a DB join over results, never a
+cross-call LLM context join. That gets you a within-subjects paired-delta
+(paired-t + Wilcoxon + McNemar with an explicit disagreement banner) instead
+of the noisier between-subjects average that any "throw it at GPT" approach
+would give you.
+
+Pricing is three credit packs, no subscription: $29 / $99 / $299. A typical
+N=30 paired study against two URLs costs about $2. No free tier — credits
+expire, and the per-visit cost is real LLM spend.
+
+Ask: I'd love feedback from anyone who has paid for a CRO audit, anyone who's
+tried to A/B-test on sub-1k-visit/day traffic, and anyone with red-team
+intuition on synthetic-respondent overclaim. Sample report and a 5-page
+benchmark are linked from the landing page.
+
+---
+
+## First-comment template
+
+> Founder here, AMA. Backstory: I ran the postgres.ai pricing page through
+> the same harness I built for Willbuy (under `growth/2026-apr/pricing-page/`
+> in our monorepo if you're curious — paired stratified, N=20 per persona,
+> two personas, fresh context per call). The top blocker every persona
+> surfaced was the same thing I'd been ignoring for a month. That's the
+> shape of the value: it doesn't tell you something a smart friend wouldn't,
+> it just gets it in front of you in 90 seconds for $2 instead of in front
+> of you in three weeks for $4k.
+>
+> Specifically NOT claiming: that these visitors are real humans, that
+> synthetic feedback substitutes for live-traffic A/B testing once you have
+> the traffic, or that we bypass bot detection (we identify as a bot to the
+> target page in v0.1; capture happens in a hardened sandboxed container
+> with default-deny egress and a Unix-socket-only host channel).
+>
+> Stack: Bun + Next.js (App Router) + self-hosted Supabase on Hetzner,
+> Anthropic Haiku for the chat backend with prompt caching on the static
+> system+schema prefix, local fastembed (`BAAI/bge-small-en-v1.5`, CPU ONNX)
+> for embeddings, deterministic HDBSCAN inside a pinned scientific-stack
+> container image. Reports render with Recharts, no PDF export in v0.1.
+>
+> Open questions I'd genuinely like HN's read on:
+> 1. Where's the line between "useful synthetic respondent" and "plausible
+>    slop"? Our ship gate is a 5-page blind benchmark with κ ≥ 0.6 across 3
+>    labelers + a 4th adjudicator + a pre-registered false-positive rubric.
+>    Is that strong enough to publish a top-3-blockers claim?
+> 2. Pricing: credit packs vs. subscription. We picked packs because variance
+>    in per-customer usage is huge. Anyone tried both and have a strong take?
+> 3. Paired-A/B framing — is "within-subjects" obvious to non-stats readers,
+>    or do we need to lead with a plain-English version (same backstory sees
+>    both pages, so we subtract out the persona effect)?


### PR DESCRIPTION
## TLDR

- **`docs/launch/show-hn.md`** — Show HN draft (title + ≤300-word body in 5 paragraphs + first-comment template). Not yet posted.
- **`docs/launch/aws-marketplace-scoping.md`** — One-pager: SaaS Subscriptions (default) vs Contracts decision, required listing fields, four onboarding integration points, gap list, open questions for AWS partner team. Scoping only.
- **`docs/launch/pricing-cta-audit.md`** — Inventory of every CTA on public surfaces, four flags against the paid-conversion goal, text-only wiring recommendations for a separate web-engineer issue.

## First-paragraph excerpts

**Show HN draft:**

> I burned three months on a pricing page that converted at 0.4% and I never figured out why, because I didn't have enough traffic to A/B test it. So I built the thing I wanted.

**AWS Marketplace scoping:**

> Status: SCOPING ONLY. This document does NOT submit a listing, file any AWS forms, or commit us to a launch date. Per issue #125 and SPEC §8 the Marketplace listing is post-v0.2 (target Q3 2026); the goal here is to know what's in front of us before we start. Decision: SaaS Subscriptions (default) — best fit for the indie ICP and our existing credit-pack model; SaaS Contracts revisited post-SOC 2.

**Pricing-page CTA audit:**

> Status: AUDIT only. Per the v0.2 launch checklist (issue #125), CTA wiring is the deliverable for a separate web-engineer issue. This document enumerates the current state, flags every CTA against our paid-conversion goal, and recommends the wiring change in TEXT only — no application code touched. Headline finding: the landing page has ZERO buying CTAs and `/pricing` does not exist on `main` — the implicit funnel today is `landing → sign-in → free dashboard → maybe buy`, which is exactly the "start_free funnel before the buyer has seen paid tiers" anti-pattern.

## Out of scope (intentionally deferred)

- The full v0.2 launch-checklist tracking file (`docs/v0.2-launch-checklist.md`) — separate manager-action issue.
- Building `apps/web/app/pricing/page.tsx` and wiring its CTAs — separate web-engineer issue, with this audit as input.
- The actual Show HN submission and the actual AWS Marketplace listing — manager-action gates.
- Pricing-tier changes — A7 stands; Nik decides.

## Test plan

- [ ] Markdown renders cleanly on GitHub for all three files.
- [ ] No broken intra-repo links (`docs/launch/show-hn.md`, `docs/launch/aws-marketplace-scoping.md`, `docs/launch/pricing-cta-audit.md` cross-reference each other).
- [ ] CI passes (linter only — docs-only PR; no test changes).

Closes #125.

🤖 Generated with [Claude Code](https://claude.com/claude-code)