### PR TITLE
feat(ops): browser-stack patch SLO doc + staging canary script (#124)

### DIFF
--- a/apps/capture-worker/src/canary.ts
+++ b/apps/capture-worker/src/canary.ts
@@ -1,0 +1,79 @@
+// canary.ts — assertion-logic for the weekly browser-stack patch SLO
+// canary (spec §2 #4 + §5.16). The Bash entry-point at
+// scripts/canary/staging-browser-canary.sh drives a real Playwright
+// browser against a known-good fixture URL; this helper turns the
+// resulting CaptureResult into a 0/1 verdict against a small, stable
+// baseline. The assertions here are deliberately structural — substring
+// presence in the a11y tree, status, host_count budget — so a Chromium
+// minor-version bump that re-arranges role nesting still passes. The
+// canary watches for symptom-level regressions (status crash, missing
+// elements, accidental banner-selector hit), not pixel diffs.
+
+import type { CaptureResult, CaptureStatus } from './types.js';
+
+export type CanaryBaseline = {
+  expectedStatus: CaptureStatus;
+  /**
+   * Substrings the JSON-stringified a11y tree must contain. Each entry
+   * is checked with String#includes; missing any one fails the canary
+   * with that phrase named in the reason so the on-call sees what
+   * regressed without grepping logs.
+   */
+  requiredA11yPhrases: string[];
+  /**
+   * Maximum allowed `banner_selectors_matched.length`. The known-good
+   * fixture has no cookie banner; a non-zero match means the curated
+   * selector list (§2 #28) gained a false-positive against a clean DOM.
+   */
+  maxBannerSelectorsMatched: number;
+  /**
+   * Maximum allowed distinct egress hosts (§2 #5 budget is 50; canary
+   * caps tighter — the fixture is local-only, so >5 implies a
+   * regression in the network-namespace egress policy or a Playwright
+   * default that started phoning home).
+   */
+  maxHostCount: number;
+};
+
+export type CanaryVerdict =
+  | { ok: true }
+  | { ok: false; reason: string };
+
+export function compareCanaryToBaseline(
+  actual: CaptureResult,
+  baseline: CanaryBaseline,
+): CanaryVerdict {
+  if (actual.status !== baseline.expectedStatus) {
+    const breach = actual.breach_reason ? ` breach=${actual.breach_reason}` : '';
+    return {
+      ok: false,
+      reason: `status mismatch: expected=${baseline.expectedStatus} actual=${actual.status}${breach}`,
+    };
+  }
+
+  if (actual.banner_selectors_matched.length > baseline.maxBannerSelectorsMatched) {
+    return {
+      ok: false,
+      reason: `banner selectors matched unexpectedly: ${actual.banner_selectors_matched.join(', ')}`,
+    };
+  }
+
+  if (actual.host_count > baseline.maxHostCount) {
+    return {
+      ok: false,
+      reason: `host_count too high: ${actual.host_count} > ${baseline.maxHostCount}`,
+    };
+  }
+
+  const flat = JSON.stringify(actual.a11y_tree);
+  for (const phrase of baseline.requiredA11yPhrases) {
+    if (!flat.includes(phrase)) {
+      return {
+        ok: false,
+        reason: `required a11y phrase missing: ${JSON.stringify(phrase)}`,
+      };
+    }
+  }
+
+  return { ok: true };
+}

--- a/apps/capture-worker/test/canary-smoke.test.ts
+++ b/apps/capture-worker/test/canary-smoke.test.ts
@@ -1,0 +1,109 @@
+// canary-smoke.test.ts — assertion-logic for the browser-stack patch SLO
+// canary (issue #124, spec §2 #4 + §5.16).
+//
+// The canary script (scripts/canary/staging-browser-canary.sh) drives a
+// real Playwright browser against a known-good fixture URL and feeds the
+// resulting CaptureResult into compareCanaryToBaseline. This test
+// exercises the assertion-logic helper with stub fixtures only; it does
+// NOT launch a browser. The browser-launch path is covered by the
+// existing captureGolden / smoke tests.
+
+import { describe, it, expect } from 'vitest';
+import {
+  compareCanaryToBaseline,
+  type CanaryBaseline,
+} from '../src/canary.js';
+import type { CaptureResult } from '../src/types.js';
+
+const BASELINE: CanaryBaseline = {
+  expectedStatus: 'ok',
+  // Substrings the rendered a11y tree (JSON-stringified) must contain.
+  // Same set captureGolden.test.ts asserts, kept short on purpose so a
+  // Chromium minor-version bump that re-arranges role nesting still passes
+  // — the canary watches for symptom-level regressions, not pixel diffs.
+  requiredA11yPhrases: [
+    'Pricing that scales with you',
+    'Postgres logo',
+    'Start free',
+    'Talk to sales',
+  ],
+  maxBannerSelectorsMatched: 0,
+  maxHostCount: 5,
+};
+
+const goldResult: CaptureResult = {
+  status: 'ok',
+  url: 'http://127.0.0.1:3014/r/test-fixture',
+  a11y_tree: [
+    {
+      role: 'RootWebArea',
+      name: 'Simple capture fixture',
+      children: [
+        { role: 'heading', name: 'Pricing that scales with you', level: 1, children: [] },
+        { role: 'image', name: 'Postgres logo', children: [] },
+        { role: 'button', name: 'Start free', children: [] },
+        { role: 'link', name: 'Talk to sales', children: [] },
+      ],
+    },
+  ],
+  banner_selectors_matched: [],
+  host_count: 1,
+};
+
+describe('compareCanaryToBaseline (spec §5.16 weekly canary)', () => {
+  it('returns ok=true when the fixture matches the baseline', () => {
+    const verdict = compareCanaryToBaseline(goldResult, BASELINE);
+    expect(verdict.ok).toBe(true);
+  });
+
+  it('fails when status is not ok (e.g. Chromium crashes)', () => {
+    const broken: CaptureResult = { ...goldResult, status: 'error', breach_reason: 'wall_clock' };
+    const verdict = compareCanaryToBaseline(broken, BASELINE);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.reason).toMatch(/status/);
+    }
+  });
+
+  it('fails when an expected a11y phrase is missing (e.g. accessibility-tree regression)', () => {
+    const stripped: CaptureResult = {
+      ...goldResult,
+      a11y_tree: [
+        {
+          role: 'RootWebArea',
+          name: 'Simple capture fixture',
+          // "Start free" button is gone — exactly the kind of regression a
+          // browser bump might silently introduce by changing role mapping.
+          children: [
+            { role: 'heading', name: 'Pricing that scales with you', level: 1, children: [] },
+            { role: 'image', name: 'Postgres logo', children: [] },
+            { role: 'link', name: 'Talk to sales', children: [] },
+          ],
+        },
+      ],
+    };
+    const verdict = compareCanaryToBaseline(stripped, BASELINE);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.reason).toMatch(/Start free/);
+    }
+  });
+
+  it('fails when host_count exceeds baseline (defence-in-depth budget signal)', () => {
+    const noisy: CaptureResult = { ...goldResult, host_count: 99 };
+    const verdict = compareCanaryToBaseline(noisy, BASELINE);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.reason).toMatch(/host_count/);
+    }
+  });
+
+  it('fails when a banner selector matches unexpectedly (false-positive regression)', () => {
+    const banner: CaptureResult = { ...goldResult, banner_selectors_matched: ['#cookie-banner'] };
+    const verdict = compareCanaryToBaseline(banner, BASELINE);
+    expect(verdict.ok).toBe(false);
+    if (!verdict.ok) {
+      expect(verdict.reason).toMatch(/banner/);
+    }
+  });
+});

