### PR TITLE
feat(visitor-worker): add bin.ts process entrypoint (#162)

### DIFF
--- a/apps/visitor-worker/package.json
+++ b/apps/visitor-worker/package.json
@@ -13,6 +13,7 @@
     }
   },
   "scripts": {
+    "build": "tsc -p tsconfig.build.json",
     "test": "vitest run",
     "typecheck": "tsc -p tsconfig.test.json"
   },
@@ -20,6 +21,7 @@
     "@willbuy/llm-adapter": "workspace:*",
     "@willbuy/log": "workspace:*",
     "@willbuy/shared": "workspace:*",
+    "pg": "^8.20.0",
     "pino": "^9.5.0",
     "zod": "^3.23.8"
   },
@@ -27,7 +29,6 @@
     "@types/node": "^22.10.2",
     "@types/pg": "^8.20.0",
     "@willbuy/api": "workspace:*",
-    "pg": "^8.20.0",
     "typescript": "^5.7.2",
     "vitest": "^2.1.8"
   }

--- a/apps/visitor-worker/src/bin.ts
+++ b/apps/visitor-worker/src/bin.ts
@@ -50,7 +50,7 @@ export function createVisitorWorker(env: NodeJS.ProcessEnv): VisitorWorkerCompon
         throw err;
       }
     },
-    async put(_key: string, _body: Buffer, _contentType: string): Promise<void> {
+    async put(): Promise<void> {
       throw new Error('visitor-worker storage is read-only');
     },
   };

--- a/apps/visitor-worker/src/bin.ts
+++ b/apps/visitor-worker/src/bin.ts
@@ -1,0 +1,108 @@
+/**
+ * Visitor Worker — CLI entrypoint.
+ *
+ * Production: started by systemd `ExecStart=/usr/bin/node dist/bin.js`.
+ * Environment is injected from `/etc/willbuy/visitor-worker.env`.
+ *
+ * Reads:
+ *   DATABASE_URL             — required; postgres connection string
+ *   CAPTURE_STORAGE_PATH     — optional; default /tmp/willbuy/captures
+ *   WILLBUY_LLM_BIN          — optional; LLM CLI binary (default: claude)
+ *   WILLBUY_LLM_MODEL        — optional; model identity token
+ */
+
+import { readFile, stat } from 'node:fs/promises';
+import { join } from 'node:path';
+import { Pool } from 'pg';
+import { LocalCliProvider } from '@willbuy/llm-adapter';
+import { runVisitorPollingLoop } from './poller.js';
+import type { ObjectStorage } from './poller.js';
+
+export type VisitorWorkerComponents = {
+  pool: Pool;
+  storage: ObjectStorage;
+  provider: LocalCliProvider;
+};
+
+/**
+ * Validate env and build the wiring components.
+ * Throws if DATABASE_URL is missing.
+ * Exported for unit testing.
+ */
+export function createVisitorWorker(env: NodeJS.ProcessEnv): VisitorWorkerComponents {
+  const dbUrl = env['DATABASE_URL'];
+  if (!dbUrl) {
+    throw new Error('DATABASE_URL is required');
+  }
+
+  const captureBasePath = env['CAPTURE_STORAGE_PATH'] ?? '/tmp/willbuy/captures';
+
+  const storage: ObjectStorage = {
+    async get(key: string): Promise<Buffer> {
+      return readFile(join(captureBasePath, key));
+    },
+    async has(key: string): Promise<boolean> {
+      try {
+        await stat(join(captureBasePath, key));
+        return true;
+      } catch (err: unknown) {
+        if ((err as NodeJS.ErrnoException).code === 'ENOENT') return false;
+        throw err;
+      }
+    },
+    async put(_key: string, _body: Buffer, _contentType: string): Promise<void> {
+      throw new Error('visitor-worker storage is read-only');
+    },
+  };
+
+  const pool = new Pool({ connectionString: dbUrl });
+  const provider = new LocalCliProvider();
+
+  return { pool, storage, provider };
+}
+
+// ── Process entrypoint ────────────────────────────────────────────────────────
+// Guard: only execute when this file is the process entry point, not when
+// imported by tests or other modules.
+
+import { fileURLToPath } from 'node:url';
+
+const isMain =
+  process.argv[1] !== undefined &&
+  fileURLToPath(import.meta.url) === process.argv[1];
+
+if (isMain) {
+  const dbUrl = process.env['DATABASE_URL'];
+  if (!dbUrl) {
+    process.stderr.write('[willbuy-visitor-worker] DATABASE_URL is required\n');
+    process.exit(1);
+  }
+
+  // Log only the host portion — never credentials.
+  const hostOnly = (() => {
+    try {
+      return new URL(dbUrl).host;
+    } catch {
+      return '<unparseable>';
+    }
+  })();
+
+  process.stdout.write(`[willbuy-visitor-worker] starting on DATABASE_URL=${hostOnly}\n`);
+
+  const { pool, storage, provider } = createVisitorWorker(process.env);
+
+  const controller = new AbortController();
+
+  const loopPromise = runVisitorPollingLoop({ pool, storage, provider, signal: controller.signal });
+
+  const shutdown = async (signal: string): Promise<void> => {
+    process.stdout.write(`[willbuy-visitor-worker] ${signal} received, shutting down\n`);
+    controller.abort();
+    await loopPromise;
+    await pool.end();
+    process.exit(0);
+  };
+
+  process.on('SIGTERM', () => void shutdown('SIGTERM'));
+  process.on('SIGINT', () => void shutdown('SIGINT'));
+}

