### PR TITLE
fix(log): scrub error_detail field; rename from 'detail' in poller (#150)

### DIFF
--- a/apps/capture-worker/src/poller.ts
+++ b/apps/capture-worker/src/poller.ts
@@ -186,7 +186,7 @@ export async function pollOnce(opts: PollOpts): Promise<PollResult> {
         const ack = await sendToBroker(brokerPayload, brokerOpts);
         if (!ack.ok) {
           log.error(
-            { event: 'broker.rejected', visit_id: String(visitId), error_class: ack.error, detail: ack.detail },
+            { event: 'broker.rejected', visit_id: String(visitId), error_class: ack.error, error_detail: ack.detail },
             'broker rejected artifact',
           );
           visitStatus = 'failed';

--- a/packages/log/src/redactor.ts
+++ b/packages/log/src/redactor.ts
@@ -64,6 +64,7 @@ const REMOVE_FIELDS = new Set([
   'provider_payload',
   'password',
   'page_bytes',
+  'error_detail',
 ]);
 const API_KEY_FIELD = 'api_key';
 const EMAIL_FIELD = 'email';

--- a/packages/log/test/redactor.test.ts
+++ b/packages/log/test/redactor.test.ts
@@ -421,6 +421,16 @@ describe('strict allowlist mode', () => {
     expect(r['duration_capture_ms']).toBe(999);
   });
 
+  it('drops error_detail regardless of strict mode (REMOVE_FIELDS)', () => {
+    const r = redact(
+      { event: 'broker.rejected', visit_id: 'v_1', error_class: 'ValidationError', error_detail: 'some debug string' },
+      salt,
+    ) as Record<string, unknown>;
+    expect(r['error_detail']).toBeUndefined();
+    expect(r['event']).toBe('broker.rejected');
+    expect(r['error_class']).toBe('ValidationError');
+  });
+
   it('strips secret_data via buildLogger strict:true but not strict:false', () => {
     function captureWithStrict(strict: boolean): Record<string, unknown> {
       const chunks: string[] = [];


### PR DESCRIPTION
## Summary

- Renames `detail: ack.detail` → `error_detail: ack.detail` at the `broker.rejected` log call site in `apps/capture-worker/src/poller.ts`
- Adds `'error_detail'` to `REMOVE_FIELDS` in `packages/log/src/redactor.ts` so the field is scrubbed from all log output (spec §5.12)
- `error_detail` is a free-form broker debug string; path fragments or other sensitive info may appear in it, so scrubbing is safer than letting it through

**Spec reference:** §5.12 — `error_detail` is not on the allowlist and must not reach production log aggregators.

**Public-repo audit:** No secrets, IPs, or secret-sauce leaks in diff. Confirmed.

## Test evidence

New test in `packages/log/test/redactor.test.ts` asserts `error_detail: 'some debug string'` is stripped by `redact()` while allowlisted fields (`event`, `error_class`) pass through.

```
bun test --cwd packages/log
37 pass, 0 fail (37 total: 36 pre-existing + 1 new)
```

## Test plan

- [x] `bun test --cwd packages/log` — 37 pass, 0 fail
- [x] Verify `detail` field no longer appears in `broker.rejected` log lines
- [x] Verify `error_detail` field is stripped from structured log output

Closes #150