### PR TITLE
fix(ops): update canary baseline phrase to match /r/test-fixture content (#142)

### DIFF
--- a/apps/capture-worker/test/canary-smoke.test.ts
+++ b/apps/capture-worker/test/canary-smoke.test.ts
@@ -27,28 +27,39 @@ const BASELINE: CanaryBaseline = {
   // on purpose so a Chromium minor-version bump that re-arranges role
   // nesting still passes — the canary watches for symptom-level
   // regressions, not pixel diffs.
+  //
+  // Note: "MEAN Δ WILL-TO-BUY" is uppercased here on purpose. The DOM
+  // text content is lowercase ("mean Δ will-to-buy"), but the span
+  // applies CSS `text-transform: uppercase` and Chromium computes the
+  // accessible name from the *rendered* string. Asserting on the a11y
+  // form keeps the unit-test honest with what live capture sees.
   requiredA11yPhrases: [
     'Paired-delta dot plot',
     'Persona cards',
-    'mean Δ will-to-buy',
+    'MEAN Δ WILL-TO-BUY',
     'test-fixture',
   ],
   maxBannerSelectorsMatched: 0,
   maxHostCount: 5,
 };
 
+// Stub a11y tree shaped after the live /r/test-fixture render
+// (apps/web/app/r/[slug]/page.tsx + ReportView): page-level h1 names the
+// study slug, then the report sections expose their h2 headings and the
+// headline-stat label. Only the substrings BASELINE asserts on need to
+// be present; structure is illustrative.
 const goldResult: CaptureResult = {
   status: 'ok',
   url: 'http://127.0.0.1:3014/r/test-fixture',
   a11y_tree: [
     {
       role: 'RootWebArea',
-      name: 'Simple capture fixture',
+      name: 'willbuy.dev — public report',
       children: [
-        { role: 'heading', name: 'Pricing that scales with you', level: 1, children: [] },
-        { role: 'image', name: 'Postgres logo', children: [] },
-        { role: 'button', name: 'Start free', children: [] },
-        { role: 'link', name: 'Talk to sales', children: [] },
+        { role: 'heading', name: 'Study test-fixture', level: 1, children: [] },
+        { role: 'text', name: 'MEAN Δ WILL-TO-BUY', children: [] },
+        { role: 'heading', name: 'Paired-delta dot plot', level: 2, children: [] },
+        { role: 'heading', name: 'Persona cards', level: 2, children: [] },
       ],
     },
   ],
@@ -77,13 +88,15 @@ describe('compareCanaryToBaseline (spec §5.16 weekly canary)', () => {
       a11y_tree: [
         {
           role: 'RootWebArea',
-          name: 'Simple capture fixture',
-          // "Start free" button is gone — exactly the kind of regression a
-          // browser bump might silently introduce by changing role mapping.
+          name: 'willbuy.dev — public report',
+          // "Persona cards" h2 is gone — exactly the kind of regression a
+          // browser bump might silently introduce by changing role mapping
+          // (e.g. h2 → generic), and a real one if the component stops
+          // rendering the section header at all.
           children: [
-            { role: 'heading', name: 'Pricing that scales with you', level: 1, children: [] },
-            { role: 'image', name: 'Postgres logo', children: [] },
-            { role: 'link', name: 'Talk to sales', children: [] },
+            { role: 'heading', name: 'Study test-fixture', level: 1, children: [] },
+            { role: 'text', name: 'MEAN Δ WILL-TO-BUY', children: [] },
+            { role: 'heading', name: 'Paired-delta dot plot', level: 2, children: [] },
           ],
         },
       ],
@@ -91,7 +104,7 @@ describe('compareCanaryToBaseline (spec §5.16 weekly canary)', () => {
     const verdict = compareCanaryToBaseline(stripped, BASELINE);
     expect(verdict.ok).toBe(false);
     if (!verdict.ok) {
-      expect(verdict.reason).toMatch(/Start free/);
+      expect(verdict.reason).toMatch(/Persona cards/);
     }
   });
 

--- a/apps/capture-worker/test/canary-smoke.test.ts
+++ b/apps/capture-worker/test/canary-smoke.test.ts
@@ -18,14 +18,20 @@ import type { CaptureResult } from '../src/types.js';
 const BASELINE: CanaryBaseline = {
   expectedStatus: 'ok',
   // Substrings the rendered a11y tree (JSON-stringified) must contain.
-  // Same set captureGolden.test.ts asserts, kept short on purpose so a
-  // Chromium minor-version bump that re-arranges role nesting still passes
-  // — the canary watches for symptom-level regressions, not pixel diffs.
+  // The canary target is /r/test-fixture (the report page rendered with
+  // WILLBUY_REPORT_FIXTURE=enabled), not the marketing pricing page —
+  // see scripts/canary/run-canary.ts. Phrases below are the structural
+  // anchors of the report view (spec §5.18): two h2 headings, the
+  // headline-stat label (which exercises the Δ codepoint round-trip),
+  // and the study slug (proves the fixture loader fired). Kept short
+  // on purpose so a Chromium minor-version bump that re-arranges role
+  // nesting still passes — the canary watches for symptom-level
+  // regressions, not pixel diffs.
   requiredA11yPhrases: [
-    'Pricing that scales with you',
-    'Postgres logo',
-    'Start free',
-    'Talk to sales',
+    'Paired-delta dot plot',
+    'Persona cards',
+    'mean Δ will-to-buy',
+    'test-fixture',
   ],
   maxBannerSelectorsMatched: 0,
   maxHostCount: 5,

--- a/scripts/canary/run-canary.ts
+++ b/scripts/canary/run-canary.ts
@@ -20,13 +20,26 @@ const FIXTURE_PATH = process.env.WILLBUY_CANARY_FIXTURE_PATH ?? '/r/test-fixture
 // Same baseline the unit test pins. Substring-only on purpose so a
 // Chromium minor bump that re-arranges role nesting still passes — the
 // canary watches for symptom-level regressions, not pixel diffs.
+//
+// Phrases below are the structural anchors of the /r/test-fixture
+// report-page render (spec §5.18, apps/web/components/report/*): two
+// h2 section headings, the headline-stat label (which exercises the Δ
+// codepoint round-trip through the a11y tree), and the study slug
+// (proves the WILLBUY_REPORT_FIXTURE loader fired and we got the
+// fixture report rather than the "Report not found" 404 branch).
+//
+// Note: "MEAN Δ WILL-TO-BUY" is uppercase on purpose — the DOM text
+// is "mean Δ will-to-buy" but CSS `text-transform: uppercase` on the
+// span causes Chromium to compute the accessible name off the
+// rendered (uppercased) string. The unit-test BASELINE in
+// apps/capture-worker/test/canary-smoke.test.ts mirrors this.
 const BASELINE: CanaryBaseline = {
   expectedStatus: 'ok',
   requiredA11yPhrases: [
-    'Pricing that scales with you',
-    'Postgres logo',
-    'Start free',
-    'Talk to sales',
+    'Paired-delta dot plot',
+    'Persona cards',
+    'MEAN Δ WILL-TO-BUY',
+    'test-fixture',
   ],
   maxBannerSelectorsMatched: 0,
   maxHostCount: 5,


### PR DESCRIPTION
## Summary

- The staging-canary baseline (introduced in #139) still asserted on pricing-page phrases — \"Pricing that scales with you\", \"Postgres logo\", \"Start free\", \"Talk to sales\" — even though the canary target is `/r/test-fixture`, the report-page fixture, not the marketing page. So the canary always failed against a healthy server.
- This PR realigns both `scripts/canary/run-canary.ts` and the `apps/capture-worker/test/canary-smoke.test.ts` baseline to four structural anchors of the report view (spec §5.18, `apps/web/components/report/*`):
  - `Paired-delta dot plot` — h2 of the key viz
  - `Persona cards` — h2 of the persona grid
  - `MEAN Δ WILL-TO-BUY` — headline-stat label (exercises the Δ codepoint round-trip)
  - `test-fixture` — study slug rendered in the page header (proves `WILLBUY_REPORT_FIXTURE` loaded the fixture rather than 404-ing)
- The `goldResult` stub in `canary-smoke.test.ts` is reshaped to match the real `/r/<slug>` render (`apps/web/app/r/[slug]/page.tsx` + `ReportView`), and the \"phrase missing\" regression assertion now drops the `Persona cards` h2 so we still exercise the same regression class the old test did.
- The `MEAN Δ WILL-TO-BUY` form is uppercase on purpose — DOM text content is `mean Δ will-to-buy` but the span carries `text-transform: uppercase`, and Chromium computes the accessible name off the *rendered* string. Inline comment in both files calls this out so the next person doesn't \"correct\" it.

Workflow followed RED → GREEN per CLAUDE.md:

1. `4ab7a71` (RED) — flipped only the BASELINE phrases; `goldResult` and the `/Start free/` regex still on the old pricing-page phrases, so `canary-smoke.test.ts` failed two specs.
2. `4d712dd` (GREEN) — reshaped `goldResult`, retargeted the regression assertion to `Persona cards`, and updated `run-canary.ts` BASELINE to match.

## Live canary verification

Against the local dev server running with `WILLBUY_REPORT_FIXTURE=enabled` on :3014:

```
$ WILLBUY_CANARY_BASE_URL=http://127.0.0.1:3014 \
    bash scripts/canary/staging-browser-canary.sh
{"ok":true,"reason":null,"target":"http://127.0.0.1:3014/r/test-fixture","status":"ok","host_count":1,"banner_selectors_matched":[],"started_at":"2026-04-26T07:15:37.930Z","finished_at":"2026-04-26T07:15:41.383Z"}
$ echo $?
0
```

The capture saw all four required phrases in the live a11y tree; `host_count=1` (well under the 5-budget); zero banner-selector hits; no breach.

For confirmation that this would have caught the original miscalibration: before swapping the phrase casing, the live canary failed exactly as expected with `\"reason\":\"required a11y phrase missing: \\\"mean Δ will-to-buy\\\"\"`, which is why the comment about CSS-rendered name calculation is in both files.

## Local unit tests

```
$ bun --cwd apps/capture-worker test --pool=threads --poolOptions.threads.minThreads=1 --poolOptions.threads.maxThreads=2
…
 Test Files  9 passed (9)
      Tests  27 passed (27)
```

(Per the `local_test_resource_budget` rule, scoped to `apps/capture-worker` with capped threads — not the repo-root test runner. CI is the source of truth.)

## Test plan

- [x] `bun --cwd apps/capture-worker test` green (27/27)
- [x] Live canary green against `:3014` with `WILLBUY_REPORT_FIXTURE=enabled` (output above)
- [x] RED commit on its own demonstrates the test failing for the right reason (missing-phrase reason names a *report-page* phrase)
- [ ] CI green on this PR
- [ ] Manager merge + post-merge canary spot-check

Closes #142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)