### PR TITLE
fix(aggregator): set meta.slug = study_id, not share_token_hash (#184)

### DIFF
--- a/apps/aggregator/src/aggregator/main.py
+++ b/apps/aggregator/src/aggregator/main.py
@@ -237,10 +237,11 @@ def _build_report_json(
     clusters: dict[str, list[dict]],
     backstory_map: dict[int, dict],
     share_token_hash: str,
+    study_id: str,
 ) -> dict:
     """Compute the full §5.18 Report visualization blob."""
     meta = {
-        "slug": share_token_hash,
+        "slug": str(study_id),
         "low_power": len(visits) < 20,
     }
 
@@ -439,6 +440,7 @@ def run_study(
         clusters=clusters,
         backstory_map=backstory_map,
         share_token_hash=share_token_hash,
+        study_id=study_id,
     )
 
     db.execute(

--- a/apps/aggregator/tests/test_main_e2e.py
+++ b/apps/aggregator/tests/test_main_e2e.py
@@ -157,8 +157,8 @@ def test_e2e_run_study_writes_report_and_clusters(tmp_path: Path) -> None:
     n_label_rows = cur.fetchone()[0]
     assert n_label_rows == total_clusters
 
-    # report_json slug matches share_token_hash.
-    assert rj["meta"]["slug"] == report_row[2]
+    # report_json slug matches study_id (the URL route key), not the share_token_hash.
+    assert rj["meta"]["slug"] == "study_e2e_001"
     # histograms has at least 1 entry (both variants present in seed data).
     assert isinstance(rj["histograms"], list)
     assert len(rj["histograms"]) >= 1


### PR DESCRIPTION
## Summary

- `_build_report_json()` was setting `meta.slug = share_token_hash` (a 64-char hex string), but the `/r/<slug>` URL route uses `study_id` as the key
- Added `study_id: str` parameter to `_build_report_json()` and changed the slug value to `str(study_id)`
- Updated `run_study()` to pass `study_id` through to `_build_report_json()`
- Updated the e2e test assertion in `test_main_e2e.py` to verify `meta.slug == "study_e2e_001"` (the study_id) instead of the hash

## Test plan

- [x] `cd apps/aggregator && .venv/bin/python -m pytest tests/ -x -q` — all tests pass except the pre-existing `test_paired_delta_disagreement_true` failure (expected per issue)

Fixes #184

🤖 Generated with [Claude Code](https://claude.com/claude-code)