--- a/docs/runbooks/browser-patch-slo.md
+++ b/docs/runbooks/browser-patch-slo.md
@@ -1,0 +1,129 @@
+# Browser-stack patch SLO — runbook
+
+**Spec refs:** §2 #4 (browser-stack patch/update SLO), §5.16 (full policy),
+§6.3 (ship-gate drill).
+
+**Issue:** [#124](https://github.com/NikolayS/willbuy/issues/124)
+
+## SLO statement
+
+| Window                                          | Target |
+| ----------------------------------------------- | ------ |
+| Weekly canary check (Tuesdays)                  | Every 7 d |
+| Upstream Playwright/Chromium release → staging  | ≤ 7 d  |
+| Upstream Playwright/Chromium release → prod     | ≤ 14 d |
+| Upstream CVE (CVSS ≥ 7.0) → prod                | ≤ 72 h (per §5.16) |
+| Canary watch window before promoting to 100 %    | 24 h at 5 % capture traffic |
+
+The SLO covers Chromium, Playwright, container runtime, host kernel,
+guest kernel (v0.2 microVM), and Firecracker itself.
+
+## Weekly canary — Tuesday checklist
+
+Owner: Nik. Bring this checklist into the issue thread for the week so
+the run is auditable.
+
+1. **Pull the upstream Playwright base image.**
+   ```sh
+   docker pull mcr.microsoft.com/playwright:v$(node -p "require('./apps/capture-worker/package.json').dependencies.playwright")-jammy
+   ```
+   If a newer `playwright` minor / patch is available on npm, bump
+   `apps/capture-worker/package.json` and `infra/firecracker/rootfs/Dockerfile`
+   in the same PR; otherwise this is just a verification pull.
+
+2. **Rebuild the capture-worker image (and the Firecracker rootfs once
+   #114 is wired) against the pulled base.**
+   The image build is the spec §5.16 "rebuild" step. Image swap requires
+   two approvals on the deploy-manifest PR (branch protection on `main`).
+
+3. **Run the canary smoke against staging.**
+   ```sh
+   WILLBUY_CANARY_BASE_URL=https://staging.willbuy.dev \
+     ./scripts/canary/staging-browser-canary.sh
+   ```
+   Locally, point at the capture-worker's fixture server instead:
+   ```sh
+   # In one shell — start the existing fixture server (used by tests).
+   bun run --filter @willbuy/capture-worker test:integration -- --watch
+   # In another — drive the canary at it.
+   WILLBUY_CANARY_BASE_URL=http://127.0.0.1:3014 \
+     ./scripts/canary/staging-browser-canary.sh
+   ```
+   Exit code `0` is green, `1` is a regression, `2` is harness error
+   (treat as "rerun, then escalate").
+
+4. **If green: tag and push.** Tag the new image as `:canary-YYYY-MM-DD`
+   and the previous prod image as `:rollback` (retain 30 days per
+   §5.16). Open the deploy-manifest bump PR. Two approvals → merge →
+   24 h watch at 5 % traffic → promote to 100 %.
+
+5. **If red: do NOT promote.** Capture the JSON line from the canary's
+   stdout into the issue, follow the rollback procedure below, and
+   open a `fix(capture-worker):` issue with the canary output pasted
+   verbatim. The rollback tag stays as the deployed image until the
+   regression is understood.
+
+6. **Document deltas.** Append a one-line entry to the table at the
+   bottom of this file: date, Playwright version, Chromium version,
+   verdict, image SHA. The first real run on the staging VM is a
+   manager action — this PR establishes the process; the first canary
+   of record happens AFTER merge.
+
+## Rollback procedure
+
+Triggered by canary red, post-promotion regression, or any CVE-driven
+emergency where we need to revert within minutes.
+
+1. **Verify the rollback tag exists.**
+   ```sh
+   docker manifest inspect ghcr.io/nikolays/willbuy-capture:rollback
+   ```
+   If missing — escalate, do NOT proceed; we lost the 30-day retention
+   invariant and must rebuild from the previous git tag instead.
+
+2. **Single-command rollback** (per §5.16):
+   ```sh
+   make rollback-capture-image
+   ```
+   The Makefile target (added when the deploy pipeline lands) updates
+   the staging deploy manifest to point at `:rollback`, requires two
+   approvals to merge into `main` (branch protection), and triggers
+   the rolling restart on `willbuy-v01`.
+
+3. **Confirm.** Re-run the canary against the rolled-back image. It
+   must be green before the on-call hands off.
+
+4. **Post-mortem.** File an issue with the canary stdout, the upstream
+   diff between the green and red Playwright/Chromium versions, and
+   the time-to-detection. Add a regression fixture if the canary
+   missed it (the canary is intentionally narrow; widening is a
+   normal response to an escape).
+
+## Test fixture target
+
+The canary uses the same deterministic fixture the capture-worker's
+golden test uses (`apps/capture-worker/test/fixtures/simple.html`).
+Staging exposes it at `/r/test-fixture` via the capture broker's
+fixture endpoint; locally the capture-worker test fixture server (port
+`3014` by convention) serves it directly. The substring assertions
+("Pricing that scales with you", "Postgres logo", "Start free", "Talk
+to sales") are pinned by `compareCanaryToBaseline` and exercised by
+`apps/capture-worker/test/canary-smoke.test.ts`.
+
+## Out of scope (tracked separately)
+
+- Auto-running the canary on a schedule (cron / GitHub Actions). The
+  weekly cadence is a manual-with-checklist action by Nik for v0.2;
+  cron lands in a follow-up once we have one quarter of clean manual
+  runs.
+- The quarterly emergency-CVE drill (§6.3 ship-gate) — next slot is
+  Q3, separate issue.
+- Cosign key rotation, branch-protection two-approver rule on the
+  deploy-manifest PR — covered by the broader §5.16 issue body and
+  arrive with the deploy pipeline.
+
+## Run log
+
+| Date       | Playwright | Chromium | Verdict | Image SHA | Notes |
+| ---------- | ---------- | -------- | ------- | --------- | ----- |
+| _pending_  | _pending_  | _pending_| _pending_ | _pending_ | first canary of record runs post-merge of #124 |

--- a/scripts/canary/run-canary.ts
+++ b/scripts/canary/run-canary.ts
@@ -1,0 +1,72 @@
+#!/usr/bin/env bun
+// run-canary.ts — Bun-executed canary runner invoked by
+// scripts/canary/staging-browser-canary.sh (issue #124, spec §2 #4 + §5.16).
+//
+// Drives a real Playwright capture against WILLBUY_CANARY_BASE_URL plus
+// the fixture path, runs compareCanaryToBaseline, prints a single-line
+// JSON verdict, and exits 0 (ok) or 1 (fail). Kept thin on purpose —
+// the assertion logic lives in apps/capture-worker/src/canary.ts and is
+// unit-tested without a browser.
+
+import { captureUrl } from '../../apps/capture-worker/src/capture.js';
+import {
+  compareCanaryToBaseline,
+  type CanaryBaseline,
+} from '../../apps/capture-worker/src/canary.js';
+
+const BASE_URL = process.env.WILLBUY_CANARY_BASE_URL ?? 'http://127.0.0.1:3014';
+const FIXTURE_PATH = process.env.WILLBUY_CANARY_FIXTURE_PATH ?? '/r/test-fixture';
+
+// Same baseline the unit test pins. Substring-only on purpose so a
+// Chromium minor bump that re-arranges role nesting still passes — the
+// canary watches for symptom-level regressions, not pixel diffs.
+const BASELINE: CanaryBaseline = {
+  expectedStatus: 'ok',
+  requiredA11yPhrases: [
+    'Pricing that scales with you',
+    'Postgres logo',
+    'Start free',
+    'Talk to sales',
+  ],
+  maxBannerSelectorsMatched: 0,
+  maxHostCount: 5,
+};
+
+async function main(): Promise<number> {
+  const target = `${BASE_URL.replace(/\/$/, '')}${FIXTURE_PATH}`;
+  const startedAt = new Date().toISOString();
+  let result;
+  try {
+    result = await captureUrl(target);
+  } catch (err) {
+    const reason = err instanceof Error ? err.message : String(err);
+    process.stdout.write(
+      JSON.stringify({ ok: false, reason: `capture threw: ${reason}`, target, started_at: startedAt }) + '\n',
+    );
+    return 1;
+  }
+
+  const verdict = compareCanaryToBaseline(result, BASELINE);
+  const finishedAt = new Date().toISOString();
+  process.stdout.write(
+    JSON.stringify({
+      ok: verdict.ok,
+      reason: verdict.ok ? null : verdict.reason,
+      target,
+      status: result.status,
+      host_count: result.host_count,
+      banner_selectors_matched: result.banner_selectors_matched,
+      started_at: startedAt,
+      finished_at: finishedAt,
+    }) + '\n',
+  );
+  return verdict.ok ? 0 : 1;
+}
+
+main().then(
+  (code) => process.exit(code),
+  (err) => {
+    process.stderr.write(`run-canary: unexpected error: ${err instanceof Error ? err.stack : String(err)}\n`);
+    process.exit(2);
+  },
+);

--- a/scripts/canary/staging-browser-canary.sh
+++ b/scripts/canary/staging-browser-canary.sh
@@ -1,0 +1,99 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+IFS=$'\n\t'
+
+# scripts/canary/staging-browser-canary.sh — weekly browser-stack patch
+# SLO canary (issue #124, spec §2 #4 + §5.16).
+#
+# Runs a single Playwright capture against the known-good local fixture
+# (or any fixture endpoint exposed by the staging environment), feeds
+# the result through compareCanaryToBaseline (apps/capture-worker/src/
+# canary.ts), and exits 0 on green / 1 on regression / 2 on harness
+# error. Idempotent — invoking it twice in a row produces the same
+# verdict (the only state it touches is stdout).
+#
+# Local run:
+#   WILLBUY_CANARY_BASE_URL=http://127.0.0.1:3014 \
+#     ./scripts/canary/staging-browser-canary.sh
+#
+# Dry run (skip the actual browser launch — useful in CI smoke tests
+# and for verifying the script itself parses):
+#   ./scripts/canary/staging-browser-canary.sh --dry-run
+#
+# Env vars:
+#   WILLBUY_CANARY_BASE_URL    base URL hosting the fixture (required)
+#   WILLBUY_CANARY_FIXTURE_PATH  fixture path (default /r/test-fixture)
+#   WILLBUY_CANARY_TIMEOUT_S   bash-side hard timeout (default 120s)
+#
+# Exit codes:
+#   0  canary green; promote allowed
+#   1  canary red; rollback per docs/runbooks/browser-patch-slo.md §Rollback
+#   2  harness error (network, missing deps, misconfig); not a verdict
+
+dry_run="false"
+for arg in "$@"; do
+  case "${arg}" in
+    --dry-run) dry_run="true" ;;
+    -h|--help)
+      sed -n '7,32p' "${BASH_SOURCE[0]}" | sed 's/^# //;s/^#$//'
+      exit 0
+      ;;
+    *)
+      echo "unknown argument: ${arg}" >&2
+      exit 2
+      ;;
+  esac
+done
+
+base_url="${WILLBUY_CANARY_BASE_URL:-}"
+fixture_path="${WILLBUY_CANARY_FIXTURE_PATH:-/r/test-fixture}"
+timeout_s="${WILLBUY_CANARY_TIMEOUT_S:-120}"
+
+if [[ "${dry_run}" == "true" ]]; then
+  cat <<EOF
+{"ok":true,"reason":null,"target":"${base_url:-<unset>}${fixture_path}","dry_run":true}
+EOF
+  exit 0
+fi
+
+if [[ -z "${base_url}" ]]; then
+  echo "WILLBUY_CANARY_BASE_URL is required (set to the staging fixture origin, e.g. http://127.0.0.1:3014)" >&2
+  exit 2
+fi
+
+if ! command -v bun >/dev/null 2>&1; then
+  echo "bun not found on PATH — install via https://bun.sh" >&2
+  exit 2
+fi
+
+here="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+runner="${here}/run-canary.ts"
+
+if [[ ! -f "${runner}" ]]; then
+  echo "runner not found: ${runner}" >&2
+  exit 2
+fi
+
+# `timeout` isn't on macOS by default; fall back to a backgrounded kill
+# pattern when absent, since the canary owner (Nik) sometimes runs this
+# locally on a Mac before pushing to staging.
+run_with_timeout() {
+  if command -v timeout >/dev/null 2>&1; then
+    timeout "${timeout_s}" "$@"
+  elif command -v gtimeout >/dev/null 2>&1; then
+    gtimeout "${timeout_s}" "$@"
+  else
+    "$@" &
+    local pid=$!
+    ( sleep "${timeout_s}" && kill -TERM "${pid}" 2>/dev/null || true ) &
+    local watcher=$!
+    wait "${pid}"
+    local rc=$?
+    kill -TERM "${watcher}" 2>/dev/null || true
+    return "${rc}"
+  fi
+}
+
+WILLBUY_CANARY_BASE_URL="${base_url}" \
+WILLBUY_CANARY_FIXTURE_PATH="${fixture_path}" \
+  run_with_timeout bun "${runner}"


