### PR TITLE
fix: absorb EPIPE in server + remove socket.end() in broker-client (#155)

### DIFF
--- a/apps/capture-broker/src/server.ts
+++ b/apps/capture-broker/src/server.ts
@@ -114,6 +114,7 @@ async function handleConnection(socket: Socket, deps: BrokerDeps): Promise<void>
     BYTE_CAPS.MESSAGE_BYTES,
     deps.frameTimeoutMs ?? READ_TIMEOUT_MS,
   );
+  socket.on('error', () => {}); // absorb EPIPE/ECONNRESET from ack write (Bun full-close)
   if (result.kind === 'too_big') {
     sendError('message_too_big', `declared ${result.declaredLen} > cap ${BYTE_CAPS.MESSAGE_BYTES}`);
     return;

--- a/apps/capture-worker/src/broker-client.ts
+++ b/apps/capture-worker/src/broker-client.ts
@@ -112,14 +112,12 @@ export async function sendToBroker(
     socket.on('connect', () => {
       const body = Buffer.from(JSON.stringify(payload), 'utf8');
       const framed = frame(body);
-      // Lifecycle (PR #96 M1 fix):
-      //   1. Write the framed request, then half-close (FIN) so the broker's
-      //      `readOneFrame` loop wakes up. The broker waits for a trailing
-      //      sentinel byte OR FIN to confirm single-shot framing — without
-      //      a half-close it would block until its frame timeout.
-      //   2. Continue listening on the readable side. socket.end() only
-      //      shuts down the WRITABLE half; the readable half keeps receiving
-      //      ack bytes from the broker.
+      // Lifecycle (PR #96 M1 fix, updated #155):
+      //   1. Write the framed request. framing.ts readOneFrame resolves as
+      //      soon as >= need bytes arrive in the onData handler — no FIN
+      //      needed to wake up the broker's read loop.
+      //   2. Continue listening on the readable side. Ack bytes arrive while
+      //      the connection is still open.
       //   3. Resolve as soon as we have parsed the full length-prefixed ack
       //      (do NOT wait for the broker's 'end'). This removes the
       //      dependency on FIN ordering that the reviewer flagged in M1.
@@ -131,7 +129,9 @@ export async function sendToBroker(
           fail(writeErr);
           return;
         }
-        socket.end();
+        // No socket.end(): Bun (v1.3.5) socket.end() is a full close (RST) not
+        // a half-close (FIN), which causes EPIPE on the broker's ack write.
+        // framing.ts now resolves on >= need bytes in onData without needing FIN.
       });
     });
 


### PR DESCRIPTION
Closes #155.

## Summary

- **`apps/capture-worker/src/broker-client.ts`**: Removed the `socket.end()` call in the write callback. Bun v1.3.5 `socket.end()` performs a full close (RST), not a half-close (FIN), which caused an EPIPE on the broker side when it tried to write the ack. Since `framing.ts` `readOneFrame` already resolves on `>= need` bytes via `onData` (PR #154), the broker wakes up without needing any FIN signal.
- **`apps/capture-broker/src/server.ts`**: Added a no-op `socket.on('error', () => {})` immediately after `readOneFrame` returns. This absorbs EPIPE/ECONNRESET errors that arrive when a Bun client destroys its socket before the broker finishes writing the ack, preventing the unhandled error from crashing the broker process.

## Test plan

- [x] `cd apps/capture-worker && bun run typecheck` — clean
- [x] `cd apps/capture-worker && bun run test` — 27/27 pass
- [x] `cd apps/capture-broker && bun run typecheck` — clean
- [x] `cd apps/capture-broker && bun run test` — 44/44 pass
- [x] `cd apps/capture-broker && bun run build` — clean
- [x] Manual Bun isolation test: started broker on `/tmp/willbuy/broker.sock`, ran `bun run /tmp/test-broker-bun.ts` → `ACK received: {"ok":true,"capture_id":"...","a11y_object_key":"..."}` (no crash, no EPIPE)

🤖 Generated with [Claude Code](https://claude.com/claude-code)