### PR TITLE
feat(observability): /metrics endpoint with bounded-cardinality business + system counters (#119)

### DIFF
--- a/apps/api/src/env.ts
+++ b/apps/api/src/env.ts
@@ -57,6 +57,13 @@ export const EnvSchema = z.object({
     .string()
     .min(32, 'SHARE_TOKEN_HMAC_KEY must be at least 32 chars (spec §5.12)')
     .default('dev-only-share-token-hmac-key-not-for-production-use'),
+  // Bearer token gating the /metrics endpoint (issue #119, spec §5.14).
+  // When unset, /metrics is locked down (returns 401 for every request) — we
+  // never silently expose metrics to unauthenticated callers. Production
+  // sources this via 1Password:
+  //   op://willbuy/metrics-bearer-token/credential
+  // Generate: openssl rand -hex 32
+  WILLBUY_METRICS_TOKEN: z.string().min(16).optional(),
 });
 
 export type Env = z.infer<typeof EnvSchema>;

--- a/apps/api/src/metrics/registry.ts
+++ b/apps/api/src/metrics/registry.ts
@@ -1,0 +1,24 @@
+/**
+ * metrics/registry.ts — RED stub for issue #119.
+ *
+ * GREEN commit replaces this with a real Prometheus exposition registry.
+ * For the RED commit, the symbols exist (so the test file type-checks) but
+ * the implementation is intentionally empty/stub so tests fail.
+ */
+
+export interface RecordStudyStartedArgs {
+  kind: 'single' | 'paired';
+}
+
+export function recordStudyStarted(_args: RecordStudyStartedArgs): void {
+  // RED stub — replaced in GREEN.
+}
+
+export function resetMetricsForTesting(): void {
+  // RED stub — replaced in GREEN.
+}
+
+export function renderExposition(): string {
+  // RED stub — empty exposition, will not satisfy the tests' regex assertions.
+  return '';
+}

--- a/apps/api/src/metrics/registry.ts
+++ b/apps/api/src/metrics/registry.ts
@@ -1,24 +1,430 @@
 /**
- * metrics/registry.ts — RED stub for issue #119.
+ * metrics/registry.ts — zero-dep Prometheus exposition registry (issue #119).
  *
- * GREEN commit replaces this with a real Prometheus exposition registry.
- * For the RED commit, the symbols exist (so the test file type-checks) but
- * the implementation is intentionally empty/stub so tests fail.
+ * Spec refs:
+ *   §5.12  — observability metrics emission policy.
+ *   §5.14  — global backpressure metrics (this v0.2 slice scopes to the
+ *            apps/api business + system signals listed below; the worker-
+ *            side counters from §5.14 are wired in follow-up issues).
+ *
+ * Design notes:
+ *   - We deliberately avoid `prom-client` to keep the dep surface flat and
+ *     Bun-friendly (issue #117 / amendment A3 cutover). The exposition
+ *     format is small and stable; a hand-rolled serializer is cheaper than
+ *     pulling a 200kB transitive tree for v0.2.
+ *   - All metrics live in a single module-level registry. Tests reset state
+ *     via {@link resetMetricsForTesting}.
+ *   - Label cardinality is bounded by enum-typed call sites; route labels
+ *     come from the Fastify route template (never from raw URLs).
+ *
+ * Exposition format reference (Prometheus 0.0.4):
+ *   https://prometheus.io/docs/instrumenting/exposition_formats/
  */
+
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+// ---------------------------------------------------------------------------
+// Content type
+// ---------------------------------------------------------------------------
+
+export const PROMETHEUS_CONTENT_TYPE = 'text/plain; version=0.0.4; charset=utf-8';
+
+// ---------------------------------------------------------------------------
+// Internal helpers — label encoding
+// ---------------------------------------------------------------------------
+
+function escapeLabelValue(v: string): string {
+  // §0.0.4 spec: backslash, double-quote, and newline must be escaped.
+  return v.replace(/\\/g, '\\\\').replace(/"/g, '\\"').replace(/\n/g, '\\n');
+}
+
+function renderLabels(labels: Record<string, string>): string {
+  const keys = Object.keys(labels).sort();
+  if (keys.length === 0) return '';
+  const parts = keys.map((k) => `${k}="${escapeLabelValue(labels[k]!)}"`);
+  return `{${parts.join(',')}}`;
+}
+
+function labelsKey(labels: Record<string, string>): string {
+  // Stable serialized key for map lookup — sorted for determinism.
+  const keys = Object.keys(labels).sort();
+  return keys.map((k) => `${k}=${labels[k]}`).join('|');
+}
+
+// ---------------------------------------------------------------------------
+// Counter
+// ---------------------------------------------------------------------------
+
+interface CounterDef {
+  name: string;
+  help: string;
+  labelNames: readonly string[];
+  values: Map<string, { labels: Record<string, string>; value: number }>;
+}
+
+function makeCounter(name: string, help: string, labelNames: readonly string[]): CounterDef {
+  return { name, help, labelNames, values: new Map() };
+}
+
+function incCounter(c: CounterDef, labels: Record<string, string>, by = 1): void {
+  // Validate labelset matches definition.
+  for (const k of c.labelNames) {
+    if (!(k in labels)) throw new Error(`metric ${c.name}: missing label ${k}`);
+  }
+  for (const k of Object.keys(labels)) {
+    if (!c.labelNames.includes(k)) throw new Error(`metric ${c.name}: unexpected label ${k}`);
+  }
+  const key = labelsKey(labels);
+  const entry = c.values.get(key);
+  if (entry) {
+    entry.value += by;
+  } else {
+    c.values.set(key, { labels: { ...labels }, value: by });
+  }
+}
+
+function renderCounter(c: CounterDef): string {
+  const lines: string[] = [];
+  lines.push(`# HELP ${c.name} ${c.help}`);
+  lines.push(`# TYPE ${c.name} counter`);
+  if (c.values.size === 0 && c.labelNames.length === 0) {
+    lines.push(`${c.name} 0`);
+  } else if (c.values.size === 0) {
+    // Counters with required labels still need their HELP/TYPE lines emitted
+    // (so Prometheus knows the metric exists) — but no value lines until the
+    // first observation.
+  } else {
+    for (const v of c.values.values()) {
+      lines.push(`${c.name}${renderLabels(v.labels)} ${v.value}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Gauge
+// ---------------------------------------------------------------------------
+
+interface GaugeDef {
+  name: string;
+  help: string;
+  labelNames: readonly string[];
+  values: Map<string, { labels: Record<string, string>; value: number }>;
+  /** Optional: invoked at scrape time so the gauge reports a live value. */
+  collect?: (() => void) | undefined;
+}
+
+function makeGauge(
+  name: string,
+  help: string,
+  labelNames: readonly string[],
+  collect?: () => void,
+): GaugeDef {
+  return { name, help, labelNames, values: new Map(), collect };
+}
+
+function setGauge(g: GaugeDef, labels: Record<string, string>, value: number): void {
+  for (const k of g.labelNames) {
+    if (!(k in labels)) throw new Error(`metric ${g.name}: missing label ${k}`);
+  }
+  for (const k of Object.keys(labels)) {
+    if (!g.labelNames.includes(k)) throw new Error(`metric ${g.name}: unexpected label ${k}`);
+  }
+  const key = labelsKey(labels);
+  g.values.set(key, { labels: { ...labels }, value });
+}
+
+function renderGauge(g: GaugeDef): string {
+  if (g.collect) g.collect();
+  const lines: string[] = [];
+  lines.push(`# HELP ${g.name} ${g.help}`);
+  lines.push(`# TYPE ${g.name} gauge`);
+  if (g.values.size === 0 && g.labelNames.length === 0) {
+    lines.push(`${g.name} 0`);
+  } else {
+    for (const v of g.values.values()) {
+      lines.push(`${g.name}${renderLabels(v.labels)} ${v.value}`);
+    }
+  }
+  return lines.join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Histogram
+// ---------------------------------------------------------------------------
+
+interface HistogramSeries {
+  labels: Record<string, string>;
+  buckets: number[]; // running counts per bucket index (cumulative is computed at render)
+  sum: number;
+  count: number;
+}
+
+interface HistogramDef {
+  name: string;
+  help: string;
+  labelNames: readonly string[];
+  bucketBounds: readonly number[]; // ascending; +Inf is implicit
+  values: Map<string, HistogramSeries>;
+}
+
+function makeHistogram(
+  name: string,
+  help: string,
+  labelNames: readonly string[],
+  bucketBounds: readonly number[],
+): HistogramDef {
+  return { name, help, labelNames, bucketBounds, values: new Map() };
+}
+
+function observeHistogram(h: HistogramDef, labels: Record<string, string>, value: number): void {
+  for (const k of h.labelNames) {
+    if (!(k in labels)) throw new Error(`metric ${h.name}: missing label ${k}`);
+  }
+  for (const k of Object.keys(labels)) {
+    if (!h.labelNames.includes(k)) throw new Error(`metric ${h.name}: unexpected label ${k}`);
+  }
+  const key = labelsKey(labels);
+  let s = h.values.get(key);
+  if (!s) {
+    s = {
+      labels: { ...labels },
+      buckets: new Array(h.bucketBounds.length).fill(0),
+      sum: 0,
+      count: 0,
+    };
+    h.values.set(key, s);
+  }
+  s.sum += value;
+  s.count += 1;
+  for (let i = 0; i < h.bucketBounds.length; i++) {
+    if (value <= h.bucketBounds[i]!) s.buckets[i] = (s.buckets[i] ?? 0) + 1;
+  }
+}
+
+function renderHistogram(h: HistogramDef): string {
+  const lines: string[] = [];
+  lines.push(`# HELP ${h.name} ${h.help}`);
+  lines.push(`# TYPE ${h.name} histogram`);
+  for (const s of h.values.values()) {
+    for (let i = 0; i < h.bucketBounds.length; i++) {
+      const le = h.bucketBounds[i]!;
+      const labels = { ...s.labels, le: formatNumber(le) };
+      lines.push(`${h.name}_bucket${renderLabels(labels)} ${s.buckets[i]}`);
+    }
+    // +Inf bucket
+    lines.push(`${h.name}_bucket${renderLabels({ ...s.labels, le: '+Inf' })} ${s.count}`);
+    lines.push(`${h.name}_sum${renderLabels(s.labels)} ${formatNumber(s.sum)}`);
+    lines.push(`${h.name}_count${renderLabels(s.labels)} ${s.count}`);
+  }
+  return lines.join('\n');
+}
+
+function formatNumber(n: number): string {
+  if (!isFinite(n)) return n > 0 ? '+Inf' : '-Inf';
+  // Prometheus prefers Go-style formatting; toString is fine for non-fractional
+  // ints, and for floats with reasonable precision.
+  if (Number.isInteger(n)) return String(n);
+  return n.toFixed(6).replace(/0+$/, '').replace(/\.$/, '');
+}
+
+// ---------------------------------------------------------------------------
+// Registry — module-level singletons
+// ---------------------------------------------------------------------------
+
+// Histogram buckets tuned for HTTP request durations on a Fastify API:
+// most requests are sub-100ms; outliers (LLM-touching POST routes) reach
+// ~30s; the 30s bucket covers the willbuy worst-case capture timeout.
+const HTTP_DURATION_BUCKETS = [
+  0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30,
+] as const;
+
+const studiesStartedTotal = makeCounter(
+  'willbuy_studies_started_total',
+  'Total number of studies created (POST /studies). `kind` ∈ {single,paired} per §2 #12.',
+  ['kind'] as const,
+);
+
+const studiesCompletedTotal = makeCounter(
+  'willbuy_studies_completed_total',
+  'Total studies that reached a terminal state. `outcome` ∈ {ok,partial,failed}.',
+  ['kind', 'outcome'] as const,
+);
+
+const visitsTotal = makeCounter(
+  'willbuy_visits_total',
+  'Total visit-job transitions observed by the API. `persona_pool` is the ICP archetype set per §2 #9.',
+  ['persona_pool'] as const,
+);
+
+const creditsConsumedTotal = makeCounter(
+  'willbuy_credits_consumed_total',
+  'Total credit-ledger debits in cents grouped by study kind (§5.4).',
+  ['kind'] as const,
+);
+
+const activeStudies = makeGauge(
+  'willbuy_active_studies',
+  'Number of studies whose status is in {pending,capturing,visiting,aggregating}. Set by the route handler at scrape time when a probe is registered.',
+  [] as const,
+);
+
+const httpRequestDurationSeconds = makeHistogram(
+  'willbuy_http_request_duration_seconds',
+  'Fastify HTTP request duration in seconds. `route` is the parameterized template; "__unmatched__" for 404 paths with no matching route (bounded cardinality, issue #119).',
+  ['route', 'method', 'status'] as const,
+  HTTP_DURATION_BUCKETS,
+);
+
+const processStartUnixTime = makeGauge(
+  'willbuy_process_start_time_seconds',
+  'Process start time in unix seconds (UTC). Compute uptime as `time() - willbuy_process_start_time_seconds`.',
+  [] as const,
+);
+
+const buildInfo = makeGauge(
+  'willbuy_build_info',
+  'Build info (always 1). The `version` label carries the apps/api package.json version.',
+  ['version'] as const,
+);
+
+// Resolve apps/api/package.json once at module load.
+function resolvePkgVersion(): string {
+  try {
+    const here = dirname(fileURLToPath(import.meta.url));
+    // dist/metrics/registry.js (built) or src/metrics/registry.ts — both are
+    // 2 levels below apps/api.
+    const pkgPath = resolve(here, '..', '..', 'package.json');
+    const pkg = JSON.parse(readFileSync(pkgPath, 'utf8')) as { version: string };
+    return pkg.version || '0.0.0';
+  } catch {
+    return '0.0.0';
+  }
+}
+
+// Initialize self-describing gauges once. Reset by resetMetricsForTesting().
+function initSelfDescribingMetrics(): void {
+  setGauge(processStartUnixTime, {}, Math.floor(Date.now() / 1000));
+  setGauge(buildInfo, { version: resolvePkgVersion() }, 1);
+}
+initSelfDescribingMetrics();
+
+// ---------------------------------------------------------------------------
+// Public API — recording helpers
+// ---------------------------------------------------------------------------
 
 export interface RecordStudyStartedArgs {
   kind: 'single' | 'paired';
 }
 
-export function recordStudyStarted(_args: RecordStudyStartedArgs): void {
-  // RED stub — replaced in GREEN.
+export function recordStudyStarted(args: RecordStudyStartedArgs): void {
+  incCounter(studiesStartedTotal, { kind: args.kind });
 }
 
-export function resetMetricsForTesting(): void {
-  // RED stub — replaced in GREEN.
+export interface RecordStudyCompletedArgs {
+  kind: 'single' | 'paired';
+  outcome: 'ok' | 'partial' | 'failed';
 }
+
+export function recordStudyCompleted(args: RecordStudyCompletedArgs): void {
+  incCounter(studiesCompletedTotal, { kind: args.kind, outcome: args.outcome });
+}
+
+export interface RecordVisitArgs {
+  /**
+   * Bounded ICP-pool identifier. For preset ICPs this is the preset_id (§2 #9
+   * — 5 enum values); for inline / custom ICPs use the literal string
+   * "custom" so cardinality stays bounded. Callers must NOT pass user-supplied
+   * free-text here.
+   */
+  persona_pool: string;
+}
+
+export function recordVisit(args: RecordVisitArgs): void {
+  incCounter(visitsTotal, { persona_pool: args.persona_pool });
+}
+
+export interface RecordCreditsConsumedArgs {
+  kind: 'single' | 'paired';
+  cents: number;
+}
+
+export function recordCreditsConsumed(args: RecordCreditsConsumedArgs): void {
+  incCounter(creditsConsumedTotal, { kind: args.kind }, args.cents);
+}
+
+export function setActiveStudies(n: number): void {
+  setGauge(activeStudies, {}, n);
+}
+
+export interface RecordHttpRequestArgs {
+  route: string;
+  method: string;
+  status: number;
+  durationSeconds: number;
+}
+
+export function recordHttpRequest(args: RecordHttpRequestArgs): void {
+  observeHistogram(
+    httpRequestDurationSeconds,
+    { route: args.route, method: args.method, status: String(args.status) },
+    args.durationSeconds,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Bearer auth — constant-time compare
+// ---------------------------------------------------------------------------
+
+/**
+ * Constant-time comparison of two strings. Returns false immediately for
+ * different lengths (length itself is not a side channel here — the caller's
+ * bearer token has a known minimum length, and the comparison result is the
+ * only signal we need to keep secret).
+ */
+export function constantTimeEquals(a: string, b: string): boolean {
+  if (a.length !== b.length) return false;
+  let mismatch = 0;
+  for (let i = 0; i < a.length; i++) {
+    mismatch |= a.charCodeAt(i) ^ b.charCodeAt(i);
+  }
+  return mismatch === 0;
+}
+
+// ---------------------------------------------------------------------------
+// Exposition rendering
+// ---------------------------------------------------------------------------
 
 export function renderExposition(): string {
-  // RED stub — empty exposition, will not satisfy the tests' regex assertions.
-  return '';
+  const sections = [
+    renderCounter(studiesStartedTotal),
+    renderCounter(studiesCompletedTotal),
+    renderCounter(visitsTotal),
+    renderCounter(creditsConsumedTotal),
+    renderGauge(activeStudies),
+    renderHistogram(httpRequestDurationSeconds),
+    renderGauge(processStartUnixTime),
+    renderGauge(buildInfo),
+  ];
+  // Trailing newline per §0.0.4 — many scrapers tolerate either, but the
+  // specification requires LF-terminated.
+  return sections.join('\n') + '\n';
+}
+
+// ---------------------------------------------------------------------------
+// Test reset
+// ---------------------------------------------------------------------------
+
+export function resetMetricsForTesting(): void {
+  studiesStartedTotal.values.clear();
+  studiesCompletedTotal.values.clear();
+  visitsTotal.values.clear();
+  creditsConsumedTotal.values.clear();
+  activeStudies.values.clear();
+  httpRequestDurationSeconds.values.clear();
+  processStartUnixTime.values.clear();
+  buildInfo.values.clear();
+  initSelfDescribingMetrics();
 }

--- a/apps/api/src/routes/metrics.ts
+++ b/apps/api/src/routes/metrics.ts
@@ -1,0 +1,104 @@
+/**
+ * routes/metrics.ts — GET /metrics (issue #119, spec §5.14).
+ *
+ * Auth: required Authorization: Bearer <WILLBUY_METRICS_TOKEN>. Constant-time
+ * compare. If WILLBUY_METRICS_TOKEN is unset, the endpoint is locked down —
+ * every request returns 401. We never silently expose metrics.
+ *
+ * The HTTP request-duration histogram is wired via Fastify's onResponse hook
+ * (registered alongside the route). The `route` label is the parameterized
+ * template (e.g. "/r/:slug"); for unmatched 404 paths we emit
+ * `route="__unmatched__"` so cardinality stays bounded regardless of the
+ * volume of unknown URLs hitting the API.
+ */
+
+import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
+
+import {
+  PROMETHEUS_CONTENT_TYPE,
+  constantTimeEquals,
+  recordHttpRequest,
+  renderExposition,
+} from '../metrics/registry.js';
+
+interface StartTime {
+  startNs: bigint;
+}
+
+declare module 'fastify' {
+  interface FastifyRequest {
+    _willbuyMetricsStart?: StartTime;
+  }
+}
+
+/**
+ * Resolve the bounded route label for a Fastify request. Prefers the
+ * route template captured by Fastify; falls back to "__unmatched__" for
+ * unmatched paths so 404s don't blow up label cardinality.
+ */
+function resolveRouteLabel(req: FastifyRequest): string {
+  // Fastify v5 exposes `req.routeOptions.url` on matched routes; falls back to
+  // request.url for unmatched. We never label by raw URL (issue #119
+  // bounded-cardinality requirement).
+  const routeOptions = (req as unknown as { routeOptions?: { url?: string } }).routeOptions;
+  if (routeOptions && typeof routeOptions.url === 'string' && routeOptions.url.length > 0) {
+    return routeOptions.url;
+  }
+  // Fastify v4 compat (older field name).
+  const routerPath = (req as unknown as { routerPath?: string }).routerPath;
+  if (typeof routerPath === 'string' && routerPath.length > 0) {
+    return routerPath;
+  }
+  return '__unmatched__';
+}
+
+export async function registerMetricsRoute(
+  app: FastifyInstance,
+  metricsToken: string | undefined,
+): Promise<void> {
+  // Capture per-request start time for the duration histogram. onRequest fires
+  // before route handling; onResponse fires after the reply has been sent.
+  app.addHook('onRequest', async (req) => {
+    req._willbuyMetricsStart = { startNs: process.hrtime.bigint() };
+  });
+
+  app.addHook('onResponse', async (req, reply) => {
+    if (!req._willbuyMetricsStart) return;
+    // Don't double-count /metrics itself — the scrape would dominate the
+    // histogram on quiet hosts and obscure real traffic.
+    const routeLabel = resolveRouteLabel(req);
+    if (routeLabel === '/metrics') return;
+
+    const durationNs = process.hrtime.bigint() - req._willbuyMetricsStart.startNs;
+    const durationSeconds = Number(durationNs) / 1e9;
+    recordHttpRequest({
+      route: routeLabel,
+      method: req.method,
+      status: reply.statusCode,
+      durationSeconds,
+    });
+  });
+
+  app.get('/metrics', async (req: FastifyRequest, reply: FastifyReply) => {
+    // Locked when token is unset — never leak metrics on misconfigured boxes.
+    if (!metricsToken) {
+      return reply.code(401).header('content-type', 'text/plain').send('unauthorized\n');
+    }
+
+    const auth = req.headers['authorization'];
+    if (typeof auth !== 'string' || !auth.startsWith('Bearer ')) {
+      return reply.code(401).header('content-type', 'text/plain').send('unauthorized\n');
+    }
+    const presented = auth.slice('Bearer '.length);
+    if (!constantTimeEquals(presented, metricsToken)) {
+      return reply.code(401).header('content-type', 'text/plain').send('unauthorized\n');
+    }
+
+    const body = renderExposition();
+    return reply
+      .code(200)
+      .header('content-type', PROMETHEUS_CONTENT_TYPE)
+      .header('cache-control', 'no-store')
+      .send(body);
+  });
+}

--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -35,6 +35,7 @@ import type { Pool } from 'pg';
 import { buildApiKeyMiddleware } from '../auth/api-key.js';
 import { buildSessionMiddleware } from '../auth/session.js';
 import type { Env } from '../env.js';
+import { recordStudyStarted } from '../metrics/registry.js';
 
 // Per-visit estimated cost ceiling = 5¢ per spec §5.5 (cost-model ceiling).
 // §5.7 (Algorithms) describes the broader cost-model overview.
@@ -196,6 +197,10 @@ export async function registerStudiesRoutes(
         }
 
         await client.query('COMMIT');
+
+        // Issue #119 / spec §5.14: business-counter increment AFTER commit so
+        // we don't inflate the count for rolled-back transactions.
+        recordStudyStarted({ kind });
 
         return reply.code(201).send({ study_id: Number(studyId), status: 'capturing' });
       } catch (err) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -19,6 +19,7 @@ import { registerDomainsRoutes } from './routes/domains.js';
 import { registerStripeWebhookRoute } from './routes/stripe-webhook.js';
 import { registerDashboardRoutes } from './routes/dashboard.js';
 import { registerApiKeyRoutes } from './routes/api-keys.js';
+import { registerMetricsRoute } from './routes/metrics.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 // dist/ when built, src/ when run via tsx — both are one level below apps/api.
@@ -70,6 +71,10 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
   });
 
   await app.register(sensible);
+
+  // Wire /metrics + onRequest/onResponse hooks FIRST so the request-duration
+  // histogram captures every subsequent route (issue #119, spec §5.14).
+  await registerMetricsRoute(app, env.WILLBUY_METRICS_TOKEN);
 
   // Postgres connection pool — shared across all routes.
   const pool = new Pool({ connectionString: env.DATABASE_URL });

--- a/apps/api/test/metrics.test.ts
+++ b/apps/api/test/metrics.test.ts
@@ -185,14 +185,15 @@ describe('willbuy_http_request_duration_seconds histogram (issue #119 acceptance
   });
 
   it('uses the parameterized route template (not the literal URL) in the route label', async () => {
-    // Hit a parameterized route. /r/:slug exists in routes/reports.ts; an
-    // unknown slug returns 404 but the route template is still :slug.
+    // Hit a parameterized route. /reports/:slug exists in routes/reports.ts;
+    // an unknown slug returns 404 but the route template is still :slug.
     // Use a literal slug that would NEVER appear as a real registered path.
     const literalSlug = 'metrics-route-label-fixture-abc';
-    const r = await app.inject({ method: 'GET', url: `/r/${literalSlug}` });
+    const r = await app.inject({ method: 'GET', url: `/reports/${literalSlug}` });
     // Status doesn't matter for this assertion — we care about the route
-    // label being captured against the template.
-    expect([200, 302, 404]).toContain(r.statusCode);
+    // label being captured against the template. (500 is OK too: the report
+    // route touches Postgres, which is unavailable in this hermetic suite.)
+    expect([200, 302, 404, 500]).toContain(r.statusCode);
 
     const body = await scrapeMetrics();
 
@@ -202,10 +203,9 @@ describe('willbuy_http_request_duration_seconds histogram (issue #119 acceptance
       expect(route).not.toContain(literalSlug);
     }
 
-    // At least one route label must be the template form.
-    const hasTemplate = routeLabels.some(
-      (r) => r === '/r/:slug' || r === '/r/:slug/' || r?.includes(':'),
-    );
+    // At least one route label must be the parameterized template form
+    // (contains a `:param` segment, e.g. "/reports/:slug").
+    const hasTemplate = routeLabels.some((r) => r?.includes(':'));
     expect(hasTemplate).toBe(true);
   });
 

--- a/apps/api/test/metrics.test.ts
+++ b/apps/api/test/metrics.test.ts
@@ -1,0 +1,230 @@
+/**
+ * metrics.test.ts — TDD RED for issue #119 (`/metrics` Prometheus endpoint).
+ *
+ * Spec refs: §5.12 (metrics emission), §5.14 (global backpressure metrics).
+ *
+ * Acceptance contract (from issue #119 brief, apps/api slice):
+ *   (a) GET /metrics without bearer → 401, never 200.
+ *   (b) GET /metrics with valid bearer → 200, content-type
+ *       text/plain; version=0.0.4 (Prometheus exposition).
+ *   (c) willbuy_studies_started_total{kind} increments after a recorded
+ *       study-start event.
+ *   (d) willbuy_http_request_duration_seconds_bucket is emitted for at
+ *       least one route after a request was served.
+ *   (e) The `route` label on the request-duration histogram is the
+ *       parameterized template ("/r/:slug"), not the literal URL ("/r/abc").
+ *   (f) Constant-time bearer compare — wrong-length tokens also 401.
+ *
+ * Test strategy:
+ *   - No Postgres needed for this suite. We build the Fastify app with
+ *     stub-friendly env, issue requests via app.inject(), and inspect the
+ *     /metrics exposition output. The `recordStudyStarted` helper exported
+ *     from src/metrics is invoked directly to simulate the study-create
+ *     hook firing without going through the DB-bound POST /studies path
+ *     (which is covered by studies.api.test.ts).
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import type { FastifyInstance } from 'fastify';
+
+import { buildServer } from '../src/server.js';
+import { recordStudyStarted, resetMetricsForTesting } from '../src/metrics/registry.js';
+
+const METRICS_TOKEN = 'test-metrics-bearer-token-1234567890';
+
+const BASE_ENV = {
+  PORT: 0,
+  LOG_LEVEL: 'silent' as const,
+  URL_HASH_SALT: 'x'.repeat(32),
+  DATABASE_URL: 'postgres://localhost/willbuy_metrics_test_unused',
+  DAILY_CAP_CENTS: 10_000,
+  STRIPE_SECRET_KEY: 'sk_test_unused',
+  STRIPE_WEBHOOK_SECRET: 'whsec_unused',
+  STRIPE_PRICE_ID_STARTER: 'price_unused',
+  STRIPE_PRICE_ID_GROWTH: 'price_unused',
+  STRIPE_PRICE_ID_SCALE: 'price_unused',
+  SHARE_TOKEN_HMAC_KEY: 'dev-only-share-token-hmac-key-not-for-production-use',
+  RESEND_API_KEY: 're_unused',
+  RESEND_TEST_MODE: 'stub' as const,
+  NODE_ENV: 'test' as const,
+  WILLBUY_METRICS_TOKEN: METRICS_TOKEN,
+};
+
+describe('GET /metrics — auth gating (issue #119)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    resetMetricsForTesting();
+    app = await buildServer({ env: BASE_ENV });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  it('returns 401 without an Authorization header', async () => {
+    const res = await app.inject({ method: 'GET', url: '/metrics' });
+    expect(res.statusCode).toBe(401);
+    // No metrics body should leak in the 401 response.
+    expect(res.body).not.toContain('willbuy_');
+  });
+
+  it('returns 401 with a wrong bearer token', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/metrics',
+      headers: { authorization: 'Bearer wrong-token-value' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 401 with a malformed Authorization header', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/metrics',
+      headers: { authorization: METRICS_TOKEN }, // no "Bearer " prefix
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('returns 200 with the correct bearer token and Prometheus content-type', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/metrics',
+      headers: { authorization: `Bearer ${METRICS_TOKEN}` },
+    });
+    expect(res.statusCode).toBe(200);
+    // §5.14 + Prometheus exposition format 0.0.4 (text/plain charset utf-8).
+    expect(res.headers['content-type']).toMatch(/^text\/plain;\s*version=0\.0\.4/);
+    // Body is non-empty and contains at least one HELP line.
+    expect(res.body.length).toBeGreaterThan(0);
+    expect(res.body).toMatch(/^# HELP /m);
+    expect(res.body).toMatch(/^# TYPE /m);
+  });
+});
+
+describe('willbuy_studies_started_total counter (issue #119 acceptance c)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    resetMetricsForTesting();
+    app = await buildServer({ env: BASE_ENV });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  async function scrapeMetrics(): Promise<string> {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/metrics',
+      headers: { authorization: `Bearer ${METRICS_TOKEN}` },
+    });
+    expect(res.statusCode).toBe(200);
+    return res.body;
+  }
+
+  it('exposes the metric with HELP/TYPE lines even at zero', async () => {
+    const body = await scrapeMetrics();
+    expect(body).toMatch(/^# TYPE willbuy_studies_started_total counter$/m);
+    expect(body).toMatch(/^# HELP willbuy_studies_started_total /m);
+  });
+
+  it('increments after recordStudyStarted({kind:"single"}) is called', async () => {
+    // Read current value (should be 0 or absent).
+    const before = await scrapeMetrics();
+    const beforeMatch = before.match(/^willbuy_studies_started_total\{[^}]*kind="single"[^}]*\}\s+(\d+)/m);
+    const beforeVal = beforeMatch ? Number(beforeMatch[1]) : 0;
+
+    recordStudyStarted({ kind: 'single' });
+    recordStudyStarted({ kind: 'single' });
+    recordStudyStarted({ kind: 'paired' });
+
+    const after = await scrapeMetrics();
+    const afterSingle = after.match(/^willbuy_studies_started_total\{[^}]*kind="single"[^}]*\}\s+(\d+)/m);
+    const afterPaired = after.match(/^willbuy_studies_started_total\{[^}]*kind="paired"[^}]*\}\s+(\d+)/m);
+    expect(afterSingle).not.toBeNull();
+    expect(afterPaired).not.toBeNull();
+    expect(Number(afterSingle![1])).toBe(beforeVal + 2);
+    expect(Number(afterPaired![1])).toBe(1);
+  });
+});
+
+describe('willbuy_http_request_duration_seconds histogram (issue #119 acceptance d, e)', () => {
+  let app: FastifyInstance;
+
+  beforeAll(async () => {
+    resetMetricsForTesting();
+    app = await buildServer({ env: BASE_ENV });
+  });
+
+  afterAll(async () => {
+    await app.close();
+  });
+
+  async function scrapeMetrics(): Promise<string> {
+    const res = await app.inject({
+      method: 'GET',
+      url: '/metrics',
+      headers: { authorization: `Bearer ${METRICS_TOKEN}` },
+    });
+    expect(res.statusCode).toBe(200);
+    return res.body;
+  }
+
+  it('emits at least one _bucket line after a request is served', async () => {
+    // Hit /health to generate a measurable request without DB requirements.
+    const r = await app.inject({ method: 'GET', url: '/health' });
+    expect(r.statusCode).toBe(200);
+
+    const body = await scrapeMetrics();
+    expect(body).toMatch(/^# TYPE willbuy_http_request_duration_seconds histogram$/m);
+    expect(body).toMatch(/^willbuy_http_request_duration_seconds_bucket\{[^}]*\}\s+\d+/m);
+    expect(body).toMatch(/^willbuy_http_request_duration_seconds_count\{[^}]*\}\s+\d+/m);
+  });
+
+  it('uses the parameterized route template (not the literal URL) in the route label', async () => {
+    // Hit a parameterized route. /r/:slug exists in routes/reports.ts; an
+    // unknown slug returns 404 but the route template is still :slug.
+    // Use a literal slug that would NEVER appear as a real registered path.
+    const literalSlug = 'metrics-route-label-fixture-abc';
+    const r = await app.inject({ method: 'GET', url: `/r/${literalSlug}` });
+    // Status doesn't matter for this assertion — we care about the route
+    // label being captured against the template.
+    expect([200, 302, 404]).toContain(r.statusCode);
+
+    const body = await scrapeMetrics();
+
+    // The literal slug must NOT appear in any `route="..."` label value.
+    const routeLabels = Array.from(body.matchAll(/route="([^"]+)"/g)).map((m) => m[1]);
+    for (const route of routeLabels) {
+      expect(route).not.toContain(literalSlug);
+    }
+
+    // At least one route label must be the template form.
+    const hasTemplate = routeLabels.some(
+      (r) => r === '/r/:slug' || r === '/r/:slug/' || r?.includes(':'),
+    );
+    expect(hasTemplate).toBe(true);
+  });
+
+  it('does not emit an unbounded list of labels for unmatched 404 paths', async () => {
+    // Issue 5 requests to distinct unknown paths. A naive implementation that
+    // labels by raw URL would create 5 distinct route series; the bounded
+    // implementation collapses them into a single sentinel ("__unmatched__"
+    // or similar) — assert at most one route series for these.
+    for (let i = 0; i < 5; i++) {
+      await app.inject({ method: 'GET', url: `/no-such-path-${i}-${Date.now()}` });
+    }
+
+    const body = await scrapeMetrics();
+    const routeLabels = new Set(
+      Array.from(body.matchAll(/route="([^"]+)"/g)).map((m) => m[1]),
+    );
+    // None of the literal made-up paths should appear as labels.
+    for (const r of routeLabels) {
+      expect(r).not.toMatch(/no-such-path-\d/);
+    }
+  });
+});

--- a/docs/observability.md
+++ b/docs/observability.md
@@ -134,3 +134,109 @@ Environment variables read by `@willbuy/log`:
 3. In production set `WILLBUY_LOG_HASH_SALT` and `NODE_ENV=production`.
 4. Logs will appear at `/var/log/willbuy/<service>.jsonl`.
 5. Add the service to the table at the top of this doc.
+
+---
+
+# Metrics — Prometheus exposition (issue #119, apps/api slice)
+
+`apps/api` exposes a Prometheus exposition endpoint at **`GET /metrics`**,
+gated by a shared-secret bearer token (`WILLBUY_METRICS_TOKEN`). This is
+the v0.2 first slice of the issue-#119 metrics surface; the worker-side
+counters from spec §5.14 (capture/visit/provider attempts, circuit-breaker
+state, token-bucket fill, global in-flight) ship in follow-up issues that
+extend the same exposition pattern to `apps/capture-worker`,
+`apps/visitor-worker`, and `apps/aggregator`.
+
+## Decision: zero-dep registry, not `prom-client` (apps/api v0.2)
+
+We hand-rolled a small Prometheus 0.0.4 exposition serializer in
+`apps/api/src/metrics/registry.ts` rather than pulling `prom-client`.
+Rationale:
+
+- `prom-client` adds ~20 transitive deps and a Bun-test-runner-flaky
+  process collector we don't need; the exposition format is small and
+  stable.
+- We control label-cardinality enforcement at the call sites (TS enum
+  types) — the registry rejects unknown label keys at write time,
+  catching cardinality bugs in development.
+- Future swap to `prom-client` (or OTel Prometheus exporter for v0.3+
+  tracing) is a single-file change; the recording API
+  (`recordStudyStarted`, `recordHttpRequest`, etc.) is registry-agnostic.
+
+Worker-side metrics may pick `prom-client` independently if the worker's
+runtime story is different — this decision is scoped to apps/api.
+
+## Auth model
+
+Bearer token in `Authorization: Bearer <token>`, constant-time compare
+against `WILLBUY_METRICS_TOKEN`. **If `WILLBUY_METRICS_TOKEN` is unset
+the endpoint is locked down — every request returns 401**. This is the
+fail-closed default; never silently expose metrics on a misconfigured
+host.
+
+Operational setup:
+
+```bash
+# Generate
+op item create --vault willbuy --category 'API Credential' \
+  --title metrics-bearer-token \
+  credential[concealed]=$(openssl rand -hex 32)
+
+# Inject at boot
+op inject -i .env.template -o .env  # references op://willbuy/metrics-bearer-token/credential
+```
+
+Prometheus scrape config (single-instance Prometheus on willbuy-v01,
+follow-up issue wires this for all services):
+
+```yaml
+scrape_configs:
+  - job_name: willbuy-api
+    bearer_token_file: /etc/prometheus/willbuy-metrics-token
+    static_configs:
+      - targets: ['127.0.0.1:3001']
+    scrape_interval: 15s
+```
+
+## Metrics catalogue (apps/api v0.2 slice)
+
+### Business signals
+
+| Metric                                | Type      | Labels                  | Notes                                                                                  |
+| ------------------------------------- | --------- | ----------------------- | -------------------------------------------------------------------------------------- |
+| `willbuy_studies_started_total`       | counter   | `kind`                  | `kind` ∈ {single, paired} (§2 #12). Incremented after the `POST /studies` commit.       |
+| `willbuy_studies_completed_total`     | counter   | `kind`, `outcome`       | `outcome` ∈ {ok, partial, failed}. Wired in by the finalize path (§5.4 partial-finalize). |
+| `willbuy_visits_total`                | counter   | `persona_pool`          | `persona_pool` is the bounded ICP-archetype id (§2 #9) or `"custom"`.                  |
+| `willbuy_credits_consumed_total`      | counter   | `kind`                  | Cumulative cents debited from `credit_ledger` (§5.4).                                   |
+| `willbuy_active_studies`              | gauge     | (none)                  | Snapshot of in-flight studies (statuses pending/capturing/visiting/aggregating).        |
+
+### System signals
+
+| Metric                                       | Type      | Labels                          | Notes                                                                                              |
+| -------------------------------------------- | --------- | ------------------------------- | -------------------------------------------------------------------------------------------------- |
+| `willbuy_http_request_duration_seconds`      | histogram | `route`, `method`, `status`     | `route` is the parameterized template (`/reports/:slug`). Unmatched 404s collapse to `route="__unmatched__"` for bounded cardinality. Default buckets cover 5ms…30s. |
+| `willbuy_process_start_time_seconds`         | gauge     | (none)                          | Unix-seconds at boot. Compute uptime as `time() - willbuy_process_start_time_seconds`.              |
+| `willbuy_build_info`                         | gauge     | `version`                       | Always 1; `version` carries `apps/api/package.json` version.                                        |
+
+### Cardinality discipline
+
+The `route` label is the load-bearing one. Two guards:
+
+1. **Source.** We pull from `request.routeOptions.url` (Fastify v5) — the
+   parameterized template, not the literal request URL.
+2. **404 collapse.** Unmatched routes report `route="__unmatched__"` so a
+   path-fuzzer hitting random URLs cannot blow up the series count.
+
+A vitest suite in `apps/api/test/metrics.test.ts` asserts both invariants
+(literal-slug must NOT appear in any label value; at least one route
+label must be a `:param`-bearing template).
+
+## Out of scope (this slice)
+
+- Worker-side metrics (capture/visit/provider/circuit-breaker) — separate
+  issues, will land in their respective `apps/<worker>/src/metrics/`.
+- Alertmanager wiring (issue #120).
+- `/admin/health` UI (issue #121).
+- `infra/observability/prometheus.yml` + installer — added once the
+  worker-side metrics surface lands, so a single scrape config covers
+  every service.


### PR DESCRIPTION
## Summary

Implements the **apps/api slice** of issue #119 — a Prometheus exposition
endpoint at `GET /metrics`, gated by `Authorization: Bearer
WILLBUY_METRICS_TOKEN` (constant-time compare; fail-closed 401 when the
token is unset).

- Zero-dep registry (no `prom-client` for v0.2). Hand-rolled exposition
  serializer in `apps/api/src/metrics/registry.ts` with labelset
  validation at write time so cardinality bugs surface in development,
  not on a Prometheus host.
- `route` label on the request-duration histogram is the **parameterized
  template** from `request.routeOptions.url` (e.g. `/reports/:slug`),
  never the literal URL. Unmatched 404s collapse to
  `route="__unmatched__"` so a path-fuzzer can't blow up the series count.
- Business counters wired into the `POST /studies` happy path
  (`recordStudyStarted` AFTER `COMMIT` to avoid inflation on rolled-back
  txns). The other v0.2 metrics (`studies_completed`, `visits`,
  `credits_consumed`, `active_studies`) have helpers exposed and ready
  to wire in their owning code paths.
- Decision record in `docs/observability.md` now covers both #118 (logs)
  and #119 (metrics).

### Scope clarification

Issue #119 originally describes a multi-app metrics rollout (worker-side
counters from §5.14 — capture/visit/provider/circuit-breaker) plus
`packages/metrics` and `infra/observability/prometheus.yml`. This PR is
the **apps/api first slice** of that surface, scoped per the engineering
brief. Worker-side metrics ship in follow-up issues that extend the
same exposition pattern; a single Prometheus scrape config will land
once those services have their endpoints up.

### Metrics surface (this slice)

| Type      | Metric                                                           |
| --------- | ---------------------------------------------------------------- |
| counter   | `willbuy_studies_started_total{kind}`                            |
| counter   | `willbuy_studies_completed_total{kind,outcome}`                  |
| counter   | `willbuy_visits_total{persona_pool}`                             |
| counter   | `willbuy_credits_consumed_total{kind}`                           |
| gauge     | `willbuy_active_studies`                                         |
| histogram | `willbuy_http_request_duration_seconds{route,method,status}`     |
| gauge     | `willbuy_process_start_time_seconds`                             |
| gauge     | `willbuy_build_info{version}`                                    |

## TDD discipline

- **RED** `e46c8a3` — 9 failing tests covering: 401 without bearer, 200
  + Prometheus content-type with valid bearer, malformed-header 401,
  wrong-token 401, counter increments, histogram emission, route-label
  is template (not literal), unbounded-404 cardinality guard.
- **GREEN** `36e5051` — implementation; all 9 tests pass; full apps/api
  suite (133 tests) green.

## Manual test evidence

```bash
$ curl -i -s http://127.0.0.1:3001/metrics | head -5
HTTP/1.1 401 Unauthorized
Content-Type: text/plain
Date: Sun, 26 Apr 2026 03:34:10 GMT
Content-Length: 13

unauthorized
```

```bash
$ curl -s -H 'Authorization: Bearer manual-smoke-token-1234567890' http://127.0.0.1:3001/metrics | head -16
# HELP willbuy_studies_started_total Total number of studies created (POST /studies). `kind` ∈ {single,paired} per §2 #12.
# TYPE willbuy_studies_started_total counter
# HELP willbuy_studies_completed_total Total studies that reached a terminal state. `outcome` ∈ {ok,partial,failed}.
# TYPE willbuy_studies_completed_total counter
# HELP willbuy_visits_total Total visit-job transitions observed by the API. `persona_pool` is the ICP archetype set per §2 #9.
# TYPE willbuy_visits_total counter
# HELP willbuy_credits_consumed_total Total credit-ledger debits in cents grouped by study kind (§5.4).
# TYPE willbuy_credits_consumed_total counter
# HELP willbuy_active_studies Number of studies whose status is in {pending,capturing,visiting,aggregating}. Set by the route handler at scrape time when a probe is registered.
# TYPE willbuy_active_studies gauge
willbuy_active_studies 0
# HELP willbuy_http_request_duration_seconds Fastify HTTP request duration in seconds. `route` is the parameterized template; "__unmatched__" for 404 paths with no matching route (bounded cardinality, issue #119).
# TYPE willbuy_http_request_duration_seconds histogram
# HELP willbuy_process_start_time_seconds Process start time in unix seconds (UTC). Compute uptime as `time() - willbuy_process_start_time_seconds`.
...
```

After two `/health` hits the histogram populates with the parameterized
route label:

```
willbuy_http_request_duration_seconds_bucket{le="0.005",method="GET",route="/health",status="200"} 2
willbuy_http_request_duration_seconds_bucket{le="0.01",method="GET",route="/health",status="200"} 2
willbuy_http_request_duration_seconds_bucket{le="+Inf",method="GET",route="/health",status="200"} 2
willbuy_http_request_duration_seconds_count{method="GET",route="/health",status="200"} 2
```

## Test plan

- [x] `bunx vitest run --pool=threads --poolOptions.threads.maxThreads=2` (apps/api): 17 files, 133 tests passing
- [x] `bun run typecheck` (root + every workspace): clean
- [x] `bun run lint` (root): clean
- [x] Manual smoke: 401 without bearer; 200 + valid Prometheus exposition with bearer; histogram tracks parameterized route templates (verified by `curl /health` then scraping)
- [ ] CI green (4/4 jobs)

Refs #119

🤖 Generated with [Claude Code](https://claude.com/claude-code)