### PR DESCRIPTION
## Summary

Establishes the weekly browser-stack patch SLO process from spec §2 #4
+ §5.16 by landing the runbook, the canary entry-point script, and the
assertion-logic helper it drives. The PR does **not** execute the first
canary on the actual staging VM — that's a manager action that follows
the doc, called out below.

- `docs/runbooks/browser-patch-slo.md` — single-page SLO (≤7 d to
  staging, ≤14 d to prod, 72 h CVE), Tuesday checklist, rollback
  procedure, fixture target, out-of-scope list, and a run-log table.
- `scripts/canary/staging-browser-canary.sh` — Bash entry-point with
  `--dry-run` / `--help`; idempotent; exits 0/1/2 (green / regression
  / harness error); reads `WILLBUY_CANARY_BASE_URL`,
  `WILLBUY_CANARY_FIXTURE_PATH`, `WILLBUY_CANARY_TIMEOUT_S`. Falls back
  to a pure-bash watchdog when GNU `timeout` is absent (macOS).
- `scripts/canary/run-canary.ts` — thin Bun runner the bash invokes.
- `apps/capture-worker/src/canary.ts` — `compareCanaryToBaseline()`,
  pure assertion logic. Substring-only baseline (status / a11y phrases
  / banner-selector cap / host_count cap) so a Chromium minor-version
  bump that re-arranges role nesting still passes.
