### PR TITLE
feat(web): landing page CTAs + /r/* buy CTA footer bar (#145, #146)

### DIFF
--- a/apps/web/app/page.tsx
+++ b/apps/web/app/page.tsx
@@ -11,12 +11,44 @@ export default function LandingPage() {
       </h1>
       <p className="mt-6 text-lg text-gray-700">
         Pre-launch landing-page A/B tests run by paired LLM visitors with
-        consistent backstories.{' '}
-        <a className="underline" href={SPEC_URL} rel="noopener noreferrer">
-          Read the spec
-        </a>
-        .
+        consistent backstories.
       </p>
+
+      {/* Primary + secondary CTAs */}
+      <div className="mt-8 flex flex-wrap items-center gap-4">
+        <a
+          href="/pricing"
+          className="rounded-md bg-indigo-600 px-6 py-3 text-base font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        >
+          See pricing →
+        </a>
+        <a
+          href="/r/test-fixture"
+          className="rounded-md border border-indigo-600 px-6 py-3 text-base font-semibold text-indigo-600 hover:bg-indigo-50 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        >
+          See a sample report
+        </a>
+      </div>
+
+      {/* Tertiary CTA — text link only, not a button */}
+      <p className="mt-4 text-sm text-gray-600">
+        <a href="/sign-in" className="underline hover:text-gray-900">
+          Sign in
+        </a>
+      </p>
+
+      {/* Footer — spec link demoted from primary position */}
+      <footer className="mt-16 border-t border-gray-200 pt-6">
+        <p className="text-xs text-gray-400">
+          <a
+            href={SPEC_URL}
+            rel="noopener noreferrer"
+            className="underline hover:text-gray-600"
+          >
+            Read the technical spec ↗
+          </a>
+        </p>
+      </footer>
     </main>
   );
 }

--- a/apps/web/app/r/[slug]/page.tsx
+++ b/apps/web/app/r/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import { Report, type ReportT } from '@willbuy/shared/report';
+import { ReportCtaBar } from '../../../components/report/ReportCtaBar';
 import { ReportView } from '../../../components/report/ReportView';
 import { fetchReport } from './fetchReport';
 
