### PR TITLE
fix(aggregator): coerce unknown role_archetype to ic_engineer in report_json

### DIFF
--- a/apps/aggregator/src/aggregator/main.py
+++ b/apps/aggregator/src/aggregator/main.py
@@ -52,6 +52,27 @@ VALID_NEXT_ACTIONS: list[str] = [
 
 VALID_TIERS: list[str] = ["none", "hobby", "express", "starter", "scale", "enterprise"]
 
+# Valid RoleArchetype values (spec §2 / amendment A1).  Any value not in this
+# set is coerced to the safe default so the report JSON never contains
+# free-form strings that downstream renderers don't know how to handle.
+VALID_ROLES: frozenset[str] = frozenset({
+    "ic_engineer",
+    "engineering_manager",
+    "vp_engineering",
+    "cto",
+    "dba",
+    "devops_sre",
+    "founder",
+    "product_manager",
+})
+
+
+def _coerce_role(raw: Any) -> str:
+    """Return *raw* unchanged if it is a valid RoleArchetype, else 'ic_engineer'."""
+    if isinstance(raw, str) and raw in VALID_ROLES:
+        return raw
+    return "ic_engineer"
+
 # Maps cluster finding_kind → theme_board key.
 CLUSTER_TO_THEME: dict[str, str] = {
     "unanswered_blockers": "blockers",
@@ -279,7 +300,7 @@ def _build_report_json(
         paired_dots.append({
             "backstory_id": str(bs_id),
             "backstory_name": bs_payload.get("name", str(bs_id)),
-            "role": bs_payload.get("role_archetype", "ic_engineer"),
+            "role": _coerce_role(bs_payload.get("role_archetype")),
             "score_a": score_a,
             "score_b": score_b,
             "swing": swing,
@@ -377,7 +398,7 @@ def _build_report_json(
         personas.append({
             "backstory_id": str(bs_id),
             "backstory_name": bs_payload.get("name", str(bs_id)),
-            "role": bs_payload.get("role_archetype", "ic_engineer"),
+            "role": _coerce_role(bs_payload.get("role_archetype")),
             "stage": str(bs_payload.get("stage", "")),
             "team_size": int(bs_payload.get("team_size", 2)),
             "stack": str(bs_payload.get("managed_postgres", "")),

--- a/apps/aggregator/tests/test_main_e2e.py
+++ b/apps/aggregator/tests/test_main_e2e.py
@@ -14,7 +14,7 @@ import json
 import sqlite3
 from pathlib import Path
 
-from aggregator.main import run_study
+from aggregator.main import run_study, _coerce_role
 
 
 SCHEMA_SQL = """
@@ -164,3 +164,100 @@ def test_e2e_run_study_writes_report_and_clusters(tmp_path: Path) -> None:
     assert len(rj["histograms"]) >= 1
     # theme_board has all four required keys.
     assert set(rj["theme_board"].keys()) == {"blockers", "objections", "confusions", "questions"}
+
+
+def _seed_with_unknown_role(conn: sqlite3.Connection, study_id: str) -> None:
+    """Seed a minimal study with one backstory whose role_archetype is unknown."""
+    conn.executescript(SCHEMA_SQL)
+    conn.execute("INSERT INTO studies(id, status) VALUES (?, ?)", (study_id, "aggregating"))
+    conn.execute(
+        "INSERT INTO visits(id, study_id, variant_idx, backstory_id, status, parsed) VALUES (?,?,?,?,?,?)",
+        (
+            "v_role_00",
+            study_id,
+            0,
+            "bs_unknown_role",
+            "ok",
+            json.dumps({
+                "first_impression": "looks interesting",
+                "will_to_buy": 6,
+                "questions": [],
+                "confusions": [],
+                "objections": ["price too high"],
+                "unanswered_blockers": [],
+                "next_action": "contact_sales",
+                "confidence": 7,
+                "reasoning": "solid product",
+                "role_archetype": "unknown_role",
+            }),
+        ),
+    )
+    conn.execute(
+        "INSERT INTO visits(id, study_id, variant_idx, backstory_id, status, parsed) VALUES (?,?,?,?,?,?)",
+        (
+            "v_role_01",
+            study_id,
+            1,
+            "bs_unknown_role",
+            "ok",
+            json.dumps({
+                "first_impression": "variant B looks better",
+                "will_to_buy": 8,
+                "questions": [],
+                "confusions": [],
+                "objections": [],
+                "unanswered_blockers": [],
+                "next_action": "purchase_paid_today",
+                "confidence": 8,
+                "reasoning": "great deal",
+                "role_archetype": "unknown_role",
+            }),
+        ),
+    )
+    # Insert a backstory row with an unknown role_archetype so _read_backstories
+    # picks it up.  We simulate via the backstories table.
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS backstories (id TEXT PRIMARY KEY, payload TEXT)"
+    )
+    conn.execute(
+        "INSERT INTO backstories(id, payload) VALUES (?, ?)",
+        (
+            "bs_unknown_role",
+            json.dumps({"name": "Unknown Role Persona", "role_archetype": "unknown_role"}),
+        ),
+    )
+    conn.commit()
+
+
+def test_unknown_role_archetype_coerced_to_ic_engineer(tmp_path: Path) -> None:
+    """Backstory with role_archetype='unknown_role' must produce 'ic_engineer' in report."""
+    # Unit-level sanity check on the coercion helper itself.
+    assert _coerce_role("unknown_role") == "ic_engineer"
+    assert _coerce_role(None) == "ic_engineer"
+    assert _coerce_role("ic_engineer") == "ic_engineer"
+    assert _coerce_role("cto") == "cto"
+
+    db_path = tmp_path / "role_test.sqlite"
+    conn = sqlite3.connect(db_path)
+    _seed_with_unknown_role(conn, "study_role_001")
+
+    def llm_caller(prompt: str, *, kind: str) -> str:
+        return "stub label"
+
+    run_study(study_id="study_role_001", conn=conn, llm_caller=llm_caller)
+
+    cur = conn.execute(
+        "SELECT report_json FROM reports WHERE study_id=?", ("study_role_001",)
+    )
+    rj = json.loads(cur.fetchone()[0])
+
+    # Both paired_dots and personas must have role='ic_engineer', not 'unknown_role'.
+    roles_in_dots = [d["role"] for d in rj.get("paired_dots", [])]
+    roles_in_personas = [p["role"] for p in rj.get("personas", [])]
+
+    assert all(r == "ic_engineer" for r in roles_in_dots), (
+        f"paired_dots contained unexpected roles: {roles_in_dots}"
+    )
+    assert all(r == "ic_engineer" for r in roles_in_personas), (
+        f"personas contained unexpected roles: {roles_in_personas}"
+    )


### PR DESCRIPTION
Closes #183

## What

Adds validation of the `role_archetype` field read from backstory payloads in `_build_report_json()`.

Previously, any string (including free-form or misspelled values from LLM output) was written verbatim into `paired_dots[].role` and `personas[].role` in the report JSON. Downstream renderers only handle the known `RoleArchetype` enum values.

## Changes

- `VALID_ROLES` frozenset — the exhaustive set of valid `RoleArchetype` values (spec §2 / amendment A1)
- `_coerce_role(raw)` helper — returns `raw` unchanged if valid, otherwise returns `"ic_engineer"`
- Applied in both `paired_dots` and `personas` sections of `_build_report_json()`
- New test `test_unknown_role_archetype_coerced_to_ic_engineer` in `test_main_e2e.py` — seeds a backstory with `role_archetype="unknown_role"`, runs `run_study()`, and asserts both `paired_dots` and `personas` contain `"ic_engineer"`

## Test run

```
cd apps/aggregator && .venv/bin/python -m pytest tests/test_main_e2e.py -x -q
..  [100%]
2 passed
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)