- `apps/capture-worker/test/canary-smoke.test.ts` — 5 cases, no real
  browser launch; covers green path + each named failure mode.

## Spec / scope notes

- Implements spec §2 #4 + §5.16. Doc landed at
  `docs/runbooks/browser-patch-slo.md` per the issue body (not
  `docs/ops/`); the repo's existing `docs/observability.md` shows
  flat layout, so we created the `runbooks/` subdir for this and
  future ops runbooks.
- **Out of scope here** (each is a separate ops follow-on referenced
  in the runbook):
  - CI cron / scheduled GitHub Actions to run the canary unattended.
  - Cosign signing key rotation; deploy-manifest two-approver
    branch-protection rule.
  - Quarterly emergency-CVE drill (§6.3) — next slot is Q3.
- **First canary of record is a manager action.** This PR establishes
  the process; the first actual canary run on the staging VM is
  performed by Nik per the Tuesday checklist after merge, and the
  result is appended to the run-log table at the bottom of the
  runbook in a follow-up commit.

## TDD

- RED: `e2b1b01 test(capture-worker): RED — canary baseline-comparison helper`
  → fails with `Failed to load url ../src/canary.js` (helper does not exist).
- GREEN: `7bab5dc feat(ops): browser-stack patch SLO doc + staging canary script`
  → 5/5 canary tests pass; full capture-worker suite 24/24 pass.

