### PR TITLE
feat(web): add overlay toggle to Histograms chart (§5.18 #3, v0.1.1)

### DIFF
--- a/apps/web/components/report/Histograms.tsx
+++ b/apps/web/components/report/Histograms.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { useState } from 'react';
 import {
   Bar,
   BarChart,
@@ -14,12 +15,14 @@ import {
 import type { ReportT, VariantId } from './types';
 
 // Spec §5.18 #3 — discrete 0–10 will-to-buy bins per variant; mean and
-// median annotated. Side-by-side; overlay toggle is v0.1.1 (out of scope).
+// median annotated. Side-by-side default; overlay toggle (v0.1.1).
 
 const VARIANT_COLOR: Record<VariantId, string> = {
   A: '#475569', // slate
   B: '#16a34a', // green (matches dot-plot "B wins")
 };
+
+type HistMode = 'side-by-side' | 'overlay';
 
 function HistOne({ row }: { row: ReportT['histograms'][number] }) {
   const data = row.bins.map((count, score) => ({ score, count }));
@@ -51,12 +54,85 @@ function HistOne({ row }: { row: ReportT['histograms'][number] }) {
   );
 }
 
-export function Histograms({ histograms }: { histograms: ReportT['histograms'] }) {
+function HistOverlay({ histograms }: { histograms: ReportT['histograms'] }) {
+  const data = Array.from({ length: 11 }, (_, score) => {
+    const entry: Record<string, number> = { score };
+    for (const h of histograms) entry[h.variant] = h.bins[score] ?? 0;
+    return entry;
+  });
   return (
-    <section className="grid grid-cols-1 gap-4 md:grid-cols-2">
-      {histograms.map((h) => (
-        <HistOne key={h.variant} row={h} />
-      ))}
+    <div
+      data-testid="histogram-overlay"
+      className="rounded-lg border border-gray-200 bg-white p-4 shadow-sm"
+    >
+      <ResponsiveContainer width="100%" height={240}>
+        <BarChart data={data} margin={{ top: 8, right: 8, bottom: 8, left: 0 }}>
+          <CartesianGrid strokeDasharray="3 3" />
+          <XAxis dataKey="score" tickCount={11} />
+          <YAxis allowDecimals={false} />
+          <Tooltip contentStyle={{ fontSize: 12 }} />
+          {histograms.map((h) => (
+            <Bar
+              key={h.variant}
+              dataKey={h.variant}
+              fill={VARIANT_COLOR[h.variant]}
+              fillOpacity={0.6}
+            />
+          ))}
+          {histograms.flatMap((h) => [
+            <ReferenceLine
+              key={`mean-${h.variant}`}
+              x={h.mean}
+              stroke={VARIANT_COLOR[h.variant]}
+              strokeDasharray="4 2"
+            />,
+            <ReferenceLine
+              key={`median-${h.variant}`}
+              x={h.median}
+              stroke={VARIANT_COLOR[h.variant]}
+              strokeDasharray="2 2"
+            />,
+          ])}
+        </BarChart>
+      </ResponsiveContainer>
+    </div>
+  );
+}
+
+export function Histograms({ histograms }: { histograms: ReportT['histograms'] }) {
+  const [mode, setMode] = useState<HistMode>('side-by-side');
+  const canOverlay = histograms.length === 2;
+  return (
+    <section>
+      {canOverlay && (
+        <div className="flex gap-2 mb-4" data-testid="histogram-mode-toggle">
+          <button
+            onClick={() => setMode('side-by-side')}
+            aria-pressed={mode === 'side-by-side'}
+            className="rounded px-3 py-1 text-sm font-medium border border-gray-300 data-[pressed=true]:bg-gray-100"
+            data-pressed={mode === 'side-by-side'}
+          >
+            Side by side
+          </button>
+          <button
+            onClick={() => setMode('overlay')}
+            aria-pressed={mode === 'overlay'}
+            className="rounded px-3 py-1 text-sm font-medium border border-gray-300 data-[pressed=true]:bg-gray-100"
+            data-pressed={mode === 'overlay'}
+          >
+            Overlay
+          </button>
+        </div>
+      )}
+      {mode === 'overlay' && canOverlay ? (
+        <HistOverlay histograms={histograms} />
+      ) : (
+        <div className="grid grid-cols-1 gap-4 md:grid-cols-2">
+          {histograms.map((h) => (
+            <HistOne key={h.variant} row={h} />
+          ))}
+        </div>
+      )}
     </section>
   );
 }

--- a/apps/web/test/report-viz.test.tsx
+++ b/apps/web/test/report-viz.test.tsx
@@ -15,6 +15,7 @@
 import { act } from 'react';
 import { describe, expect, it, beforeAll, afterEach, vi } from 'vitest';
 import { cleanup, render, screen, fireEvent, within } from '@testing-library/react';
+import { Histograms } from '../components/report/Histograms';
 import { Report, type ReportT } from '@willbuy/shared/report';
 import fixtureJson from './fixtures/report.fixture.json';
 import disagreementJson from './fixtures/report.disagreement.fixture.json';
@@ -289,6 +290,25 @@ describe('§5.18 — report visualization', () => {
     const { container } = render(<ReportView report={parsed} mode="public" />);
     await act(async () => { await Promise.resolve(); });
     expect(container.querySelectorAll('[data-testid="persona-grid"]').length).toBe(1);
+  });
+
+  it('§5.18 #3 v0.1.1 — overlay toggle renders when histograms.length === 2', () => {
+    render(<Histograms histograms={fixture.histograms} />);
+    expect(screen.getByTestId('histogram-mode-toggle')).toBeTruthy();
+  });
+
+  it('§5.18 #3 v0.1.1 — clicking Overlay shows histogram-overlay', () => {
+    render(<Histograms histograms={fixture.histograms} />);
+    // Initially side-by-side
+    expect(screen.queryByTestId('histogram-overlay')).toBeNull();
+    // Click Overlay button
+    fireEvent.click(screen.getByRole('button', { name: /overlay/i }));
+    expect(screen.getByTestId('histogram-overlay')).toBeTruthy();
+  });
+
+  it('§5.18 #3 v0.1.1 — overlay toggle absent for single-variant (histograms.length === 1)', () => {
+    render(<Histograms histograms={[fixture.histograms[0]!]} />);
+    expect(screen.queryByTestId('histogram-mode-toggle')).toBeNull();
   });
 
   it('F1 — paired-dot plot renders one SVG <line> connector per backstory (§5.18 #2)', () => {


### PR DESCRIPTION
## Summary

- Adds a "Side by side | Overlay" mode toggle above the histogram section
- In overlay mode, both variants' bins render on the same `BarChart` with two `<Bar>` components at `fillOpacity={0.6}`; mean/median reference lines for each variant remain visible
- Toggle is only shown when `histograms.length === 2`; single-variant reports are unaffected

## Test plan

- [x] `data-testid="histogram-mode-toggle"` renders when histograms.length === 2
- [x] Clicking "Overlay" shows `data-testid="histogram-overlay"`
- [x] Toggle is absent for single-variant (histograms.length === 1)
- [x] All 14 tests in `report-viz.test.tsx` pass
- [x] `bun run typecheck` passes with no errors

Closes #176

🤖 Generated with [Claude Code](https://claude.com/claude-code)