### PR TITLE
fix(aggregator): re-pin Wilcoxon p-value gold to scipy 1.17.1

### DIFF
--- a/apps/aggregator/tests/test_stats.py
+++ b/apps/aggregator/tests/test_stats.py
@@ -102,8 +102,10 @@ def test_paired_delta_disagreement_true() -> None:
     # Paired-t: p ≈ 0.6633 (≥ 0.05, NOT significant).
     assert pytest.approx(out.paired_t_p, abs=1e-4) == 0.6633
 
-    # Wilcoxon: p ≈ 0.0121 (< 0.05, significant).
-    assert pytest.approx(out.wilcoxon_p, abs=1e-4) == 0.0121
+    # Wilcoxon: p ≈ 0.0069 (< 0.05, significant).
+    # Gold value re-pinned to scipy 1.17.1 (venv); older scipy returned 0.0121.
+    # Both are < 0.05, so the disagreement=True conclusion is unchanged.
+    assert pytest.approx(out.wilcoxon_p, abs=1e-4) == 0.0069
 
     # Exactly one test is significant → disagreement = True.
     assert out.disagreement is True


### PR DESCRIPTION
## Problem

`test_paired_delta_disagreement_true` has been failing as a pre-existing issue across every PR in Sprint 6+7 (silently, since Python tests run separately from the CI bun suite — but blocks local `pytest` runs and makes the test output noisy).

Root cause: the Wilcoxon signed-rank p-value gold was pinned to an older scipy version (~1.10.x) that computed `0.0121` for this fixture. scipy 1.17.1 (used in the venv) computes `0.0069` for identical inputs (`[0.3]*18 + [-2.0]*2`, `zero_method='wilcox'`, `correction=False`).

Both values are `< 0.05`, so `disagreement=True` is correct and unchanged. Only the expected float needed updating.

## Fix

Update the gold value comment and assertion from `0.0121` to `0.0069` (scipy 1.17.1 output, 4 decimal places).

## Test plan

- All 3 `test_stats.py` tests pass locally with the venv's scipy 1.17.1

🤖 Generated with [Claude Code](https://claude.com/claude-code)