### PR TITLE
fix(visitor-worker): poller SELECT leaks terminal visits + JSONB backstory cast (#164)

### DIFF
--- a/apps/visitor-worker/src/poller.ts
+++ b/apps/visitor-worker/src/poller.ts
@@ -80,9 +80,19 @@ export async function pollVisitorOnce(opts: PollVisitorOpts): Promise<PollVisito
       backstory_payload: string;
       a11y_object_key: string | null;
     }>(
+      // b.payload::text — backstories.payload is JSONB; the pg driver deserializes
+      // JSONB columns to JS objects automatically. Casting to text keeps it as a
+      // raw JSON string so the downstream JSON.parse() call works correctly.
+      // (Without ::text, JSON.parse(obj) stringifies the object to "[object Object]"
+      // and throws a SyntaxError — see issue #164, bug 2.)
+      //
+      // v.terminal_reason IS NULL — exclude visits that already failed irrecoverably
+      // (e.g. backstory_invalid). Without this guard the poller re-leases the same
+      // terminal visit on every poll, loops forever, and never makes progress.
+      // (See issue #164, bug 1.)
       `SELECT v.id,
               v.study_id,
-              b.payload    AS backstory_payload,
+              b.payload::text AS backstory_payload,
               pc.a11y_storage_key AS a11y_object_key
          FROM visits v
          JOIN studies s    ON s.id = v.study_id
@@ -90,6 +100,7 @@ export async function pollVisitorOnce(opts: PollVisitorOpts): Promise<PollVisito
          LEFT JOIN page_captures pc ON pc.id = v.capture_id
         WHERE s.status = 'visiting'
           AND v.parsed IS NULL
+          AND v.terminal_reason IS NULL
         ORDER BY v.id
         LIMIT 1
         FOR UPDATE OF v SKIP LOCKED`,

--- a/apps/visitor-worker/src/poller.ts
+++ b/apps/visitor-worker/src/poller.ts
@@ -80,16 +80,8 @@ export async function pollVisitorOnce(opts: PollVisitorOpts): Promise<PollVisito
       backstory_payload: string;
       a11y_object_key: string | null;
     }>(
-      // b.payload::text — backstories.payload is JSONB; the pg driver deserializes
-      // JSONB columns to JS objects automatically. Casting to text keeps it as a
-      // raw JSON string so the downstream JSON.parse() call works correctly.
-      // (Without ::text, JSON.parse(obj) stringifies the object to "[object Object]"
-      // and throws a SyntaxError — see issue #164, bug 2.)
-      //
-      // v.terminal_reason IS NULL — exclude visits that already failed irrecoverably
-      // (e.g. backstory_invalid). Without this guard the poller re-leases the same
-      // terminal visit on every poll, loops forever, and never makes progress.
-      // (See issue #164, bug 1.)
+      // ::text — pg driver auto-deserializes JSONB to objects; JSON.parse needs a string (#164 bug2).
+      // terminal_reason IS NULL — skip already-failed visits so they aren't re-leased (#164 bug1).
       `SELECT v.id,
               v.study_id,
               b.payload::text AS backstory_payload,

--- a/apps/visitor-worker/test/poller.test.ts
+++ b/apps/visitor-worker/test/poller.test.ts
@@ -355,6 +355,51 @@ describe('pollVisitorOnce — bug #164 fix 2: JSONB backstory_payload parsed cor
   });
 });
 
+describe('pollVisitorOnce — backstory_invalid (Zod parse failure)', () => {
+  it('marks terminal_reason=backstory_invalid when payload fails Backstory schema', async () => {
+    // Regression guard for the dogfood backstory bug: if the DB stores
+    // {"preset_id":"saas_founder_post_pmf"} instead of expanded fields,
+    // the Zod parse fails and the visit should be marked terminal.
+    const queries: string[] = [];
+    const invalidPayload = JSON.stringify({ preset_id: 'saas_founder_post_pmf' });
+
+    const pool = buildFakePool({
+      scripts: [
+        {
+          match: 'FOR UPDATE OF v SKIP LOCKED',
+          rows: [
+            {
+              id: '77',
+              study_id: '5',
+              backstory_payload: invalidPayload,
+              a11y_object_key: SAMPLE_A11Y_KEY,
+            },
+          ],
+        },
+        { match: 'pending_count', rows: [{ pending_count: '0' }] },
+      ],
+      onQuery: (sql) => queries.push(sql),
+    });
+
+    const provider = new MockProvider({ responses: [] });
+    const storage = buildStorage({ [SAMPLE_A11Y_KEY]: SAMPLE_A11Y_TEXT });
+
+    const result = await pollVisitorOnce({ pool, storage, provider });
+
+    expect(result.kind).toBe('processed');
+    if (result.kind === 'processed') {
+      expect(result.visitOk).toBe(false);
+    }
+
+    const terminalUpdate = queries.find(
+      (q) => q.includes('terminal_reason') && q.includes('backstory_invalid'),
+    );
+    expect(terminalUpdate).toBeTruthy();
+    // Provider must NOT have been called — invalid backstory bails before LLM.
+    expect(provider.calls).toHaveLength(0);
+  });
+});
+
 describe('pollVisitorOnce — study does not advance when visits still pending', () => {
   it('skips study UPDATE when pending_count > 0', async () => {
     const queries: string[] = [];

--- a/apps/visitor-worker/test/poller.test.ts
+++ b/apps/visitor-worker/test/poller.test.ts
@@ -281,6 +281,80 @@ describe('pollVisitorOnce — LLM transport failure', () => {
   });
 });
 
+// ─── Bug #164 regression tests ───────────────────────────────────────────────
+
+describe('pollVisitorOnce — bug #164 fix 1: terminal visits are not re-leased', () => {
+  it('returns { kind: "empty" } when the only available visit has terminal_reason set', async () => {
+    // Arrange: The WHERE clause now includes `AND v.terminal_reason IS NULL`.
+    // A visit with terminal_reason='backstory_invalid' must NOT be selected.
+    // We simulate this by returning 0 rows from the lease query — as Postgres
+    // would when every candidate row has terminal_reason IS NOT NULL.
+    const pool = buildFakePool({
+      scripts: [
+        // The lease SELECT returns no rows because the only visit has
+        // terminal_reason='backstory_invalid' and is filtered out by the fix.
+        { match: 'FOR UPDATE OF v SKIP LOCKED', rows: [] },
+      ],
+    });
+
+    const provider = new MockProvider({ responses: [] });
+    const storage = buildStorage();
+
+    const result = await pollVisitorOnce({ pool, storage, provider });
+
+    // Must not process the terminal visit — must return empty.
+    expect(result.kind).toBe('empty');
+    // Provider must never be called.
+    expect(provider.calls).toHaveLength(0);
+  });
+});
+
+describe('pollVisitorOnce — bug #164 fix 2: JSONB backstory_payload parsed correctly via ::text cast', () => {
+  it('processes normally when backstory_payload arrives as a JSON string (from ::text cast)', async () => {
+    // Arrange: b.payload::text means the pg driver gives us a raw JSON string,
+    // not a pre-parsed JS object.  JSON.parse(string) succeeds; JSON.parse(object)
+    // would stringify the object to "[object Object]" and throw SyntaxError.
+    // The mock DB returns a JSON string — exactly what ::text produces.
+    const queries: string[] = [];
+
+    const pool = buildFakePool({
+      scripts: [
+        {
+          match: 'FOR UPDATE OF v SKIP LOCKED',
+          rows: [
+            {
+              id: '88',
+              study_id: '4',
+              // backstory_payload is a JSON string, as returned by b.payload::text.
+              backstory_payload: makeBackstoryPayload(),
+              a11y_object_key: SAMPLE_A11Y_KEY,
+            },
+          ],
+        },
+        { match: 'pending_count', rows: [{ pending_count: '0' }] },
+      ],
+      onQuery: (sql) => queries.push(sql),
+    });
+
+    const provider = new MockProvider({
+      responses: [
+        { raw: validVisitorJsonString(), transportAttempts: 1, status: 'ok' },
+      ],
+    });
+    const storage = buildStorage({ [SAMPLE_A11Y_KEY]: SAMPLE_A11Y_TEXT });
+
+    const result = await pollVisitorOnce({ pool, storage, provider });
+
+    // Must succeed — JSON.parse on the string payload must not throw.
+    expect(result).toEqual({ kind: 'processed', visitId: 88, visitOk: true });
+    // Provider was called — backstory was parsed successfully.
+    expect(provider.calls).toHaveLength(1);
+    // parsed UPDATE must have been issued.
+    const visitUpdate = queries.find((q) => q.includes('UPDATE visits') && q.includes('parsed'));
+    expect(visitUpdate).toBeDefined();
+  });
+});
+
 describe('pollVisitorOnce — study does not advance when visits still pending', () => {
   it('skips study UPDATE when pending_count > 0', async () => {
     const queries: string[] = [];


### PR DESCRIPTION
## Summary

- **Bug 1 (spec §5.11):** The lease SELECT was missing `AND v.terminal_reason IS NULL`, so visits that had already been marked terminal (e.g. `backstory_invalid`) were re-leased on every poll tick — creating a tight infinite loop without progress.
- **Bug 2 (spec §5.11):** `backstories.payload` is a JSONB column; the `pg` driver auto-deserializes it to a JS object before the code could call `JSON.parse()`. Calling `JSON.parse(object)` stringifies it to `"[object Object]"` → SyntaxError. Fixed by casting to `b.payload::text` in SQL so the value stays a raw JSON string.

## Test plan

- [x] New test: `bug #164 fix 1` — mock returns 0 rows from lease query (simulating a DB where every candidate has `terminal_reason` set); `pollVisitorOnce` returns `{ kind: 'empty' }` and never calls the LLM provider.
- [x] New test: `bug #164 fix 2` — mock returns `backstory_payload` as a JSON string (matching what `::text` produces); full happy-path flow completes, `visitOk: true`, provider called once.
- [x] All 24 existing tests continue to pass (`bun run test` in `apps/visitor-worker`).

Closes #164