## Manual test evidence

Dry-run path (no browser):

```
$ ./scripts/canary/staging-browser-canary.sh --dry-run
{"ok":true,"reason":null,"target":"<unset>/r/test-fixture","dry_run":true}
exit=0
```

Real path against a local fixture server serving
`apps/capture-worker/test/fixtures/simple.html` at `/r/test-fixture`:

```
$ WILLBUY_CANARY_BASE_URL=http://127.0.0.1:3014 ./scripts/canary/staging-browser-canary.sh
{"ok":true,"reason":null,"target":"http://127.0.0.1:3014/r/test-fixture","status":"ok","host_count":1,"banner_selectors_matched":[],"started_at":"2026-04-26T03:29:09.171Z","finished_at":"2026-04-26T03:29:12.728Z"}
exit=0
```

Unit tests (workspace-scoped, 2-thread cap per CLAUDE.md guidance):

```
$ ./node_modules/.bin/vitest run test/canary-smoke.test.ts --maxWorkers=2 --minWorkers=1
 Test Files  1 passed (1)
      Tests  5 passed (5)
```

Full capture-worker suite (excluding live `smoke.test.ts` and
`integration.test.ts`):

```
 Test Files  8 passed (8)
      Tests  24 passed (24)
```

## Public-repo audit

No secrets / IPs / VM identifiers in the diff; baseline phrases come
from the existing public test fixture; helper is structural, not
visual.

Closes #124