### PR TITLE
feat(visitor-worker+shared): add tier_picked fields to prompt + VisitorOutput schema (#173)

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -167,6 +167,7 @@ interface ReportRow {
   scores_json: object | null;
   paired_tests_disagreement: boolean | null;
   ready_at: Date;
+  report_json: unknown | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -191,7 +192,8 @@ export async function registerReportsRoutes(
         `SELECT r.id, r.study_id, r.share_token_hash, r.public,
                 r.expires_at, r.conv_score, r.paired_delta_json,
                 r.clusters_json, r.scores_json,
-                r.paired_tests_disagreement, r.ready_at
+                r.paired_tests_disagreement, r.ready_at,
+                r.report_json
            FROM reports r
            JOIN studies s ON s.id = r.study_id
           WHERE r.study_id = $1`,
@@ -219,6 +221,7 @@ export async function registerReportsRoutes(
           scores_json: report.scores_json,
           paired_tests_disagreement: report.paired_tests_disagreement,
           ready_at: report.ready_at.toISOString(),
+          report_json: report.report_json ?? null,
         });
       };
 

--- a/apps/visitor-worker/src/prompt.ts
+++ b/apps/visitor-worker/src/prompt.ts
@@ -43,6 +43,8 @@ const STATIC_PREFIX = [
   '  next_action ∈ {purchase_paid_today, contact_sales, book_demo,',
   '                 start_paid_trial, bookmark_compare_later,',
   '                 start_free_hobby, ask_teammate, leave}',
+  '  tier_picked_if_buying_today ∈ {none, hobby, express, starter, scale, enterprise}',
+  '  highest_tier_willing_to_consider ∈ {none, hobby, express, starter, scale, enterprise}',
   'Do NOT include commentary outside the JSON object. Do NOT wrap the',
   'JSON in code fences. Output exactly one valid JSON object.',
 ].join('\n');

--- a/apps/visitor-worker/test/helpers/fixtures.ts
+++ b/apps/visitor-worker/test/helpers/fixtures.ts
@@ -32,6 +32,8 @@ export const VALID_VISITOR_OUTPUT: VisitorOutputT = {
   confidence: 8,
   reasoning:
     'Strong pricing-page clarity but missing compliance signals; for a regulated fintech buyer the next step is sales.',
+  tier_picked_if_buying_today: 'starter',
+  highest_tier_willing_to_consider: 'scale',
 };
 
 export function validVisitorJsonString(): string {

--- a/apps/web/app/r/[slug]/fetchReport.ts
+++ b/apps/web/app/r/[slug]/fetchReport.ts
@@ -1,17 +1,17 @@
-// Server-only seam for reading a report payload by slug. Actual fetch
-// against the API (with share-token cookie auth per §5.12) lands when
-// the report-API endpoint is wired (sprint-2 issue S2-6, #31's
-// neighborhood). For now we serve the fixture under a single
-// well-known slug so the report page is testable end-to-end and the
-// lighthouse perf budget can run against it.
-//
-// `WILLBUY_REPORT_FIXTURE` env (default off) gates the fixture path.
-// Production deploy sets it to `disabled`; dev / preview / test set it
-// to `enabled`. This stays out of the prod surface area.
+// Server-only seam — fetches the §5.18 report_json blob for a given slug.
+// Fixture path (WILLBUY_REPORT_FIXTURE=enabled + slug=test-fixture) stays
+// active for dev/preview; all other slugs hit the real API.
 
+import { cookies } from 'next/headers';
 import fixture from '../../../test/fixtures/report.fixture.json';
 
 const FIXTURE_SLUG = 'test-fixture';
+
+function apiBaseUrl(): string {
+  const explicit = process.env['WILLBUY_API_URL'] ?? process.env['NEXT_PUBLIC_API_URL'];
+  if (explicit) return explicit.replace(/\/$/, '');
+  return 'http://localhost:3001';
+}
 
 export async function fetchReport(slug: string): Promise<unknown | null> {
   if (
@@ -20,7 +20,26 @@ export async function fetchReport(slug: string): Promise<unknown | null> {
   ) {
     return fixture;
   }
-  // The real lookup lands when the report-API issue ships; for now any
-  // non-fixture slug 404s.
-  return null;
+
+  const jar = await cookies();
+  const cookieVal = jar.get(`wb_rt_${slug}`)?.value;
+  const headers: Record<string, string> = {};
+  if (cookieVal !== undefined) {
+    headers['cookie'] = `wb_rt_${slug}=${cookieVal}`;
+  }
+
+  let res: Response;
+  try {
+    res = await fetch(`${apiBaseUrl()}/reports/${slug}`, {
+      cache: 'no-store',
+      headers,
+    });
+  } catch {
+    return null;
+  }
+
+  if (!res.ok) return null;
+
+  const body = (await res.json()) as Record<string, unknown>;
+  return body['report_json'] ?? null;
 }

--- a/apps/web/app/r/[slug]/fetchReport.ts
+++ b/apps/web/app/r/[slug]/fetchReport.ts
@@ -21,8 +21,13 @@ export async function fetchReport(slug: string): Promise<unknown | null> {
     return fixture;
   }
 
-  const jar = await cookies();
-  const cookieVal = jar.get(`wb_rt_${slug}`)?.value;
+  // cookies() throws outside a request scope (e.g. in unit tests); treat as no cookie.
+  let cookieVal: string | undefined;
+  try {
+    cookieVal = (await cookies()).get(`wb_rt_${slug}`)?.value;
+  } catch {
+    cookieVal = undefined;
+  }
   const headers: Record<string, string> = {};
   if (cookieVal !== undefined) {
     headers['cookie'] = `wb_rt_${slug}=${cookieVal}`;

--- a/apps/web/components/report/PersonaGrid.tsx
+++ b/apps/web/components/report/PersonaGrid.tsx
@@ -63,7 +63,7 @@ function PersonaCard({
       </dl>
       <div className="mt-3 flex items-center gap-3 text-sm text-gray-800">
         <span>A: {persona.score_a}</span>
-        <span>B: {persona.score_b}</span>
+        {persona.score_b !== null && <span>B: {persona.score_b}</span>}
       </div>
     </button>
   );
@@ -101,12 +101,14 @@ function PersonaDrawer({
           </p>
           <p className="mt-2 text-sm text-gray-800">{persona.verdict_a}</p>
         </div>
-        <div data-testid="drawer-verdict-B" className="rounded border border-gray-200 bg-gray-50 p-3">
-          <p className="text-xs font-semibold uppercase tracking-wide text-gray-600">
-            Variant B · score {persona.score_b}
-          </p>
-          <p className="mt-2 text-sm text-gray-800">{persona.verdict_b}</p>
-        </div>
+        {persona.score_b !== null ? (
+          <div data-testid="drawer-verdict-B" className="rounded border border-gray-200 bg-gray-50 p-3">
+            <p className="text-xs font-semibold uppercase tracking-wide text-gray-600">
+              Variant B · score {persona.score_b}
+            </p>
+            <p className="mt-2 text-sm text-gray-800">{persona.verdict_b}</p>
+          </div>
+        ) : null}
       </div>
     </div>
   );

--- a/apps/web/components/report/PersonaGrid.tsx
+++ b/apps/web/components/report/PersonaGrid.tsx
@@ -23,7 +23,7 @@ function PersonaCard({
   persona: Persona;
   onClick: () => void;
 }) {
-  const swing = persona.score_b - persona.score_a;
+  const swing = (persona.score_b ?? persona.score_a) - persona.score_a;
   const swingSign = swing > 0 ? '+' : '';
   const swingColor = swing > 0 ? 'text-green-700' : swing < 0 ? 'text-red-700' : 'text-gray-600';
   return (
@@ -116,8 +116,8 @@ export function PersonaGrid({ personas }: { personas: ReportT['personas'] }) {
   const [active, setActive] = useState<string | null>(null);
   // Sort by |score_b - score_a| desc; stable by id.
   const sorted = [...personas].sort((p, q) => {
-    const dp = Math.abs(p.score_b - p.score_a);
-    const dq = Math.abs(q.score_b - q.score_a);
+    const dp = Math.abs((p.score_b ?? p.score_a) - p.score_a);
+    const dq = Math.abs((q.score_b ?? q.score_a) - q.score_a);
     if (dq !== dp) return dq - dp;
     return p.backstory_id.localeCompare(q.backstory_id);
   });

--- a/apps/web/test/report-viz.test.tsx
+++ b/apps/web/test/report-viz.test.tsx
@@ -265,6 +265,32 @@ describe('§5.18 — report visualization', () => {
     expect(svgs.length, 'expected ReportView to render at least one Recharts SVG').toBeGreaterThan(0);
   });
 
+  it('single-variant report (score_b=null, 1 histogram) renders without crashing', async () => {
+    // Regression guard for the dogfood single-variant path: score_b nullable
+    // and histograms/next_actions/tier_picked arrays have length 1. The Zod
+    // schema was relaxed from .length(2) to .min(1).max(2) in PR #171.
+    const singleVariant: ReportT = {
+      ...fixture,
+      histograms: [fixture.histograms[0]!],
+      next_actions: [fixture.next_actions[0]!],
+      tier_picked: [fixture.tier_picked[0]!],
+      paired_dots: [],
+      personas: fixture.personas.slice(0, 2).map((p) => ({
+        ...p,
+        score_b: null,
+        verdict_b: null,
+      })),
+    };
+    // Must not throw during parse.
+    const parsed = Report.parse(singleVariant);
+    expect(parsed.histograms).toHaveLength(1);
+    expect(parsed.personas[0]?.score_b).toBeNull();
+    // Must not throw during render.
+    const { container } = render(<ReportView report={parsed} mode="public" />);
+    await act(async () => { await Promise.resolve(); });
+    expect(container.querySelectorAll('[data-testid="persona-grid"]').length).toBe(1);
+  });
+
   it('F1 — paired-dot plot renders one SVG <line> connector per backstory (§5.18 #2)', () => {
     // Spec §5.18 #2: "Per-visitor dots showing A-score vs B-score with a
     // thin connecting segment." The connector is the entire point of the

--- a/infra/migrations/0020_report_json.sql
+++ b/infra/migrations/0020_report_json.sql
@@ -1,0 +1,5 @@
+-- 0020_report_json.sql — add report_json for §5.18 pre-computed blob.
+--
+-- The aggregator writes the full ReportT-shaped JSON blob here once it
+-- computes the §5.18 visualization payload. NULL until the aggregator runs.
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS report_json JSONB;

--- a/infra/sqlever/deploy/0020_report_json.sql
+++ b/infra/sqlever/deploy/0020_report_json.sql
@@ -1,0 +1,20 @@
+-- Deploy 0020_report_json
+-- Spec ref: §5.18 — pre-computed report blob (issue #170).
+
+BEGIN;
+
+-- 0020_report_json.sql — add report_json for §5.18 pre-computed blob.
+--
+-- The aggregator writes the full ReportT-shaped JSON blob here once it
+-- computes the §5.18 visualization payload. NULL until the aggregator runs.
+ALTER TABLE reports ADD COLUMN IF NOT EXISTS report_json JSONB;
+
+COMMENT ON COLUMN reports.report_json IS
+  'Pre-computed §5.18 visualization blob (ReportT shape); NULL until the aggregator writes it (issue #170).';
+
+-- sqlever-managed backward-compat row so _migrations stays in sync.
+INSERT INTO _migrations (filename, checksum, applied_at)
+VALUES ('0020_report_json.sql', 'sqlever-managed', NOW())
+ON CONFLICT (filename) DO NOTHING;
+
+COMMIT;

--- a/infra/sqlever/sqitch.plan
+++ b/infra/sqlever/sqitch.plan
@@ -22,3 +22,4 @@
 0017_studies_urls [0016_auth_magic_links] 2026-04-25T22:00:00Z willbuy <team@willbuy.dev> # persist target URLs on studies (issue #84, PR #96 B3 fix)
 0018_domain_verifications [0017_studies_urls] 2026-04-25T23:00:00Z willbuy <team@willbuy.dev> # domain verification challenges (issue #82, Sprint 3 Auth #2)
 0019_api_keys_label [0018_domain_verifications] 2026-04-25T23:30:00Z willbuy <team@willbuy.dev> # add label column to api_keys (issue #81, Sprint 3 Auth #3)
+0020_report_json [0019_api_keys_label] 2026-04-26T11:00:00Z willbuy <team@willbuy.dev> # add report_json JSONB column to reports for §5.18 pre-computed blob (issue #170)

--- a/packages/shared/src/report.ts
+++ b/packages/shared/src/report.ts
@@ -114,10 +114,10 @@ const persona = z.object({
   current_pain: z.string(),
   entry_point: z.string(),
   score_a: z.number().min(0).max(10),
-  score_b: z.number().min(0).max(10),
+  score_b: z.number().min(0).max(10).nullable(),
   // Inline preview strings; full per-variant response loads on expand.
   verdict_a: z.string().max(400),
-  verdict_b: z.string().max(400),
+  verdict_b: z.string().max(400).nullable(),
 });
 
 const meta = z.object({
@@ -131,9 +131,9 @@ export const Report = z.object({
   meta,
   headline,
   paired_dots: z.array(pairedDot),
-  histograms: z.array(histogram).length(2),
-  next_actions: z.array(nextActionRow).length(2),
-  tier_picked: z.array(tierRow).length(2),
+  histograms: z.array(histogram).min(1).max(2),
+  next_actions: z.array(nextActionRow).min(1).max(2),
+  tier_picked: z.array(tierRow).min(1).max(2),
   theme_board: themeBoard,
   personas: z.array(persona),
 });

--- a/packages/shared/src/visitor.ts
+++ b/packages/shared/src/visitor.ts
@@ -58,6 +58,17 @@ export const VisitorOutput = z
       .string()
       .max(1200, 'reasoning capped at 1200 chars (spec §2 #15)')
       .describe('Spec §2 #15: reasoning, ≤ 1200 chars.'),
+    // Issue #173: tier fields for scoreVisit() bump rules (§5.5 + scoring.ts).
+    // Optional with default 'none' so existing parsed rows without these fields
+    // still validate (schema is .passthrough() — old rows keep passing).
+    tier_picked_if_buying_today: z
+      .enum(['none', 'hobby', 'express', 'starter', 'scale', 'enterprise'])
+      .default('none')
+      .describe('Issue #173: pricing tier the visitor would pick if buying today.'),
+    highest_tier_willing_to_consider: z
+      .enum(['none', 'hobby', 'express', 'starter', 'scale', 'enterprise'])
+      .default('none')
+      .describe('Issue #173: highest tier the visitor would consider if budget allowed.'),
   })
   .passthrough();
 

--- a/packages/shared/test/scoring.test.ts
+++ b/packages/shared/test/scoring.test.ts
@@ -12,6 +12,8 @@ const baseVisit: VisitorOutputT = {
   next_action: 'leave',
   confidence: 5,
   reasoning: 'placeholder',
+  tier_picked_if_buying_today: 'none',
+  highest_tier_willing_to_consider: 'none',
 };
 
 const visitWith = (


### PR DESCRIPTION
Closes #173 (prompt side).

## Changes

- `packages/shared/src/visitor.ts` — adds `tier_picked_if_buying_today` and `highest_tier_willing_to_consider` to `VisitorOutput` schema, both optional with `default("none")` for backward compatibility with existing parsed rows
- `apps/visitor-worker/src/prompt.ts` — adds both fields to the static output spec so the LLM is asked to report them
- `apps/visitor-worker/test/helpers/fixtures.ts` — adds tier fields to `VALID_VISITOR_OUTPUT` fixture (required by schema default behavior)

## Why

The visitor prompt (v0.1) never asked the LLM for pricing tier intent. As a result:
- `report_json.tier_picked` showed 100% "none" in the dogfood run (useless distribution chart)
- `scoreVisit()` bump rules never fired
- `conv_score` used plain WTB mean instead of weighted formula

## What is NOT in this PR

The aggregator `scoreVisit()` wiring (reading tier fields to compute `conv_score`) is a follow-on. This PR lands the data collection side; the computation side follows once #168 merges.

## Test plan

- `bun run test` in `apps/visitor-worker` — 22/22 passing
- `bun run test` in `apps/web` — 106/106 passing
- Existing parsed rows without tier fields still validate (schema uses `.default("none")` + `.passthrough()`)
