### PR TITLE
fix(aggregator): small-dataset fallback when HDBSCAN finds no clusters (#180)

### DIFF
--- a/apps/aggregator/src/aggregator/cluster.py
+++ b/apps/aggregator/src/aggregator/cluster.py
@@ -164,6 +164,21 @@ def cluster_findings(strings: Sequence[str]) -> list[Cluster]:
         key=lambda g: g[0],  # tie-break by lowest sorted-input index
     )
 
+    # Small-dataset fallback (issue #180): when HDBSCAN finds no clusters but
+    # strings exist, return one catch-all cluster rather than an empty list.
+    # Prevents hollow report sections for finding kinds with sparse data (< ~50
+    # visits); HDBSCAN needs density ≥ min_cluster_size to form any cluster, so
+    # small studies always fall through to noise. The fallback fires only when
+    # the density-based pass found nothing — large datasets are unaffected.
+    if not groups:
+        return [
+            Cluster(
+                id=0,
+                members=tuple(normalized),
+                member_indices=tuple(range(len(normalized))),
+            )
+        ]
+
     return [
         Cluster(
             id=new_id,

--- a/apps/aggregator/tests/test_cluster.py
+++ b/apps/aggregator/tests/test_cluster.py
@@ -81,8 +81,41 @@ def test_cluster_findings_returns_lex_sorted_inputs_in_member_indices() -> None:
 
 def test_cluster_findings_handles_empty_and_tiny_inputs() -> None:
     assert cluster_findings([]) == []
-    # 2 inputs cannot meet min_cluster_size=3 → all noise → 0 clusters.
+    # 2 inputs: early bail (< min_cluster_size=3) before HDBSCAN → no fallback.
     assert cluster_findings(["alpha", "beta"]) == []
+
+
+def test_cluster_findings_small_dataset_fallback(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Issue #180: when HDBSCAN returns no clusters, return one catch-all cluster.
+
+    With sparse strings in a small study HDBSCAN with min_cluster_size=3 labels
+    everything as noise. The fallback must surface a single cluster with all
+    normalized strings rather than an empty list.
+    """
+    import numpy as np
+    import aggregator.cluster as cluster_mod
+
+    strings = [
+        "no transparent pricing for enterprise",
+        "unclear about storage limits",
+        "missing sla documentation",
+        "cannot find cancellation policy",
+    ]
+
+    # Random spread embeddings → no HDBSCAN density cluster guaranteed.
+    rng = np.random.default_rng(99)
+    vectors = rng.standard_normal((len(strings), 16)).astype(np.float32)
+    norms = np.linalg.norm(vectors, axis=1, keepdims=True)
+    vectors = vectors / norms
+
+    monkeypatch.setattr(cluster_mod, "_embed", lambda _strs: vectors)
+
+    result = cluster_mod.cluster_findings(strings)
+
+    assert len(result) == 1
+    assert result[0].id == 0
+    assert len(result[0].members) == len(strings)
+    assert result[0].member_indices == tuple(range(len(strings)))
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Problem

`cluster_findings()` uses `HDBSCAN(min_cluster_size=3)`. With sparse finding strings from a small study (< ~50 visits), the density-based pass labels everything as noise and returns an empty list. In the Sprint 6 dogfood (study_id=1, n=10 visits), `unanswered_blockers` produced zero clusters despite ~30 total strings.

## Fix

When HDBSCAN returns no clusters but `len(normalized) >= 3`, return one catch-all cluster containing all normalized strings. Large datasets are unaffected (they get real density-based clusters). The early bail for `len < 3` is unchanged.

## Tests

- Existing test `cluster_findings(["alpha", "beta"]) == []` still passes (early bail, < min_cluster_size)
- New `test_cluster_findings_small_dataset_fallback`: monkeypatches `_embed` with random-spread vectors that HDBSCAN cannot cluster, asserts one catch-all cluster is returned

## Closes

Fixes #180

🤖 Generated with [Claude Code](https://claude.com/claude-code)