--- a/apps/visitor-worker/test/bin.test.ts
+++ b/apps/visitor-worker/test/bin.test.ts
@@ -1,0 +1,58 @@
+/**
+ * bin.test.ts — unit tests for the createVisitorWorker factory (spec §5.1, §5.11).
+ *
+ * We test the exported `createVisitorWorker` factory rather than spawning the
+ * process entrypoint directly, which avoids needing a pre-built dist/ and keeps
+ * the suite fast (no subprocesses, no real Postgres).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { createVisitorWorker } from '../src/bin.js';
+
+describe('createVisitorWorker — env validation', () => {
+  it('throws when DATABASE_URL is missing', () => {
+    expect(() => createVisitorWorker({})).toThrow('DATABASE_URL is required');
+  });
+
+  it('throws when DATABASE_URL is an empty string', () => {
+    expect(() => createVisitorWorker({ DATABASE_URL: '' })).toThrow('DATABASE_URL is required');
+  });
+});
+
+describe('createVisitorWorker — wiring', () => {
+  it('returns pool, storage, and provider when DATABASE_URL is set', () => {
+    const result = createVisitorWorker({
+      DATABASE_URL: 'postgresql://localhost:5432/test',
+    });
+
+    expect(result).toHaveProperty('pool');
+    expect(result).toHaveProperty('storage');
+    expect(result).toHaveProperty('provider');
+
+    // Tear down the pool (no real connection needed for this check).
+    void result.pool.end();
+  });
+
+  it('storage.put throws read-only error', async () => {
+    const { pool, storage } = createVisitorWorker({
+      DATABASE_URL: 'postgresql://localhost:5432/test',
+    });
+
+    await expect(storage.put('key', Buffer.from('x'), 'text/plain')).rejects.toThrow(
+      'visitor-worker storage is read-only',
+    );
+
+    void pool.end();
+  });
+
+  it('provider exposes name() and model()', () => {
+    const { pool, provider } = createVisitorWorker({
+      DATABASE_URL: 'postgresql://localhost:5432/test',
+    });
+
+    expect(typeof provider.name()).toBe('string');
+    expect(typeof provider.model()).toBe('string');
+
+    void pool.end();
+  });
+});

--- a/apps/visitor-worker/tsconfig.build.json
+++ b/apps/visitor-worker/tsconfig.build.json
@@ -1,0 +1,11 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "composite": true,
+    "noEmit": false,
+    "rootDir": "src",
+    "outDir": "dist"
+  },
+  "include": ["src/**/*"],
+  "exclude": ["dist", "node_modules", "test"]
+}


### PR DESCRIPTION
## Summary

- Adds `apps/visitor-worker/src/bin.ts` — the visiting-phase process entrypoint (spec §5.1, §5.11)
- Exports `createVisitorWorker(env)` factory that validates `DATABASE_URL`, builds a read-only `ObjectStorage` backed by the local filesystem, creates a `pg.Pool`, and instantiates `LocalCliProvider`
- Process entrypoint wires the factory to `runVisitorPollingLoop`, handles `SIGTERM`/`SIGINT` via `AbortController`, and logs the host portion of `DATABASE_URL` (no credentials) on startup
- Adds `apps/visitor-worker/tsconfig.build.json` (mirrors `apps/capture-broker/tsconfig.build.json`) and `build` script (`tsc -p tsconfig.build.json → dist/`)
- Moves `pg` from `devDependencies` to `dependencies` (runtime dependency)

## Test evidence

```
$ bun run test

 RUN  v2.1.9 /Users/nik/github/willbuy/apps/visitor-worker

 ✓ test/logger.test.ts (2 tests) 3ms
 ✓ test/bin.test.ts (5 tests) 3ms
 ✓ test/logicalRequestKey.test.ts (6 tests) 2ms
 ✓ test/runVisit.transportError.test.ts (1 test) 2ms
 ✓ test/runVisit.schemaFail.test.ts (1 test) 3ms
 ✓ test/runVisit.happyPath.test.ts (1 test) 3ms
 ✓ test/runVisit.schemaRepair.test.ts (1 test) 4ms
 ✓ test/poller.test.ts (5 tests) 7ms
 ✓ test/skeleton.test.ts (1 test) 20ms
 ✓ test/lease-release.test.ts (4 tests) 2105ms

 Test Files  10 passed (10)
      Tests  27 passed (27)
```

## Spec refs

- §5.1 — worker process entrypoints
- §5.11 — visitor worker process lifecycle

## Checklist

- [x] `bun run typecheck` passes
- [x] `bun run build` produces `dist/bin.js`
- [x] All 27 tests pass (5 new in `bin.test.ts`)
- [x] No secrets — `DATABASE_URL` logged as host-only
- [x] `pg` moved to runtime `dependencies`

Closes #162

🤖 Generated with [Claude Code](https://claude.com/claude-code)