### PR TITLE
feat(api): wire Resend cap-warning email for §5.6 daily-cap threshold

### DIFF
--- a/apps/api/src/billing/cap-warning.ts
+++ b/apps/api/src/billing/cap-warning.ts
@@ -8,13 +8,12 @@
  * inserts with a unique_violation, so only one concurrent caller succeeds.
  *
  * Returns true when this caller was the one that inserted the warning row
- * (i.e., should enqueue the email). Returns false when the row already
+ * (i.e., the email was dispatched). Returns false when the row already
  * existed (another caller beat us, or the 50% threshold hasn't been crossed).
- *
- * Email sending is stubbed — TODO wire Resend when it's available.
  */
 
 import type postgres from 'postgres';
+import type { ResendClient } from '../email/resend.js';
 
 export type MaybeWarnCapInput = {
   sql: ReturnType<typeof postgres>;
@@ -24,6 +23,12 @@ export type MaybeWarnCapInput = {
   /** The new total cents after a successful reserve (from RETURNING cents). */
   new_cents: number;
   daily_cap_cents: number;
+  /** Account owner email — recipient of the cap-warning email. */
+  owner_email: string;
+  /** The study that pushed spend over the threshold. */
+  study_id: string;
+  /** Resend client for sending the warning email. */
+  resend: ResendClient;
 };
 
 /**
@@ -38,7 +43,7 @@ export type MaybeWarnCapInput = {
  * migration 0008_llm_spend_daily.sql — that is our exactly-once gate.
  */
 export async function maybeWarnCap(input: MaybeWarnCapInput): Promise<boolean> {
-  const { sql, account_id, date, new_cents, daily_cap_cents } = input;
+  const { sql, account_id, date, new_cents, daily_cap_cents, owner_email, study_id, resend } = input;
 
   if (new_cents < daily_cap_cents * 0.5) {
     return false;
@@ -57,9 +62,22 @@ export async function maybeWarnCap(input: MaybeWarnCapInput): Promise<boolean> {
     return false;
   }
 
-  // This caller won the race — enqueue the warning email.
-  // TODO: wire Resend transactional email here once available (spec §5.6).
-  // await resend.emails.send({ to: account.owner_email, subject: '50% cap warning', ... });
+  // This caller won the race — send the warning email (spec §5.6).
+  // cap_warning_sent_at (the INSERT above) is committed first so idempotency
+  // holds even if the send fails. We log errors but do not throw — a missed
+  // email is recoverable; propagating the error here would break the study
+  // creation response.
+  try {
+    await resend.sendCapWarning({
+      to: owner_email,
+      account_id: String(account_id),
+      current_cents: new_cents,
+      cap_cents: daily_cap_cents,
+      study_id,
+    });
+  } catch (err) {
+    console.error('[cap-warning] sendCapWarning failed (non-fatal):', err);
+  }
 
   return true;
 }

--- a/apps/api/src/email/resend.ts
+++ b/apps/api/src/email/resend.ts
@@ -15,8 +15,17 @@ export interface MagicLinkEmailOptions {
   verifyUrl: string;
 }
 
+export interface CapWarningEmailOptions {
+  to: string;          // account owner email
+  account_id: string;
+  current_cents: number;
+  cap_cents: number;
+  study_id: string;
+}
+
 export interface ResendClient {
   sendMagicLink(opts: MagicLinkEmailOptions): Promise<void>;
+  sendCapWarning(opts: CapWarningEmailOptions): Promise<void>;
   /** Number of times sendMagicLink was called — useful in test assertions. */
   callCount: number;
 }
@@ -69,6 +78,39 @@ export function buildResendClient(opts: {
           '<p>Click the button below to sign in. This link expires in <strong>30 minutes</strong> and can only be used once.</p>',
           `<p><a href="${verifyUrl}" style="display:inline-block;padding:12px 24px;background:#111;color:#fff;text-decoration:none;border-radius:6px;font-weight:600">Sign in</a></p>`,
           '<p style="color:#666;font-size:13px">If you did not request this, you can safely ignore this email.</p>',
+          '</body></html>',
+        ].join(''),
+      });
+
+      if (result.error) {
+        throw new Error(`Resend error: ${result.error.message}`);
+      }
+    },
+
+    async sendCapWarning(opts: CapWarningEmailOptions): Promise<void> {
+      if (testMode || !client) {
+        console.log('[resend-stub] sendCapWarning', opts);
+        return;
+      }
+
+      const currentDollars = (opts.current_cents / 100).toFixed(2);
+      const capDollars = (opts.cap_cents / 100).toFixed(2);
+
+      const result = await client.emails.send({
+        from: 'alerts@willbuy.dev',
+        to: opts.to,
+        subject: 'Daily cap 50% warning — willbuy.dev',
+        html: [
+          '<!DOCTYPE html><html><body style="font-family:sans-serif;max-width:600px;margin:auto;padding:24px">',
+          '<h2 style="color:#b45309">Daily spend cap 50% warning</h2>',
+          '<p>Your account has reached <strong>50% of its daily spend cap</strong>.</p>',
+          '<table style="border-collapse:collapse;width:100%">',
+          `<tr><td style="padding:8px;border:1px solid #e5e7eb;color:#6b7280">Account ID</td><td style="padding:8px;border:1px solid #e5e7eb">${opts.account_id}</td></tr>`,
+          `<tr><td style="padding:8px;border:1px solid #e5e7eb;color:#6b7280">Study ID</td><td style="padding:8px;border:1px solid #e5e7eb">${opts.study_id}</td></tr>`,
+          `<tr><td style="padding:8px;border:1px solid #e5e7eb;color:#6b7280">Current spend</td><td style="padding:8px;border:1px solid #e5e7eb">$${currentDollars} (${opts.current_cents}¢)</td></tr>`,
+          `<tr><td style="padding:8px;border:1px solid #e5e7eb;color:#6b7280">Daily cap</td><td style="padding:8px;border:1px solid #e5e7eb">$${capDollars} (${opts.cap_cents}¢)</td></tr>`,
+          '</table>',
+          '<p style="color:#666;font-size:13px;margin-top:16px">New studies will be blocked once the daily cap is reached. To increase your cap, contact support.</p>',
           '</body></html>',
         ].join(''),
       });

--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -31,10 +31,13 @@ import tldts from 'tldts';
 import { z } from 'zod';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
+import type postgres from 'postgres';
 
 import { buildApiKeyMiddleware } from '../auth/api-key.js';
 import { buildSessionMiddleware } from '../auth/session.js';
 import type { Env } from '../env.js';
+import type { ResendClient } from '../email/resend.js';
+import { maybeWarnCap } from '../billing/cap-warning.js';
 import { recordStudyStarted } from '../metrics/registry.js';
 
 // Per-visit estimated cost ceiling = 5¢ per spec §5.5 (cost-model ceiling).
@@ -90,6 +93,8 @@ export async function registerStudiesRoutes(
   app: FastifyInstance,
   pool: Pool,
   env: Env,
+  sql: ReturnType<typeof postgres>,
+  resend: ResendClient,
 ): Promise<void> {
   const apiKeyMiddleware = buildApiKeyMiddleware(pool);
 
@@ -201,6 +206,20 @@ export async function registerStudiesRoutes(
         // Issue #119 / spec §5.14: business-counter increment AFTER commit so
         // we don't inflate the count for rolled-back transactions.
         recordStudyStarted({ kind });
+
+        // §5.6: fire-and-forget cap-warning email. maybeWarnCap is idempotent
+        // (ON CONFLICT DO NOTHING) — safe to call without awaiting in the
+        // response path. Errors are logged inside maybeWarnCap, not propagated.
+        void maybeWarnCap({
+          sql,
+          account_id: account.id,
+          date: today,
+          new_cents: spendRows.rows[0]!.cents,
+          daily_cap_cents: env.DAILY_CAP_CENTS,
+          owner_email: account.owner_email,
+          study_id: studyId,
+          resend,
+        });
 
         return reply.code(201).send({ study_id: Number(studyId), status: 'capturing' });
       } catch (err) {

--- a/apps/api/src/server.ts
+++ b/apps/api/src/server.ts
@@ -5,6 +5,7 @@ import { fileURLToPath } from 'node:url';
 import sensible from '@fastify/sensible';
 import Fastify, { type FastifyBaseLogger, type FastifyInstance } from 'fastify';
 import { Pool } from 'pg';
+import postgres from 'postgres';
 import Stripe from 'stripe';
 
 import type { Env } from './env.js';
@@ -76,8 +77,12 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
   // histogram captures every subsequent route (issue #119, spec §5.14).
   await registerMetricsRoute(app, env.WILLBUY_METRICS_TOKEN);
 
-  // Postgres connection pool — shared across all routes.
+  // Postgres connection pool — shared across all routes (pg.Pool for most routes).
   const pool = new Pool({ connectionString: env.DATABASE_URL });
+
+  // postgres tagged-template client — used by billing helpers (reserveSpend,
+  // maybeWarnCap) that require the postgres() API rather than pg.Pool.
+  const sql = postgres(env.DATABASE_URL, { max: 5, idle_timeout: 10 });
 
   // Initialize credit-pack tiers with price IDs from env (§5.6, issue #36).
   initPacks({
@@ -117,7 +122,7 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
   await registerApiKeyRoutes(app, pool, env);
 
   // Wire authenticated routes.
-  await registerStudiesRoutes(app, pool, env);
+  await registerStudiesRoutes(app, pool, env, sql, resend);
 
   // Wire public report route (§5.12 share-token cookie redirect, issue #76).
   await registerReportsRoutes(app, pool, env.SHARE_TOKEN_HMAC_KEY);
@@ -126,9 +131,10 @@ export async function buildServer(opts: BuildServerOptions): Promise<FastifyInst
   await registerCheckoutRoutes(app, pool, env, stripe);
   await registerStripeWebhookRoute(app, pool, stripe, env.STRIPE_WEBHOOK_SECRET);
 
-  // Close pool on server shutdown.
+  // Close pool and postgres client on server shutdown.
   app.addHook('onClose', async () => {
     await pool.end();
+    await sql.end();
   });
 
   return app;

--- a/apps/api/test/api-keys.test.ts
+++ b/apps/api/test/api-keys.test.ts
@@ -72,6 +72,9 @@ function buildStubResend(): ResendClient {
     async sendMagicLink() {
       callCount += 1;
     },
+    async sendCapWarning() {
+      // no-op stub
+    },
   };
 }
 

--- a/apps/api/test/atomic-spend.test.ts
+++ b/apps/api/test/atomic-spend.test.ts
@@ -18,6 +18,7 @@ import { startPostgres, stopPostgres } from '../../../tests/helpers/start-postgr
 import { reserveSpend } from '../src/billing/atomic-spend.js';
 import { startAttempt, endAttempt } from '../src/billing/provider-attempts.js';
 import { maybeWarnCap } from '../src/billing/cap-warning.js';
+import type { ResendClient, CapWarningEmailOptions } from '../src/email/resend.js';
 
 // ---------------------------------------------------------------------------
 // Docker availability guard
@@ -37,6 +38,26 @@ const describeIfDocker = dockerAvailable ? describe : describe.skip;
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '..', '..', '..');
+
+// ---------------------------------------------------------------------------
+// Stub Resend client — tracks sendCapWarning calls for assertions
+// ---------------------------------------------------------------------------
+
+interface CapWarnStub extends ResendClient {
+  capWarnCalls: CapWarningEmailOptions[];
+}
+
+function buildCapWarnStubResend(): CapWarnStub {
+  const capWarnCalls: CapWarningEmailOptions[] = [];
+  return {
+    get callCount() { return 0; },
+    async sendMagicLink() { /* no-op */ },
+    async sendCapWarning(opts) {
+      capWarnCalls.push(opts);
+    },
+    capWarnCalls,
+  };
+}
 
 // ---------------------------------------------------------------------------
 // Globals set up in beforeAll
@@ -271,8 +292,10 @@ describeIfDocker('atomic spend reservation (§5.5)', () => {
   // -------------------------------------------------------------------------
   it('AC5: concurrent cap_50_warning inserts → exactly one row in cap_warnings', async () => {
     const accountId = await newAccount();
+    const studyId = await newStudy(accountId);
     const date = '2099-01-05';
     const DAILY_CAP = 100;
+    const resend = buildCapWarnStubResend();
 
     // Two concurrent calls both indicate crossing 50%
     const results = await Promise.all([
@@ -282,6 +305,9 @@ describeIfDocker('atomic spend reservation (§5.5)', () => {
         date,
         new_cents: 51,
         daily_cap_cents: DAILY_CAP,
+        owner_email: 'ac5@example.com',
+        study_id: String(studyId),
+        resend,
       }),
       maybeWarnCap({
         sql,
@@ -289,6 +315,9 @@ describeIfDocker('atomic spend reservation (§5.5)', () => {
         date,
         new_cents: 52,
         daily_cap_cents: DAILY_CAP,
+        owner_email: 'ac5@example.com',
+        study_id: String(studyId),
+        resend,
       }),
     ]);
 
@@ -302,6 +331,106 @@ describeIfDocker('atomic spend reservation (§5.5)', () => {
       [String(accountId), date],
     );
     expect(Number(rows[0]!.count)).toBe(1);
+
+    // Exactly one sendCapWarning call dispatched (by the winner of the race).
+    expect(resend.capWarnCalls).toHaveLength(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // AC7: sendCapWarning called with correct params when threshold crossed
+  // -------------------------------------------------------------------------
+  it('AC7: sendCapWarning called with correct params when 50% threshold crossed', async () => {
+    const accountId = await newAccount();
+    const studyId = await newStudy(accountId);
+    const date = '2099-01-07';
+    const DAILY_CAP = 200;
+    const resend = buildCapWarnStubResend();
+
+    const result = await maybeWarnCap({
+      sql,
+      account_id: accountId,
+      date,
+      new_cents: 105, // > 50% of 200
+      daily_cap_cents: DAILY_CAP,
+      owner_email: 'owner@example.com',
+      study_id: String(studyId),
+      resend,
+    });
+
+    expect(result).toBe(true);
+    expect(resend.capWarnCalls).toHaveLength(1);
+    expect(resend.capWarnCalls[0]).toMatchObject({
+      to: 'owner@example.com',
+      account_id: String(accountId),
+      current_cents: 105,
+      cap_cents: DAILY_CAP,
+      study_id: String(studyId),
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // AC8: sendCapWarning NOT called when threshold not crossed
+  // -------------------------------------------------------------------------
+  it('AC8: sendCapWarning NOT called when below 50% threshold', async () => {
+    const accountId = await newAccount();
+    const studyId = await newStudy(accountId);
+    const date = '2099-01-08';
+    const DAILY_CAP = 200;
+    const resend = buildCapWarnStubResend();
+
+    const result = await maybeWarnCap({
+      sql,
+      account_id: accountId,
+      date,
+      new_cents: 99, // < 50% of 200
+      daily_cap_cents: DAILY_CAP,
+      owner_email: 'owner@example.com',
+      study_id: String(studyId),
+      resend,
+    });
+
+    expect(result).toBe(false);
+    expect(resend.capWarnCalls).toHaveLength(0);
+  });
+
+  // -------------------------------------------------------------------------
+  // AC9: sendCapWarning NOT called when cap_warning_sent_at already exists
+  // -------------------------------------------------------------------------
+  it('AC9: sendCapWarning NOT called when warning already sent (idempotent)', async () => {
+    const accountId = await newAccount();
+    const studyId = await newStudy(accountId);
+    const date = '2099-01-09';
+    const DAILY_CAP = 100;
+    const resend = buildCapWarnStubResend();
+
+    // First call: inserts warning row, sends email
+    const first = await maybeWarnCap({
+      sql,
+      account_id: accountId,
+      date,
+      new_cents: 55,
+      daily_cap_cents: DAILY_CAP,
+      owner_email: 'owner@example.com',
+      study_id: String(studyId),
+      resend,
+    });
+    expect(first).toBe(true);
+    expect(resend.capWarnCalls).toHaveLength(1);
+
+    // Second call with same (account_id, date): ON CONFLICT DO NOTHING → no email
+    const second = await maybeWarnCap({
+      sql,
+      account_id: accountId,
+      date,
+      new_cents: 60,
+      daily_cap_cents: DAILY_CAP,
+      owner_email: 'owner@example.com',
+      study_id: String(studyId),
+      resend,
+    });
+    expect(second).toBe(false);
+    // Still only one call — idempotent
+    expect(resend.capWarnCalls).toHaveLength(1);
   });
 
   // -------------------------------------------------------------------------

--- a/apps/api/test/auth.test.ts
+++ b/apps/api/test/auth.test.ts
@@ -63,6 +63,9 @@ function buildStubResend(): ResendClient & { lastCall: { to: string; verifyUrl: 
       callCount += 1;
       lastCall = opts;
     },
+    async sendCapWarning() {
+      // no-op stub
+    },
   };
 }
 

--- a/apps/api/test/dashboard.test.ts
+++ b/apps/api/test/dashboard.test.ts
@@ -64,6 +64,9 @@ function buildStubResend(): ResendClient {
     async sendMagicLink() {
       callCount += 1;
     },
+    async sendCapWarning() {
+      // no-op stub
+    },
   };
 }
 

--- a/apps/api/test/studies-list.test.ts
+++ b/apps/api/test/studies-list.test.ts
@@ -70,6 +70,9 @@ function buildStubResend(): ResendClient {
     async sendMagicLink() {
       callCount += 1;
     },
+    async sendCapWarning() {
+      // no-op stub
+    },
   };
 }
 


### PR DESCRIPTION
## Summary

- Adds `CapWarningEmailOptions` interface and `sendCapWarning` method to `ResendClient` in `resend.ts`; implements stub (console.log) and live (Resend API with HTML table body) variants
- Extends `MaybeWarnCapInput` with `owner_email`, `study_id`, `resend`; `maybeWarnCap` now calls `sendCapWarning` after the exactly-once `cap_warnings` INSERT — errors are caught/logged, not rethrown, preserving the study creation response
- Threads a `postgres` sql client + `resend` through `buildServer` → `registerStudiesRoutes`; `POST /studies` calls `maybeWarnCap` (fire-and-forget via `void`) after COMMIT

## Tests

- Updated existing AC5 test to pass new required fields; all 6 pre-existing tests still pass
- Added AC7: `sendCapWarning` called with correct params when 50% threshold crossed
- Added AC8: `sendCapWarning` not called when below threshold
- Added AC9: `sendCapWarning` not called when idempotency row already exists (ON CONFLICT)
- Updated all `buildStubResend` stubs in `auth.test.ts`, `dashboard.test.ts`, `api-keys.test.ts`, `studies-list.test.ts` to implement the new interface method

## Test plan

- [x] `bun run typecheck` — zero errors
- [x] `bun run test test/atomic-spend.test.ts` — 9/9 passed (Docker required, confirmed green locally)
- [ ] CI green on full suite

Closes #174

🤖 Generated with [Claude Code](https://claude.com/claude-code)