### PR TITLE
fix(aggregator): column name mismatches + missing conv_score/share_token_hash (#167)

### DIFF
--- a/apps/aggregator/src/aggregator/main.py
+++ b/apps/aggregator/src/aggregator/main.py
@@ -14,6 +14,7 @@ function trusts that the caller (API service) has already acquired the row.
 from __future__ import annotations
 
 import argparse
+import hashlib
 import json
 import os
 import secrets
@@ -191,14 +192,12 @@ def run_study(
         ledger = _PgLedger(conn, study_id)
     clusters = _cluster_with_labels(findings, llm_caller=llm_caller, ledger=ledger)
 
-    payload = {
-        "paired_delta": paired.to_dict(),
-        "clusters": clusters,
-    }
+    payload = paired.to_dict()
 
     conv_score = float(sum(_score_visit(v["output"]) for v in visits) / len(visits)) if visits else 0.0
 
-    share_token_hash = secrets.token_hex(16)
+    raw_token = secrets.token_urlsafe(32)
+    share_token_hash = hashlib.sha256(raw_token.encode()).hexdigest()
 
     db.execute(
         conn,

--- a/apps/aggregator/src/aggregator/main.py
+++ b/apps/aggregator/src/aggregator/main.py
@@ -56,6 +56,18 @@ class _PgLedger:
         )
 
 
+class _NoOpLedger:
+    """No-op ledger for the CLI path.
+
+    provider_attempts requires account_id (NOT NULL) which the CLI path
+    doesn't have. The API service wires the real ledger; the CLI aggregator
+    skips ledger writes (issue #178).
+    """
+
+    def record(self, row: dict) -> None:
+        pass
+
+
 def _read_visits(conn: Any, study_id: str) -> list[dict]:
     rows = db.fetchall(
         conn,
@@ -137,6 +149,7 @@ def run_study(
     study_id: str,
     conn: Any,
     llm_caller: LLMCaller,
+    ledger: Any = None,
 ) -> None:
     """Finalize a study: cluster findings, label, compute paired stats, write report.
 
@@ -148,7 +161,8 @@ def run_study(
     paired = paired_delta(paired_input)
 
     findings = _collect_findings(visits)
-    ledger = _PgLedger(conn, study_id)
+    if ledger is None:
+        ledger = _PgLedger(conn, study_id)
     clusters = _cluster_with_labels(findings, llm_caller=llm_caller, ledger=ledger)
 
     payload = {
@@ -206,7 +220,7 @@ def cli(argv: list[str] | None = None) -> int:
 
     conn = _connect_from_env()
     try:
-        run_study(study_id=args.study_id, conn=conn, llm_caller=_stub_llm_caller)
+        run_study(study_id=args.study_id, conn=conn, llm_caller=_stub_llm_caller, ledger=_NoOpLedger())
     finally:
         conn.close()
     return 0

--- a/apps/aggregator/src/aggregator/main.py
+++ b/apps/aggregator/src/aggregator/main.py
@@ -144,6 +144,32 @@ def _cluster_with_labels(
     return out
 
 
+# Mirrors scoreVisit() in packages/shared/src/scoring.ts (amendment A1).
+_PAID_TIERS: frozenset[str] = frozenset({"express", "starter", "scale", "enterprise"})
+_NEXT_ACTION_WEIGHTS: dict[str, float] = {
+    "purchase_paid_today": 1.0,
+    "contact_sales": 0.8,
+    "book_demo": 0.8,
+    "start_paid_trial": 0.6,
+    "bookmark_compare_later": 0.0,
+    "start_free_hobby": 0.0,
+    "ask_teammate": 0.2,
+    "leave": 0.0,
+}
+
+
+def _score_visit(output: dict) -> float:
+    """Weighted conversion score for one visit (mirrors scoreVisit() in scoring.ts)."""
+    action = output.get("next_action", "leave")
+    tier_today = output.get("tier_picked_if_buying_today", "none") or "none"
+    tier_considered = output.get("highest_tier_willing_to_consider", "none") or "none"
+    if action == "bookmark_compare_later":
+        return 0.3 if tier_today in _PAID_TIERS else 0.0
+    if action == "start_free_hobby":
+        return 0.2 if tier_considered in _PAID_TIERS else 0.0
+    return _NEXT_ACTION_WEIGHTS.get(action, 0.0)
+
+
 def run_study(
     *,
     study_id: str,
@@ -170,8 +196,7 @@ def run_study(
         "clusters": clusters,
     }
 
-    scores = [v["output"].get("will_to_buy") for v in visits if v["output"].get("will_to_buy") is not None]
-    conv_score = float(sum(scores) / len(scores)) if scores else 0.0
+    conv_score = float(sum(_score_visit(v["output"]) for v in visits) / len(visits)) if visits else 0.0
 
     share_token_hash = secrets.token_hex(16)
 

--- a/apps/aggregator/src/aggregator/main.py
+++ b/apps/aggregator/src/aggregator/main.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 import argparse
 import json
 import os
+import secrets
 import sys
 from collections import defaultdict
 from typing import Any
@@ -58,22 +59,25 @@ class _PgLedger:
 def _read_visits(conn: Any, study_id: str) -> list[dict]:
     rows = db.fetchall(
         conn,
-        "SELECT id, variant, backstory_id, status, output_json FROM visits WHERE study_id=%s",
+        "SELECT id, variant_idx, backstory_id, status, parsed FROM visits WHERE study_id=%s",
         (study_id,),
     )
     out: list[dict] = []
     for row in rows:
-        _id, variant, backstory_id, status, output_json = row
+        _id, variant_idx, backstory_id, status, parsed_col = row
         if status != "ok":
             continue
-        try:
-            parsed = json.loads(output_json)
-        except (TypeError, ValueError):
-            continue
+        if isinstance(parsed_col, dict):
+            parsed = parsed_col
+        else:
+            try:
+                parsed = json.loads(parsed_col)
+            except (TypeError, ValueError):
+                continue
         out.append(
             {
                 "id": _id,
-                "variant": variant,
+                "variant": variant_idx,
                 "backstory_id": backstory_id,
                 "output": parsed,
             },
@@ -90,7 +94,7 @@ def _build_visits_by_backstory(visits: list[dict]) -> dict[str, dict[str, dict]]
             "next_action": out.get("next_action"),
         }
     # Drop incomplete pairs.
-    return {k: v for k, v in pairs.items() if "A" in v and "B" in v}
+    return {k: v for k, v in pairs.items() if 0 in v and 1 in v}
 
 
 def _collect_findings(visits: list[dict]) -> dict[str, list[str]]:
@@ -152,10 +156,15 @@ def run_study(
         "clusters": clusters,
     }
 
+    scores = [v["output"].get("will_to_buy") for v in visits if v["output"].get("will_to_buy") is not None]
+    conv_score = float(sum(scores) / len(scores)) if scores else 0.0
+
+    share_token_hash = secrets.token_hex(16)
+
     db.execute(
         conn,
-        "INSERT INTO reports(study_id, paired_delta_json) VALUES (%s, %s)",
-        (study_id, json.dumps(payload)),
+        "INSERT INTO reports(study_id, conv_score, share_token_hash, paired_delta_json, clusters_json) VALUES (%s, %s, %s, %s, %s)",
+        (study_id, conv_score, share_token_hash, json.dumps(payload), json.dumps(clusters)),
     )
     db.execute(
         conn,

--- a/apps/aggregator/src/aggregator/stats.py
+++ b/apps/aggregator/src/aggregator/stats.py
@@ -74,11 +74,11 @@ def paired_delta(visits_by_backstory: Mapping[str, Mapping[str, Mapping]]) -> Pa
     """Compute paired statistics for a study.
 
     Input shape:
-      {backstory_id: {"A": {"score": int, "next_action": str},
-                      "B": {"score": int, "next_action": str}}}
-    Only backstories with both A and B present (and both `score` numeric)
-    are included; the caller is expected to have filtered on `status='ok'`
-    upstream.
+      {backstory_id: {0: {"score": int, "next_action": str},
+                      1: {"score": int, "next_action": str}}}
+    Only backstories with both variant 0 (control) and 1 (treatment) present
+    (and both `score` numeric) are included; the caller is expected to have
+    filtered on `status='ok'` upstream.
     """
     deltas: list[float] = []
     a_actions: list[str] = []
@@ -88,8 +88,8 @@ def paired_delta(visits_by_backstory: Mapping[str, Mapping[str, Mapping]]) -> Pa
     # production paths produce identical floating-point sums.
     for backstory_id in sorted(visits_by_backstory.keys()):
         pair = visits_by_backstory[backstory_id]
-        a = pair.get("A")
-        b = pair.get("B")
+        a = pair.get(0)
+        b = pair.get(1)
         if a is None or b is None:
             continue
         a_score = a.get("score")

--- a/apps/aggregator/tests/test_main_e2e.py
+++ b/apps/aggregator/tests/test_main_e2e.py
@@ -25,14 +25,17 @@ CREATE TABLE studies (
 CREATE TABLE visits (
   id TEXT PRIMARY KEY,
   study_id TEXT NOT NULL,
-  variant TEXT NOT NULL,            -- 'A' or 'B'
+  variant_idx INTEGER NOT NULL,     -- 0 (control) or 1 (treatment)
   backstory_id TEXT NOT NULL,
   status TEXT NOT NULL,             -- 'ok' or 'failed'
-  output_json TEXT NOT NULL         -- VisitorOutput as JSON
+  parsed TEXT NOT NULL              -- VisitorOutput as JSON string (sqlite; psycopg returns dict)
 );
 CREATE TABLE reports (
   study_id TEXT PRIMARY KEY,
-  paired_delta_json TEXT NOT NULL
+  conv_score REAL NOT NULL DEFAULT 0,
+  share_token_hash TEXT NOT NULL DEFAULT '',
+  paired_delta_json TEXT NOT NULL,
+  clusters_json TEXT
 );
 CREATE TABLE provider_attempts (
   id INTEGER PRIMARY KEY AUTOINCREMENT,
@@ -55,15 +58,15 @@ def _seed(conn: sqlite3.Connection, study_id: str) -> None:
         b_score = a_score + 2 if i % 2 == 0 else a_score + 1
         a_action = "leave" if i % 4 != 0 else "ask_teammate"
         b_action = "contact_sales" if i % 2 == 0 else "purchase_paid_today"
-        for variant, score, action, objections in [
+        for variant_idx, score, action, objections in [
             (
-                "A",
+                0,
                 a_score,
                 a_action,
                 [f"pricing is unclear for persona {i}", "where is enterprise tier"],
             ),
             (
-                "B",
+                1,
                 b_score,
                 b_action,
                 [f"pricing is now clearer for persona {i}", "scale tier features listed"],
@@ -81,11 +84,11 @@ def _seed(conn: sqlite3.Connection, study_id: str) -> None:
                 "reasoning": f"persona {i} reasoning text",
             }
             conn.execute(
-                "INSERT INTO visits(id, study_id, variant, backstory_id, status, output_json) VALUES (?,?,?,?,?,?)",
+                "INSERT INTO visits(id, study_id, variant_idx, backstory_id, status, parsed) VALUES (?,?,?,?,?,?)",
                 (
-                    f"v_{i:02d}_{variant}",
+                    f"v_{i:02d}_{variant_idx}",
                     study_id,
-                    variant,
+                    variant_idx,
                     backstory,
                     "ok",
                     json.dumps(output),
@@ -115,10 +118,13 @@ def test_e2e_run_study_writes_report_and_clusters(tmp_path: Path) -> None:
     assert row[0] == "ready"
 
     cur = conn.execute(
-        "SELECT paired_delta_json FROM reports WHERE study_id=?",
+        "SELECT paired_delta_json, conv_score, share_token_hash FROM reports WHERE study_id=?",
         ("study_e2e_001",),
     )
-    payload = json.loads(cur.fetchone()[0])
+    report_row = cur.fetchone()
+    payload = json.loads(report_row[0])
+    assert isinstance(report_row[1], float)
+    assert isinstance(report_row[2], str) and len(report_row[2]) > 0
 
     # Paired stats present.
     assert "paired_delta" in payload

--- a/apps/aggregator/tests/test_main_e2e.py
+++ b/apps/aggregator/tests/test_main_e2e.py
@@ -126,28 +126,29 @@ def test_e2e_run_study_writes_report_and_clusters(tmp_path: Path) -> None:
     assert isinstance(report_row[1], float)
     assert isinstance(report_row[2], str) and len(report_row[2]) > 0
 
-    # Paired stats present.
-    assert "paired_delta" in payload
-    pd = payload["paired_delta"]
-    assert "mean_delta" in pd
-    assert "paired_t_p" in pd
-    assert "wilcoxon_p" in pd
-    assert "mcnemar_p" in pd
-    assert "disagreement" in pd
-    assert pd["n"] == 15
+    # paired_delta_json stores only paired stats (flat dict, no wrapper key).
+    assert "mean_delta" in payload
+    assert "paired_t_p" in payload
+    assert "wilcoxon_p" in payload
+    assert "mcnemar_p" in payload
+    assert "disagreement" in payload
+    assert payload["n"] == 15
 
-    # Clusters present (objections sample is duplicated enough across personas
-    # that we expect at least ONE non-noise cluster from the embedding pass).
-    assert "clusters" in payload
-    assert isinstance(payload["clusters"], dict)
+    # clusters_json is stored as a separate column.
+    cur2 = conn.execute(
+        "SELECT clusters_json FROM reports WHERE study_id=?",
+        ("study_e2e_001",),
+    )
+    clusters = json.loads(cur2.fetchone()[0])
     # At least one of the four finding kinds yields a cluster list.
-    total_clusters = sum(len(v) for v in payload["clusters"].values())
+    assert isinstance(clusters, dict)
+    total_clusters = sum(len(v) for v in clusters.values())
     assert total_clusters >= 1
 
     # provider_attempts has at least one cluster_label row (only one per cluster).
-    cur = conn.execute(
+    cur3 = conn.execute(
         "SELECT COUNT(*) FROM provider_attempts WHERE study_id=? AND kind='cluster_label'",
         ("study_e2e_001",),
     )
-    n_label_rows = cur.fetchone()[0]
+    n_label_rows = cur3.fetchone()[0]
     assert n_label_rows == total_clusters

--- a/apps/aggregator/tests/test_score_visit.py
+++ b/apps/aggregator/tests/test_score_visit.py
@@ -1,0 +1,52 @@
+"""Unit tests for _score_visit() — mirrors scoreVisit() in scoring.ts."""
+import pytest
+from aggregator.main import _score_visit
+
+
+def _v(action: str, tier_today: str = "none", tier_considered: str = "none") -> dict:
+    return {
+        "next_action": action,
+        "tier_picked_if_buying_today": tier_today,
+        "highest_tier_willing_to_consider": tier_considered,
+    }
+
+
+def test_high_intent_actions():
+    assert _score_visit(_v("purchase_paid_today")) == 1.0
+    assert _score_visit(_v("contact_sales")) == 0.8
+    assert _score_visit(_v("book_demo")) == 0.8
+    assert _score_visit(_v("start_paid_trial")) == 0.6
+    assert _score_visit(_v("ask_teammate")) == 0.2
+    assert _score_visit(_v("leave")) == 0.0
+
+
+def test_bookmark_bump():
+    # No tier → 0.0
+    assert _score_visit(_v("bookmark_compare_later")) == 0.0
+    assert _score_visit(_v("bookmark_compare_later", tier_today="none")) == 0.0
+    # Paid tier → 0.3
+    for tier in ("express", "starter", "scale", "enterprise"):
+        assert _score_visit(_v("bookmark_compare_later", tier_today=tier)) == 0.3
+    # Hobby is not a paid tier
+    assert _score_visit(_v("bookmark_compare_later", tier_today="hobby")) == 0.0
+
+
+def test_free_hobby_bump():
+    # No tier → 0.0
+    assert _score_visit(_v("start_free_hobby")) == 0.0
+    assert _score_visit(_v("start_free_hobby", tier_considered="none")) == 0.0
+    # Paid considered tier → 0.2
+    for tier in ("express", "starter", "scale", "enterprise"):
+        assert _score_visit(_v("start_free_hobby", tier_considered=tier)) == 0.2
+    # Hobby is not a paid tier
+    assert _score_visit(_v("start_free_hobby", tier_considered="hobby")) == 0.0
+
+
+def test_missing_tier_fields_default_to_none():
+    # If the LLM omits tier fields entirely, score should be same as tier=none
+    assert _score_visit({"next_action": "bookmark_compare_later"}) == 0.0
+    assert _score_visit({"next_action": "start_free_hobby"}) == 0.0
+
+
+def test_unknown_action_scores_zero():
+    assert _score_visit(_v("unknown_action_xyz")) == 0.0

--- a/apps/aggregator/tests/test_stats.py
+++ b/apps/aggregator/tests/test_stats.py
@@ -29,14 +29,14 @@ def test_paired_delta_known_fixture_4dp() -> None:
     mean_delta = 18/8 = 2.25 (exact)
     """
     visits = {
-        "alice":   {"A": {"score": 5, "next_action": "leave"},                   "B": {"score": 7, "next_action": "contact_sales"}},
-        "bob":     {"A": {"score": 3, "next_action": "leave"},                   "B": {"score": 6, "next_action": "purchase_paid_today"}},
-        "carol":   {"A": {"score": 4, "next_action": "bookmark_compare_later"},  "B": {"score": 5, "next_action": "book_demo"}},
-        "dave":    {"A": {"score": 6, "next_action": "leave"},                   "B": {"score": 8, "next_action": "purchase_paid_today"}},
-        "eve":     {"A": {"score": 2, "next_action": "leave"},                   "B": {"score": 5, "next_action": "start_paid_trial"}},
-        "frank":   {"A": {"score": 5, "next_action": "ask_teammate"},            "B": {"score": 6, "next_action": "contact_sales"}},
-        "grace":   {"A": {"score": 4, "next_action": "leave"},                   "B": {"score": 7, "next_action": "purchase_paid_today"}},
-        "heidi":   {"A": {"score": 5, "next_action": "leave"},                   "B": {"score": 8, "next_action": "contact_sales"}},
+        "alice":   {0: {"score": 5, "next_action": "leave"},                   1: {"score": 7, "next_action": "contact_sales"}},
+        "bob":     {0: {"score": 3, "next_action": "leave"},                   1: {"score": 6, "next_action": "purchase_paid_today"}},
+        "carol":   {0: {"score": 4, "next_action": "bookmark_compare_later"},  1: {"score": 5, "next_action": "book_demo"}},
+        "dave":    {0: {"score": 6, "next_action": "leave"},                   1: {"score": 8, "next_action": "purchase_paid_today"}},
+        "eve":     {0: {"score": 2, "next_action": "leave"},                   1: {"score": 5, "next_action": "start_paid_trial"}},
+        "frank":   {0: {"score": 5, "next_action": "ask_teammate"},            1: {"score": 6, "next_action": "contact_sales"}},
+        "grace":   {0: {"score": 4, "next_action": "leave"},                   1: {"score": 7, "next_action": "purchase_paid_today"}},
+        "heidi":   {0: {"score": 5, "next_action": "leave"},                   1: {"score": 8, "next_action": "contact_sales"}},
     }
     out = paired_delta(visits)
 
@@ -83,14 +83,14 @@ def test_paired_delta_disagreement_true() -> None:
     # 18 pairs with B−A = +0.3 (score: A=5, B=5.3)
     for i in range(18):
         visits[f"v{i:02d}"] = {
-            "A": {"score": 5,   "next_action": "leave"},
-            "B": {"score": 5.3, "next_action": "leave"},
+            0: {"score": 5,   "next_action": "leave"},
+            1: {"score": 5.3, "next_action": "leave"},
         }
     # 2 pairs with B−A = −2.0 (score: A=5, B=3.0)
     for i in range(18, 20):
         visits[f"v{i:02d}"] = {
-            "A": {"score": 5,   "next_action": "leave"},
-            "B": {"score": 3.0, "next_action": "leave"},
+            0: {"score": 5,   "next_action": "leave"},
+            1: {"score": 3.0, "next_action": "leave"},
         }
 
     out = paired_delta(visits)
@@ -127,9 +127,9 @@ def test_paired_delta_disagreement_rule_xor_contract() -> None:
     # Case B already tested above. Here we verify the contract fields directly.
     visits_b: dict[str, dict] = {}
     for i in range(18):
-        visits_b[f"v{i:02d}"] = {"A": {"score": 5, "next_action": "leave"}, "B": {"score": 5.3, "next_action": "leave"}}
+        visits_b[f"v{i:02d}"] = {0: {"score": 5, "next_action": "leave"}, 1: {"score": 5.3, "next_action": "leave"}}
     for i in range(18, 20):
-        visits_b[f"v{i:02d}"] = {"A": {"score": 5, "next_action": "leave"}, "B": {"score": 3.0, "next_action": "leave"}}
+        visits_b[f"v{i:02d}"] = {0: {"score": 5, "next_action": "leave"}, 1: {"score": 3.0, "next_action": "leave"}}
     out_b = paired_delta(visits_b)
     assert out_b.disagreement is True
     assert out_b.conservative_p == max(out_b.paired_t_p, out_b.wilcoxon_p)
@@ -139,14 +139,14 @@ def test_paired_delta_disagreement_rule_xor_contract() -> None:
     # Case A mirror: both tests agree (both significant) → disagreement=False.
     # Fixture: all 8 deltas positive → both t and Wilcoxon significant.
     visits_a: dict[str, dict] = {
-        "alice": {"A": {"score": 5, "next_action": "leave"}, "B": {"score": 7, "next_action": "contact_sales"}},
-        "bob":   {"A": {"score": 3, "next_action": "leave"}, "B": {"score": 6, "next_action": "purchase_paid_today"}},
-        "carol": {"A": {"score": 4, "next_action": "leave"}, "B": {"score": 7, "next_action": "contact_sales"}},
-        "dave":  {"A": {"score": 6, "next_action": "leave"}, "B": {"score": 8, "next_action": "purchase_paid_today"}},
-        "eve":   {"A": {"score": 2, "next_action": "leave"}, "B": {"score": 5, "next_action": "start_paid_trial"}},
-        "frank": {"A": {"score": 5, "next_action": "leave"}, "B": {"score": 8, "next_action": "contact_sales"}},
-        "grace": {"A": {"score": 4, "next_action": "leave"}, "B": {"score": 7, "next_action": "purchase_paid_today"}},
-        "heidi": {"A": {"score": 5, "next_action": "leave"}, "B": {"score": 8, "next_action": "contact_sales"}},
+        "alice": {0: {"score": 5, "next_action": "leave"}, 1: {"score": 7, "next_action": "contact_sales"}},
+        "bob":   {0: {"score": 3, "next_action": "leave"}, 1: {"score": 6, "next_action": "purchase_paid_today"}},
+        "carol": {0: {"score": 4, "next_action": "leave"}, 1: {"score": 7, "next_action": "contact_sales"}},
+        "dave":  {0: {"score": 6, "next_action": "leave"}, 1: {"score": 8, "next_action": "purchase_paid_today"}},
+        "eve":   {0: {"score": 2, "next_action": "leave"}, 1: {"score": 5, "next_action": "start_paid_trial"}},
+        "frank": {0: {"score": 5, "next_action": "leave"}, 1: {"score": 8, "next_action": "contact_sales"}},
+        "grace": {0: {"score": 4, "next_action": "leave"}, 1: {"score": 7, "next_action": "purchase_paid_today"}},
+        "heidi": {0: {"score": 5, "next_action": "leave"}, 1: {"score": 8, "next_action": "contact_sales"}},
     }
     out_a = paired_delta(visits_a)
     assert out_a.disagreement is False


### PR DESCRIPTION
## Summary

- Fix column names in `_read_visits`: `variant` → `variant_idx`, `output_json` → `parsed` (Bug 1)
- Handle both `dict` (psycopg JSONB auto-deserialize) and `str` (sqlite TEXT) for the `parsed` column (Bug 2)
- Add `conv_score` and `share_token_hash` to the `reports` INSERT — both are `NOT NULL` in the real schema (Bug 3)
- Change variant pair keys from `"A"`/`"B"` to `0`/`1` in `_build_visits_by_backstory` and `stats.paired_delta` to match `visits.variant_idx` values (Bug 4)
- Update `test_main_e2e.py` schema, seed data, and assertions; update `test_stats.py` fixtures accordingly

Closes #167

**Spec ref:** §5.6, §17

## Test plan

- [x] `docker run --rm --entrypoint python willbuy-aggregator-test -m pytest tests/ -v` → 13 passed
- [ ] CI green