### PR TITLE
feat(visitor-worker): add polling loop — poll visits for study.status='visiting' (#158)

### DIFF
--- a/apps/visitor-worker/src/index.ts
+++ b/apps/visitor-worker/src/index.ts
@@ -6,7 +6,13 @@
 // prior bad output passed back as user-role content only — NEVER as an
 // assistant turn) and retry up to 2 times.
 //
-// Heavy lifting lives in ./visitor.js so the package barrel stays stable.
+// `pollVisitorOnce` / `runVisitorPollingLoop` poll the visits table for rows
+// with study.status='visiting' and parsed IS NULL, run the LLM visitor, and
+// write results back. When all visits for a study are processed the study
+// advances to 'aggregating'.
+//
+// Heavy lifting lives in ./visitor.js and ./poller.js so the package barrel
+// stays stable.
 
 export { runVisit, computeLogicalRequestKey } from './visitor.js';
 export type {
@@ -16,3 +22,6 @@ export type {
   VisitStatus,
   LeaseReleaseContext,
 } from './visitor.js';
+
+export { pollVisitorOnce, runVisitorPollingLoop } from './poller.js';
+export type { PollVisitorOpts, PollVisitorResult, ObjectStorage } from './poller.js';

--- a/apps/visitor-worker/src/poller.ts
+++ b/apps/visitor-worker/src/poller.ts
@@ -163,7 +163,7 @@ export async function pollVisitorOnce(opts: PollVisitorOpts): Promise<PollVisito
     let backstoryRaw: unknown;
     try {
       backstoryRaw = JSON.parse(row.backstory_payload);
-    } catch (parseErr) {
+    } catch (_parseErr) {
       log.error(
         { event: 'visit.backstory_parse_failed', visit_id: String(visitId) },
         'backstory_payload is not valid JSON',

--- a/apps/visitor-worker/src/poller.ts
+++ b/apps/visitor-worker/src/poller.ts
@@ -163,7 +163,7 @@ export async function pollVisitorOnce(opts: PollVisitorOpts): Promise<PollVisito
     let backstoryRaw: unknown;
     try {
       backstoryRaw = JSON.parse(row.backstory_payload);
-    } catch (_parseErr) {
+    } catch {
       log.error(
         { event: 'visit.backstory_parse_failed', visit_id: String(visitId) },
         'backstory_payload is not valid JSON',

--- a/apps/visitor-worker/src/poller.ts
+++ b/apps/visitor-worker/src/poller.ts
@@ -1,0 +1,381 @@
+/**
+ * poller.ts — visitor-worker job-queue polling loop (spec §5.1, §5.11).
+ *
+ * Polls the `visits` table for rows with `parsed IS NULL` whose parent study
+ * has `status='visiting'`. For each leased row:
+ *
+ *   1. SELECT … FOR UPDATE OF v SKIP LOCKED takes a row lock that blocks any
+ *      concurrent worker from re-leasing this visit. The transaction stays
+ *      OPEN for the duration of the LLM call so the row lock is held throughout.
+ *   2. Read the a11y snapshot from object storage via the injected ObjectStorage.
+ *      If a11y_object_key is null (capture not yet linked), fail the visit with
+ *      terminal_reason='no_snapshot'.
+ *   3. Call runVisit() with the backstory + page snapshot.
+ *   4. Write back parsed, score, provider, model, cost_cents, latency_ms,
+ *      ended_at. On failure, write terminal_reason='<reason>'.
+ *   5. COMMIT — releasing the row lock.
+ *   6. In a fresh transaction, check if ALL visits for the study have
+ *      parsed IS NOT NULL. If yes → transition study 'visiting' → 'aggregating'.
+ *
+ * The idle_in_transaction_session_timeout is set to '120s' (visitor lease
+ * timeout per spec) so a wedged LLM call eventually releases the row lock
+ * for sweeper recovery.
+ */
+
+import { Pool, type PoolClient } from 'pg';
+import { Backstory } from '@willbuy/shared';
+import type { LLMProvider } from '@willbuy/llm-adapter';
+import { runVisit } from './visitor.js';
+import { buildVisitorWorkerLogger } from './logger.js';
+
+const log = buildVisitorWorkerLogger();
+
+// Re-declare the ObjectStorage interface inline to avoid a cross-package
+// dependency on apps/capture-broker. The shape must stay in sync with
+// apps/capture-broker/src/storage.ts.
+export type ObjectStorage = {
+  /** Read bytes by object key; throws if missing. */
+  get(key: string): Promise<Buffer>;
+  /** Upload bytes; returns void on success. */
+  put(key: string, body: Buffer, contentType: string): Promise<void>;
+  /** Cheap existence check. */
+  has(key: string): Promise<boolean>;
+};
+
+export type PollVisitorOpts = {
+  pool: Pool;
+  storage: ObjectStorage;
+  provider: LLMProvider;
+  signal?: AbortSignal;
+};
+
+export type PollVisitorResult =
+  | { kind: 'processed'; visitId: number; visitOk: boolean }
+  | { kind: 'empty' };
+
+/**
+ * Poll once for a pending visit (study.status='visiting', visits.parsed IS NULL),
+ * run the LLM visitor, and write results back to the DB.
+ *
+ * Lease durability: the FOR UPDATE SKIP LOCKED row lock is held for the
+ * duration of the LLM call inside a single open transaction.
+ * idle_in_transaction_session_timeout = '120s' bounds a wedged worker.
+ */
+export async function pollVisitorOnce(opts: PollVisitorOpts): Promise<PollVisitorResult> {
+  const client = await opts.pool.connect();
+  let leaseHeld = false;
+  let visitId = 0;
+  let studyId = 0;
+  let visitOk = false;
+
+  try {
+    await client.query('BEGIN');
+    leaseHeld = true;
+    // 120s visitor lease timeout per spec — bounds a wedged LLM call.
+    await client.query(`SET LOCAL idle_in_transaction_session_timeout = '120s'`);
+
+    const leaseResult = await client.query<{
+      id: string;
+      study_id: string;
+      backstory_payload: string;
+      a11y_object_key: string | null;
+    }>(
+      `SELECT v.id,
+              v.study_id,
+              b.payload    AS backstory_payload,
+              pc.a11y_storage_key AS a11y_object_key
+         FROM visits v
+         JOIN studies s    ON s.id = v.study_id
+         JOIN backstories b ON b.id = v.backstory_id
+         LEFT JOIN page_captures pc ON pc.id = v.capture_id
+        WHERE s.status = 'visiting'
+          AND v.parsed IS NULL
+        ORDER BY v.id
+        LIMIT 1
+        FOR UPDATE OF v SKIP LOCKED`,
+    );
+
+    const row = leaseResult.rows[0];
+    if (!row) {
+      await client.query('ROLLBACK');
+      leaseHeld = false;
+      return { kind: 'empty' };
+    }
+
+    visitId = Number(row.id);
+    studyId = Number(row.study_id);
+
+    // ── 2. Guard: no snapshot available yet ──────────────────────────────────
+    if (row.a11y_object_key === null) {
+      log.warn(
+        { event: 'visit.no_snapshot', visit_id: String(visitId), study_id: String(studyId) },
+        'visit has no a11y snapshot key (capture_id not linked); marking terminal_reason=no_snapshot',
+      );
+      await client.query(
+        `UPDATE visits SET terminal_reason = 'no_snapshot', ended_at = now() WHERE id = $1`,
+        [visitId],
+      );
+      await client.query('COMMIT');
+      leaseHeld = false;
+      visitOk = false;
+      // After commit, attempt study advance in case this was the last visit.
+      const advClient = await opts.pool.connect();
+      try {
+        await maybeAdvanceStudy(advClient, studyId);
+      } finally {
+        advClient.release();
+      }
+      return { kind: 'processed', visitId, visitOk };
+    }
+
+    // ── 3. Read a11y snapshot from object storage ─────────────────────────────
+    let pageSnapshot: string;
+    try {
+      const buf = await opts.storage.get(row.a11y_object_key);
+      pageSnapshot = buf.toString('utf8');
+    } catch (storageErr) {
+      log.error(
+        {
+          event: 'visit.storage_read_failed',
+          visit_id: String(visitId),
+          key: row.a11y_object_key,
+          error_class: storageErr instanceof Error ? storageErr.name : 'UnknownError',
+        },
+        'failed to read a11y snapshot from storage',
+      );
+      await client.query(
+        `UPDATE visits SET terminal_reason = 'no_snapshot', ended_at = now() WHERE id = $1`,
+        [visitId],
+      );
+      await client.query('COMMIT');
+      leaseHeld = false;
+      visitOk = false;
+      const advClient = await opts.pool.connect();
+      try {
+        await maybeAdvanceStudy(advClient, studyId);
+      } finally {
+        advClient.release();
+      }
+      return { kind: 'processed', visitId, visitOk };
+    }
+
+    // ── 4. Parse and validate backstory ──────────────────────────────────────
+    let backstoryRaw: unknown;
+    try {
+      backstoryRaw = JSON.parse(row.backstory_payload);
+    } catch (parseErr) {
+      log.error(
+        { event: 'visit.backstory_parse_failed', visit_id: String(visitId) },
+        'backstory_payload is not valid JSON',
+      );
+      await client.query(
+        `UPDATE visits SET terminal_reason = 'backstory_invalid', ended_at = now() WHERE id = $1`,
+        [visitId],
+      );
+      await client.query('COMMIT');
+      leaseHeld = false;
+      visitOk = false;
+      const advClient = await opts.pool.connect();
+      try {
+        await maybeAdvanceStudy(advClient, studyId);
+      } finally {
+        advClient.release();
+      }
+      return { kind: 'processed', visitId, visitOk };
+    }
+
+    const backstoryResult = Backstory.safeParse(backstoryRaw);
+    if (!backstoryResult.success) {
+      log.error(
+        {
+          event: 'visit.backstory_invalid',
+          visit_id: String(visitId),
+          zod_errors: backstoryResult.error.message,
+        },
+        'backstory_payload failed zod validation',
+      );
+      await client.query(
+        `UPDATE visits SET terminal_reason = 'backstory_invalid', ended_at = now() WHERE id = $1`,
+        [visitId],
+      );
+      await client.query('COMMIT');
+      leaseHeld = false;
+      visitOk = false;
+      const advClient = await opts.pool.connect();
+      try {
+        await maybeAdvanceStudy(advClient, studyId);
+      } finally {
+        advClient.release();
+      }
+      return { kind: 'processed', visitId, visitOk };
+    }
+
+    const backstory = backstoryResult.data;
+
+    // ── 5. Run the LLM visitor (lock still held; lease is durable) ───────────
+    const t0 = Date.now();
+    const result = await runVisit({
+      provider: opts.provider,
+      backstory,
+      pageSnapshot,
+      visitId: String(visitId),
+    });
+    const latencyMs = Date.now() - t0;
+
+    // ── 6. Write results back within the lease transaction ───────────────────
+    if (result.status === 'ok' && result.parsed !== undefined) {
+      await client.query(
+        `UPDATE visits
+            SET parsed      = $1::jsonb,
+                score       = $2,
+                provider    = $3,
+                model       = $4,
+                cost_cents  = $5,
+                latency_ms  = $6,
+                ended_at    = now()
+          WHERE id = $7`,
+        [
+          JSON.stringify(result.parsed),
+          // score is not computed here (that is the aggregation phase's job);
+          // will_to_buy is stored as the raw score for now.
+          result.parsed.will_to_buy ?? null,
+          opts.provider.name(),
+          opts.provider.model(),
+          null, // cost_cents: not available from MockProvider / LocalCliProvider in v0.1
+          latencyMs,
+          visitId,
+        ],
+      );
+      visitOk = true;
+    } else {
+      const reason = result.failure_reason ?? 'unknown';
+      await client.query(
+        `UPDATE visits
+            SET terminal_reason = $1,
+                provider        = $2,
+                model           = $3,
+                latency_ms      = $4,
+                ended_at        = now()
+          WHERE id = $5`,
+        [
+          reason,
+          opts.provider.name(),
+          opts.provider.model(),
+          latencyMs,
+          visitId,
+        ],
+      );
+      visitOk = false;
+    }
+
+    await client.query('COMMIT');
+    leaseHeld = false;
+  } catch (err) {
+    if (leaseHeld) {
+      try { await client.query('ROLLBACK'); } catch { /* ignore */ }
+      leaseHeld = false;
+    }
+    throw err;
+  } finally {
+    client.release();
+  }
+
+  // ── 7. Maybe advance study → 'aggregating' (separate txn after commit) ─────
+  if (visitId !== 0) {
+    const advClient = await opts.pool.connect();
+    try {
+      await maybeAdvanceStudy(advClient, studyId);
+    } finally {
+      advClient.release();
+    }
+  }
+
+  return { kind: 'processed', visitId, visitOk };
+}
+
+/**
+ * If all visits for the study have `parsed IS NOT NULL` (or have a
+ * terminal_reason set, meaning they failed irrecoverably), transition the
+ * study from 'visiting' → 'aggregating'. Idempotent.
+ *
+ * "Null parsed with a terminal_reason" means the visit failed without a
+ * parsed result — we count those as done for the purpose of advancing.
+ * Concretely: a visit is still pending iff parsed IS NULL AND terminal_reason
+ * IS NULL. When either is non-null the visit is done for this phase.
+ *
+ * Runs in its own transaction AFTER the visit-lease transaction commits
+ * so concurrent workers see freshly-committed results.
+ */
+async function maybeAdvanceStudy(
+  client: PoolClient,
+  studyId: number,
+): Promise<void> {
+  await client.query('BEGIN');
+  try {
+    // Lock the study row to serialize concurrent advance attempts.
+    await client.query(
+      `SELECT 1 FROM studies WHERE id = $1 FOR UPDATE`,
+      [studyId],
+    );
+
+    // A visit is still pending iff both parsed and terminal_reason are null
+    // (meaning the visitor phase hasn't processed it yet).
+    const pendingResult = await client.query<{ pending_count: string }>(
+      `SELECT count(*) AS pending_count
+         FROM visits
+        WHERE study_id = $1
+          AND parsed IS NULL
+          AND terminal_reason IS NULL`,
+      [studyId],
+    );
+
+    const pendingCount = Number(pendingResult.rows[0]?.pending_count ?? 1);
+
+    if (pendingCount === 0) {
+      // All visits processed → advance study to 'aggregating'.
+      await client.query(
+        `UPDATE studies SET status = 'aggregating' WHERE id = $1 AND status = 'visiting'`,
+        [studyId],
+      );
+    }
+
+    await client.query('COMMIT');
+  } catch (err) {
+    try { await client.query('ROLLBACK'); } catch { /* ignore */ }
+    throw err;
+  }
+}
+
+/**
+ * Run the visitor polling loop until the signal is aborted.
+ *
+ * Backs off 5 s on empty polls. Errors from individual visits are logged but
+ * do not crash the loop (1 s backoff on error to avoid spinning on a
+ * persistent DB or storage failure).
+ */
+export async function runVisitorPollingLoop(opts: PollVisitorOpts): Promise<void> {
+  const signal = opts.signal;
+
+  while (!signal?.aborted) {
+    try {
+      const result = await pollVisitorOnce(opts);
+      if (result.kind === 'empty') {
+        await sleepUnlessAborted(5_000, signal);
+      }
+    } catch (err) {
+      log.error(
+        { event: 'visitor_poll.error', error_class: err instanceof Error ? err.name : 'UnknownError' },
+        'visitor poll error',
+      );
+      await sleepUnlessAborted(1_000, signal);
+    }
+  }
+}
+
+function sleepUnlessAborted(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise<void>((resolve) => {
+    if (signal?.aborted) { resolve(); return; }
+    const t = setTimeout(resolve, ms);
+    signal?.addEventListener('abort', () => { clearTimeout(t); resolve(); }, { once: true });
+  });
+}

--- a/apps/visitor-worker/test/poller.test.ts
+++ b/apps/visitor-worker/test/poller.test.ts
@@ -1,0 +1,326 @@
+// apps/visitor-worker/test/poller.test.ts
+//
+// Unit tests for pollVisitorOnce (issue #158).
+//
+// These tests use an in-memory fake pool and an in-memory storage double so
+// they run without Docker or a live Postgres instance. The pool fake
+// intercepts every query string and returns scripted results.
+
+import { describe, expect, it } from 'vitest';
+
+import { pollVisitorOnce } from '../src/poller.js';
+import type { PollVisitorOpts, ObjectStorage } from '../src/poller.js';
+import { MockProvider } from './helpers/mockProvider.js';
+import {
+  SAMPLE_BACKSTORY,
+  VALID_VISITOR_OUTPUT,
+  validVisitorJsonString,
+} from './helpers/fixtures.js';
+
+// ─── In-memory storage double ────────────────────────────────────────────────
+
+function buildStorage(initial: Record<string, string> = {}): ObjectStorage {
+  const store = new Map<string, Buffer>(
+    Object.entries(initial).map(([k, v]) => [k, Buffer.from(v, 'utf8')]),
+  );
+  return {
+    async get(key) {
+      const b = store.get(key);
+      if (!b) throw new Error(`storage: key not found: ${key}`);
+      return b;
+    },
+    async put(key, body) {
+      store.set(key, Buffer.from(body));
+    },
+    async has(key) {
+      return store.has(key);
+    },
+  };
+}
+
+// ─── Fake pg Pool / PoolClient ────────────────────────────────────────────────
+//
+// The fake intercepts query strings via pattern matching and returns scripted
+// rows. Each test builds its own script so patterns are scoped per scenario.
+
+type QueryRow = Record<string, string | null | number>;
+
+interface QueryScript {
+  /** Substring or RegExp that must match the SQL string. */
+  match: string | RegExp;
+  /** Rows to return (empty means rowCount=0, rows=[]). */
+  rows: QueryRow[];
+}
+
+interface FakePoolOpts {
+  /**
+   * Scripts are matched in order; first match wins. Unmatched queries
+   * return { rows: [], rowCount: 0 } which is the benign default for
+   * BEGIN/COMMIT/ROLLBACK/SET/UPDATE statements.
+   */
+  scripts: QueryScript[];
+  /** Called with every (sql, params) pair so tests can assert on side-effects. */
+  onQuery?: (sql: string, params: unknown[] | undefined) => void;
+}
+
+function buildFakePool(opts: FakePoolOpts): import('pg').Pool {
+  const makeClient = () => {
+    const client = {
+      async query(sql: string, params?: unknown[]) {
+        opts.onQuery?.(sql, params);
+        for (const script of opts.scripts) {
+          const matched =
+            typeof script.match === 'string'
+              ? sql.includes(script.match)
+              : script.match.test(sql);
+          if (matched) {
+            return { rows: script.rows, rowCount: script.rows.length };
+          }
+        }
+        // Default: empty result (safe for BEGIN/COMMIT/SET/UPDATE)
+        return { rows: [], rowCount: 0 };
+      },
+      release() {},
+    };
+    return client;
+  };
+
+  return {
+    async connect() {
+      return makeClient() as unknown as import('pg').PoolClient;
+    },
+  } as unknown as import('pg').Pool;
+}
+
+// ─── Helpers ──────────────────────────────────────────────────────────────────
+
+const SAMPLE_A11Y_KEY = 'a11y/study-1/capture-1.json';
+const SAMPLE_A11Y_TEXT = 'a11y-tree: Pricing page. Tiers: hobby, starter, scale.';
+
+function makeBackstoryPayload(): string {
+  return JSON.stringify(SAMPLE_BACKSTORY);
+}
+
+// ─── Tests ────────────────────────────────────────────────────────────────────
+
+describe('pollVisitorOnce — empty queue', () => {
+  it('returns { kind: "empty" } when no visits are pending', async () => {
+    const pool = buildFakePool({
+      // The lease query returns no rows → empty.
+      scripts: [
+        { match: 'FOR UPDATE OF v SKIP LOCKED', rows: [] },
+      ],
+    });
+
+    const provider = new MockProvider({ responses: [] });
+    const storage = buildStorage();
+
+    const result = await pollVisitorOnce({
+      pool,
+      storage,
+      provider,
+    } satisfies PollVisitorOpts);
+
+    expect(result.kind).toBe('empty');
+    // Provider must never be called on an empty queue.
+    expect(provider.calls).toHaveLength(0);
+  });
+});
+
+describe('pollVisitorOnce — null a11y_object_key (no_snapshot)', () => {
+  it('returns { kind: "processed", visitOk: false } with terminal_reason=no_snapshot', async () => {
+    const queries: string[] = [];
+
+    const pool = buildFakePool({
+      scripts: [
+        {
+          match: 'FOR UPDATE OF v SKIP LOCKED',
+          rows: [
+            {
+              id: '42',
+              study_id: '7',
+              backstory_payload: makeBackstoryPayload(),
+              a11y_object_key: null,
+            },
+          ],
+        },
+        // maybeAdvanceStudy: no pending visits (all processed)
+        { match: 'pending_count', rows: [{ pending_count: '0' }] },
+      ],
+      onQuery: (sql) => queries.push(sql),
+    });
+
+    const provider = new MockProvider({ responses: [] });
+    const storage = buildStorage(); // empty — should not be accessed
+
+    const result = await pollVisitorOnce({ pool, storage, provider });
+
+    expect(result).toEqual({ kind: 'processed', visitId: 42, visitOk: false });
+    // Provider must NOT be called.
+    expect(provider.calls).toHaveLength(0);
+    // terminal_reason update must have been issued.
+    const terminalUpdate = queries.find((q) => q.includes('terminal_reason'));
+    expect(terminalUpdate).toBeDefined();
+    // Storage must not be accessed.
+  });
+});
+
+describe('pollVisitorOnce — happy path', () => {
+  it('calls runVisit, writes parsed/score/provider/model back, advances study', async () => {
+    const queries: string[] = [];
+    const updateParams: unknown[][] = [];
+
+    const pool = buildFakePool({
+      scripts: [
+        {
+          match: 'FOR UPDATE OF v SKIP LOCKED',
+          rows: [
+            {
+              id: '99',
+              study_id: '5',
+              backstory_payload: makeBackstoryPayload(),
+              a11y_object_key: SAMPLE_A11Y_KEY,
+            },
+          ],
+        },
+        // maybeAdvanceStudy pending check: 0 pending → study advances
+        { match: 'pending_count', rows: [{ pending_count: '0' }] },
+      ],
+      onQuery: (sql, params) => {
+        queries.push(sql);
+        if (sql.includes('UPDATE visits') && params) {
+          updateParams.push(params);
+        }
+      },
+    });
+
+    const provider = new MockProvider({
+      responses: [
+        { raw: validVisitorJsonString(), transportAttempts: 1, status: 'ok' },
+      ],
+    });
+    const storage = buildStorage({ [SAMPLE_A11Y_KEY]: SAMPLE_A11Y_TEXT });
+
+    const result = await pollVisitorOnce({ pool, storage, provider });
+
+    expect(result).toEqual({ kind: 'processed', visitId: 99, visitOk: true });
+
+    // Provider must have been called exactly once (happy path, no repair).
+    expect(provider.calls).toHaveLength(1);
+
+    // The UPDATE visits must contain the parsed output.
+    const visitUpdate = queries.find((q) => q.includes('UPDATE visits') && q.includes('parsed'));
+    expect(visitUpdate).toBeDefined();
+
+    // Check that score (will_to_buy) was passed correctly.
+    const updateParam = updateParams[0];
+    expect(updateParam).toBeDefined();
+    // First param is the parsed JSON string
+    const parsedArg = JSON.parse(updateParam![0] as string);
+    expect(parsedArg).toEqual(VALID_VISITOR_OUTPUT);
+    // Second param is the score (will_to_buy = 7 from fixture)
+    expect(updateParam![1]).toBe(VALID_VISITOR_OUTPUT.will_to_buy);
+    // Third param is provider name
+    expect(updateParam![2]).toBe(provider.name());
+    // Fourth param is model name
+    expect(updateParam![3]).toBe(provider.model());
+
+    // Study advance UPDATE must have been issued.
+    const studyUpdate = queries.find(
+      (q) => q.includes('UPDATE studies') && q.includes('aggregating'),
+    );
+    expect(studyUpdate).toBeDefined();
+  });
+});
+
+describe('pollVisitorOnce — LLM transport failure', () => {
+  it('writes terminal_reason and visitOk=false when provider returns error', async () => {
+    const queries: string[] = [];
+
+    const pool = buildFakePool({
+      scripts: [
+        {
+          match: 'FOR UPDATE OF v SKIP LOCKED',
+          rows: [
+            {
+              id: '77',
+              study_id: '3',
+              backstory_payload: makeBackstoryPayload(),
+              a11y_object_key: SAMPLE_A11Y_KEY,
+            },
+          ],
+        },
+        { match: 'pending_count', rows: [{ pending_count: '1' }] },
+      ],
+      onQuery: (sql) => queries.push(sql),
+    });
+
+    const provider = new MockProvider({
+      responses: [{ raw: '', transportAttempts: 1, status: 'error' }],
+    });
+    const storage = buildStorage({ [SAMPLE_A11Y_KEY]: SAMPLE_A11Y_TEXT });
+
+    const result = await pollVisitorOnce({ pool, storage, provider });
+
+    expect(result).toEqual({ kind: 'processed', visitId: 77, visitOk: false });
+
+    // Provider was called once.
+    expect(provider.calls).toHaveLength(1);
+
+    // terminal_reason update must have been issued (failure path: UPDATE visits SET terminal_reason=...).
+    const terminalUpdate = queries.find(
+      (q) => q.includes('UPDATE visits') && q.includes('terminal_reason'),
+    );
+    expect(terminalUpdate).toBeDefined();
+
+    // Study must NOT have advanced (still 1 pending).
+    const studyUpdate = queries.find(
+      (q) => q.includes('UPDATE studies') && q.includes('aggregating'),
+    );
+    expect(studyUpdate).toBeUndefined();
+  });
+});
+
+describe('pollVisitorOnce — study does not advance when visits still pending', () => {
+  it('skips study UPDATE when pending_count > 0', async () => {
+    const queries: string[] = [];
+
+    const pool = buildFakePool({
+      scripts: [
+        {
+          match: 'FOR UPDATE OF v SKIP LOCKED',
+          rows: [
+            {
+              id: '55',
+              study_id: '9',
+              backstory_payload: makeBackstoryPayload(),
+              a11y_object_key: SAMPLE_A11Y_KEY,
+            },
+          ],
+        },
+        // Still 2 pending visits after this one is processed
+        { match: 'pending_count', rows: [{ pending_count: '2' }] },
+      ],
+      onQuery: (sql) => queries.push(sql),
+    });
+
+    const provider = new MockProvider({
+      responses: [
+        { raw: validVisitorJsonString(), transportAttempts: 1, status: 'ok' },
+      ],
+    });
+    const storage = buildStorage({ [SAMPLE_A11Y_KEY]: SAMPLE_A11Y_TEXT });
+
+    const result = await pollVisitorOnce({ pool, storage, provider });
+
+    expect(result.kind).toBe('processed');
+    if (result.kind === 'processed') {
+      expect(result.visitOk).toBe(true);
+    }
+
+    const studyUpdate = queries.find(
+      (q) => q.includes('UPDATE studies') && q.includes('aggregating'),
+    );
+    expect(studyUpdate).toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `pollVisitorOnce` / `runVisitorPollingLoop` to `apps/visitor-worker/src/poller.ts`, mirroring the `capture-worker` poller pattern exactly
- Leases a `visits` row with `SELECT … FOR UPDATE OF v SKIP LOCKED` (idle timeout `120s`), joins `backstories` and `page_captures` to get backstory payload + `a11y_storage_key`
- Reads the a11y snapshot from the injected `ObjectStorage` (`storage.get(key) → Buffer → .toString('utf8')`); fails the visit with `terminal_reason='no_snapshot'` when the key is null
- Parses and validates the backstory with the `Backstory` zod schema
- Calls `runVisit({ provider, backstory, pageSnapshot, visitId })` with the provider injected via `PollVisitorOpts`
- On success: writes `parsed`, `score` (will_to_buy), `provider`, `model`, `latency_ms`, `ended_at` back inside the lease transaction
- On failure: writes `terminal_reason`, `provider`, `model`, `latency_ms`, `ended_at`
- After the lease commits: `maybeAdvanceStudy` runs in a separate transaction and advances `visiting → aggregating` when all visits have `parsed IS NOT NULL OR terminal_reason IS NOT NULL`
- Exports `pollVisitorOnce`, `runVisitorPollingLoop`, `PollVisitorOpts`, `PollVisitorResult`, `ObjectStorage` from the package barrel

## Test plan

- [ ] `bun run typecheck` in `apps/visitor-worker` — clean (verified)
- [ ] `bun run test` in `apps/visitor-worker` — 22 tests pass across 9 files (verified)
- [ ] `test/poller.test.ts` covers: empty queue → `{ kind: 'empty' }`, null `a11y_object_key` → `terminal_reason='no_snapshot'`, happy path (parsed written + study advanced), transport failure (terminal_reason written, study not advanced), study not advanced when pending count > 0

🤖 Generated with [Claude Code](https://claude.com/claude-code)