@@ -21,12 +22,15 @@ export default async function ReportPage({
 
   if (result === null) {
     return (
-      <main className="mx-auto max-w-3xl px-6 py-16">
-        <h1 className="text-3xl font-bold tracking-tight">Report not found</h1>
-        <p className="mt-6 text-gray-700">
-          No report exists for <code>{slug}</code>, or the share link has been revoked.
-        </p>
-      </main>
+      <>
+        <main className="mx-auto max-w-3xl px-6 py-16">
+          <h1 className="text-3xl font-bold tracking-tight">Report not found</h1>
+          <p className="mt-6 text-gray-700">
+            No report exists for <code>{slug}</code>, or the share link has been revoked.
+          </p>
+        </main>
+        <ReportCtaBar />
+      </>
     );
   }
 
@@ -35,14 +39,17 @@ export default async function ReportPage({
   // we'd rather 500 than render a malformed report.
   const report: ReportT = Report.parse(result);
   return (
-    <main className="mx-auto max-w-6xl px-4 py-10">
-      <header className="mb-6">
-        <p className="text-xs uppercase tracking-wide text-gray-500">willbuy.dev — public report</p>
-        <h1 className="text-2xl font-bold tracking-tight text-gray-900">
-          Study <code className="text-base">{report.meta.slug}</code>
-        </h1>
-      </header>
-      <ReportView report={report} mode="public" />
-    </main>
+    <>
+      <main className="mx-auto max-w-6xl px-4 py-10">
+        <header className="mb-6">
+          <p className="text-xs uppercase tracking-wide text-gray-500">willbuy.dev — public report</p>
+          <h1 className="text-2xl font-bold tracking-tight text-gray-900">
+            Study <code className="text-base">{report.meta.slug}</code>
+          </h1>
+        </header>
+        <ReportView report={report} mode="public" />
+      </main>
+      <ReportCtaBar />
+    </>
   );
 }

--- a/apps/web/components/report/ReportCtaBar.tsx
+++ b/apps/web/components/report/ReportCtaBar.tsx
@@ -1,0 +1,66 @@
+'use client';
+
+// Spec §3d (docs/launch/pricing-cta-audit.md) — buy CTA footer bar for
+// /r/* public report pages. Issue #146.
+//
+// Design constraints:
+//   - Fixed to viewport bottom, low-profile strip (not a modal).
+//   - Dismissible via localStorage key `willbuy_report_cta_dismissed=1`.
+//   - SSR renders the bar visible; client hydration manages dismiss state.
+//   - No inline <script> tags — localStorage access is inside event handlers,
+//     which is fine under the existing nonce-based CSP (§5.10 / middleware.ts).
+
+import { useState, useEffect } from 'react';
+
+const STORAGE_KEY = 'willbuy_report_cta_dismissed';
+
+export function ReportCtaBar() {
+  // Initialise as visible so the SSR HTML always includes the bar.
+  // After hydration, check localStorage and hide if already dismissed.
+  const [dismissed, setDismissed] = useState(false);
+
+  useEffect(() => {
+    try {
+      if (typeof window !== 'undefined' && window.localStorage.getItem(STORAGE_KEY) === '1') {
+        setDismissed(true);
+      }
+    } catch {
+      // localStorage may be unavailable (private browsing, security policies).
+    }
+  }, []);
+
+  if (dismissed) return null;
+
+  function handleDismiss() {
+    try {
+      if (typeof window !== 'undefined') {
+        window.localStorage.setItem(STORAGE_KEY, '1');
+      }
+    } catch {
+      // localStorage may be unavailable (private browsing, security policies).
+    }
+    setDismissed(true);
+  }
+
+  return (
+    <div
+      data-testid="report-cta-bar"
+      className="fixed bottom-0 inset-x-0 z-50 flex items-center justify-between gap-4 bg-gray-900 px-4 py-3 text-sm text-white shadow-lg"
+    >
+      <a
+        href="/pricing"
+        className="font-medium hover:underline focus-visible:underline"
+      >
+        Run a study on your own page →
+      </a>
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={handleDismiss}
+        className="flex-shrink-0 rounded p-1 text-gray-400 hover:text-white focus-visible:outline focus-visible:outline-2 focus-visible:outline-white"
+      >
+        ×
+      </button>
+    </div>
+  );
+}

--- a/apps/web/test/landing.test.tsx
+++ b/apps/web/test/landing.test.tsx
@@ -1,0 +1,49 @@
+/**
+ * landing.test.tsx — TDD acceptance for issue #145.
+ *
+ * Asserts the / landing page renders:
+ *  - "See pricing" link pointing to /pricing (primary CTA)
+ *  - "See a sample report" link pointing to /r/test-fixture (secondary CTA)
+ *  - "Sign in" link pointing to /sign-in (tertiary, text-only — NOT a button)
+ *  - "Read the spec" link still present (demoted to footer)
+ *  - No "start free" copy anywhere (paid-conversion — pricing_conversion_goal)
+ *
+ * Spec refs: docs/launch/pricing-cta-audit.md §3a, SPEC §1 positioning.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import LandingPage from '../app/page';
+
+describe('/ landing page CTAs (issue #145)', () => {
+  function getHtml(): string {
+    return renderToStaticMarkup(<LandingPage />);
+  }
+
+  it('primary CTA: "See pricing" link points to /pricing', () => {
+    const html = getHtml();
+    expect(html).toMatch(/see pricing/i);
+    expect(html).toMatch(/href="\/pricing"/i);
+  });
+
+  it('secondary CTA: "See a sample report" link points to /r/test-fixture', () => {
+    const html = getHtml();
+    expect(html).toMatch(/see a sample report/i);
+    expect(html).toMatch(/href="\/r\/test-fixture"/i);
+  });
+
+  it('tertiary CTA: "Sign in" link points to /sign-in', () => {
+    const html = getHtml();
+    expect(html).toMatch(/sign in/i);
+    expect(html).toMatch(/href="\/sign-in"/i);
+  });
+
+  it('footer: "Read the spec" link is still present', () => {
+    const html = getHtml();
+    expect(html).toMatch(/read the.*spec/i);
+  });
+
+  it('contains no "start free" copy (paid-conversion page)', () => {
+    expect(getHtml()).not.toMatch(/start free/i);
+  });
+});

--- a/apps/web/test/report-cta.test.tsx
+++ b/apps/web/test/report-cta.test.tsx
@@ -13,9 +13,26 @@
 // not tested here — it's a one-liner and JSDOM quirks make it fragile.
 // Presence of the button is sufficient per the issue spec.
 
-import { describe, it, expect, afterEach } from 'vitest';
+import { describe, it, expect, beforeAll, afterEach } from 'vitest';
 import { cleanup, render, screen } from '@testing-library/react';
 import { ReportCtaBar } from '../components/report/ReportCtaBar';
+
+// jsdom in this project's Bun/Vitest config launches without a localStorage
+// file path, which leaves window.localStorage as a non-functional stub.
+// Install a minimal in-memory shim so the useEffect inside ReportCtaBar
+// doesn't throw and doesn't incorrectly set dismissed=true.
+beforeAll(() => {
+  const store: Record<string, string> = {};
+  const stub = {
+    getItem: (k: string) => store[k] ?? null,
+    setItem: (k: string, v: string) => { store[k] = v; },
+    removeItem: (k: string) => { delete store[k]; },
+    clear: () => { for (const k of Object.keys(store)) delete store[k]; },
+    get length() { return Object.keys(store).length; },
+    key: (i: number) => Object.keys(store)[i] ?? null,
+  };
+  Object.defineProperty(window, 'localStorage', { value: stub, writable: false });
+});
 
 afterEach(() => {
   cleanup();

--- a/apps/web/test/report-cta.test.tsx
+++ b/apps/web/test/report-cta.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment jsdom
+//
+// Spec §3d (docs/launch/pricing-cta-audit.md) — buy CTA footer bar on /r/* pages.
+// Issue #146.
+//
+// These four assertions match the acceptance criteria in the issue:
+//   1. The CTA bar renders in the report page output.
+//   2. The CTA link points to /pricing.
+//   3. No email-capture form is present.
+//   4. The close / dismiss button is present.
+//
+// The dismiss interaction itself (localStorage writes) is intentionally
+// not tested here — it's a one-liner and JSDOM quirks make it fragile.
+// Presence of the button is sufficient per the issue spec.
+
+import { describe, it, expect, afterEach } from 'vitest';
+import { cleanup, render, screen } from '@testing-library/react';
+import { ReportCtaBar } from '../components/report/ReportCtaBar';
+
+afterEach(() => {
+  cleanup();
+});
+
+describe('§3d — report CTA bar (#146)', () => {
+  it('1. renders the CTA bar', () => {
+    render(<ReportCtaBar />);
+    expect(screen.getByTestId('report-cta-bar')).toBeTruthy();
+  });
+
+  it('2. CTA link points to /pricing', () => {
+    render(<ReportCtaBar />);
+    const link = screen.getByRole('link', { name: /run a study/i });
+    expect(link.getAttribute('href')).toBe('/pricing');
+  });
+
+  it('3. no email-capture form in the CTA bar', () => {
+    const { container } = render(<ReportCtaBar />);
+    // No <form> element, no email input.
+    expect(container.querySelectorAll('form').length).toBe(0);
+    expect(container.querySelectorAll('input[type="email"]').length).toBe(0);
+    expect(container.querySelectorAll('input[type="text"]').length).toBe(0);
+  });
+
+  it('4. dismiss/close button is present', () => {
+    render(<ReportCtaBar />);
+    // Accept aria-label or visible text containing dismiss, close, or ×.
+    const btn =
+      screen.queryByRole('button', { name: /dismiss|close|×/i }) ??
+      screen.queryByLabelText(/dismiss|close|×/i);
+    expect(btn).toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `ReportCtaBar`, a `'use client'` fixed-bottom strip component rendering **"Run a study on your own page →"** linked to `/pricing`
- Dismissible: clicking × writes `willbuy_report_cta_dismissed=1` to `localStorage` and hides the bar; persists across page loads
- SSR-visible by default (bar is in server-rendered HTML on first load); no inline `<script>` tags added — fully CSP-compliant with the existing nonce-based `script-src` in `middleware.ts` (§5.10)
- Imported into the RSC `ReportPage` for both the found and not-found return paths

## Spec reference

Implements `docs/launch/pricing-cta-audit.md` §3d.

## Public-repo audit

No secrets, IPs, or secret-sauce leaks in diff. Confirmed.

## Test evidence

```
✓ test/report-cta.test.tsx (4 tests) 28ms
  ✓ §3d — report CTA bar (#146) > 1. renders the CTA bar
  ✓ §3d — report CTA bar (#146) > 2. CTA link points to /pricing
  ✓ §3d — report CTA bar (#146) > 3. no email-capture form in the CTA bar
  ✓ §3d — report CTA bar (#146) > 4. dismiss/close button is present

Test Files  16 passed (16)
Tests       105 passed (105)
```

TDD discipline followed: RED commit `cb41269` (failing import), GREEN commit `94cf5fb` (component + page wiring).

## Test plan

- [ ] Visit `/r/test-fixture` (with `WILLBUY_REPORT_FIXTURE=enabled`) — dark strip appears at viewport bottom
- [ ] Click × — bar disappears and stays gone on page reload
- [ ] Clear `localStorage` — bar re-appears on next visit
- [ ] No email input, no form, no tracking pixel in the bar's DOM

Closes #146

🤖 Generated with [Claude Code](https://claude.com/claude-code)