### PR TITLE
feat(web+api): show tested URL(s) as context banner on report page (issue #194)

### DIFF
--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -168,6 +168,7 @@ interface ReportRow {
   paired_tests_disagreement: boolean | null;
   ready_at: Date;
   report_json: unknown | null;
+  urls: string[] | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -193,7 +194,8 @@ export async function registerReportsRoutes(
                 r.expires_at, r.conv_score, r.paired_delta_json,
                 r.clusters_json, r.scores_json,
                 r.paired_tests_disagreement, r.ready_at,
-                r.report_json
+                r.report_json,
+                s.urls
            FROM reports r
            JOIN studies s ON s.id = r.study_id
           WHERE r.study_id = $1`,
@@ -222,6 +224,7 @@ export async function registerReportsRoutes(
           paired_tests_disagreement: report.paired_tests_disagreement,
           ready_at: report.ready_at.toISOString(),
           report_json: report.report_json ?? null,
+          urls: report.urls ?? null,
         });
       };
 

--- a/apps/web/app/r/[slug]/fetchReport.ts
+++ b/apps/web/app/r/[slug]/fetchReport.ts
@@ -5,14 +5,15 @@
 // Return value is a discriminated union:
 //   - 'not_found'  API returned 404 (study_id invalid, report expired, or fetch error)
 //   - 'pending'    API returned 200 but report_json is null (aggregator not yet run)
-//   - unknown      API returned 200 with valid report_json (parsed payload)
+//   - ReportPayload  API returned 200 with valid report_json (parsed payload + urls)
 
 import { cookies } from 'next/headers';
 import fixture from '../../../test/fixtures/report.fixture.json';
 
 const FIXTURE_SLUG = 'test-fixture';
 
-export type FetchReportResult = 'not_found' | 'pending' | unknown;
+export type ReportPayload = { reportJson: unknown; urls: string[] | null };
+export type FetchReportResult = 'not_found' | 'pending' | ReportPayload;
 
 function apiBaseUrl(): string {
   const explicit = process.env['WILLBUY_API_URL'] ?? process.env['NEXT_PUBLIC_API_URL'];
@@ -25,7 +26,7 @@ export async function fetchReport(slug: string): Promise<FetchReportResult> {
     process.env.WILLBUY_REPORT_FIXTURE === 'enabled' &&
     slug === FIXTURE_SLUG
   ) {
-    return fixture;
+    return { reportJson: fixture, urls: null };
   }
 
   // cookies() throws outside a request scope (e.g. in unit tests); treat as no cookie.
@@ -56,5 +57,6 @@ export async function fetchReport(slug: string): Promise<FetchReportResult> {
   const body = (await res.json()) as Record<string, unknown>;
   const reportJson = body['report_json'];
   if (reportJson === null || reportJson === undefined) return 'pending';
-  return reportJson;
+  const urls = Array.isArray(body['urls']) ? (body['urls'] as string[]) : null;
+  return { reportJson, urls };
 }

--- a/apps/web/app/r/[slug]/page.tsx
+++ b/apps/web/app/r/[slug]/page.tsx
@@ -21,7 +21,7 @@ export default async function ReportPage({
   const { slug } = await params;
   const result = await fetchReport(slug);
 
-  if (result === 'not_found' || result === null) {
+  if (result === 'not_found') {
     return (
       <>
         <main className="mx-auto max-w-3xl px-6 py-16">

--- a/apps/web/app/r/[slug]/page.tsx
+++ b/apps/web/app/r/[slug]/page.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from 'next';
 
 import { Report, type ReportT } from '@willbuy/shared/report';
+import { ContextBanner } from '../../../components/report/ContextBanner';
 import { ReportCtaBar } from '../../../components/report/ReportCtaBar';
 import { ReportView } from '../../../components/report/ReportView';
 import { fetchReport } from './fetchReport';
@@ -51,7 +52,8 @@ export default async function ReportPage({
   // Parse at the boundary (per CLAUDE.md zod-at-the-boundary rule).
   // Anything that fails this validation is an aggregator-side bug and
   // we'd rather 500 than render a malformed report.
-  const report: ReportT = Report.parse(result);
+  const report: ReportT = Report.parse(result.reportJson);
+  const urls = result.urls ?? [];
   return (
     <>
       <main className="mx-auto max-w-6xl px-4 py-10">
@@ -61,6 +63,7 @@ export default async function ReportPage({
             Study <code className="text-base">{report.meta.slug}</code>
           </h1>
         </header>
+        {urls.length > 0 && <ContextBanner urls={urls} />}
         <ReportView report={report} mode="public" />
       </main>
       <ReportCtaBar />

--- a/apps/web/components/report/ContextBanner.tsx
+++ b/apps/web/components/report/ContextBanner.tsx
@@ -1,0 +1,55 @@
+// ContextBanner — shows which URL(s) were tested, displayed above the report.
+// Single-variant: "Page tested: <url>"
+// Paired A/B: "A: <url-a>  vs  B: <url-b>"
+
+interface ContextBannerProps {
+  urls: string[];
+}
+
+export function ContextBanner({ urls }: ContextBannerProps) {
+  if (urls.length === 0) return null;
+
+  return (
+    <div className="mb-6 rounded-lg border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-700">
+      {urls.length === 1 ? (
+        <span>
+          <span className="font-medium text-gray-500">Page tested:&nbsp;</span>
+          <a
+            href={urls[0]}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="text-blue-600 underline underline-offset-2 hover:text-blue-800 break-all"
+          >
+            {urls[0]}
+          </a>
+        </span>
+      ) : (
+        <span className="flex flex-wrap items-center gap-x-3 gap-y-1">
+          <span>
+            <span className="font-semibold">A:&nbsp;</span>
+            <a
+              href={urls[0]}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline underline-offset-2 hover:text-blue-800 break-all"
+            >
+              {urls[0]}
+            </a>
+          </span>
+          <span className="text-gray-400">vs</span>
+          <span>
+            <span className="font-semibold">B:&nbsp;</span>
+            <a
+              href={urls[1]}
+              target="_blank"
+              rel="noopener noreferrer"
+              className="text-blue-600 underline underline-offset-2 hover:text-blue-800 break-all"
+            >
+              {urls[1]}
+            </a>
+          </span>
+        </span>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- `GET /reports/:slug` now returns `urls: string[] | null` sourced from `studies.urls`
- `fetchReport` now returns `ReportPayload { reportJson, urls }` instead of raw `unknown`, fixing the discriminated union type
- New `ContextBanner` component renders above the report: single-URL shows "Page tested: <link>", paired shows "A: <link>  vs  B: <link>"
- Banner is skipped for legacy reports where `urls` is null/empty

## Test plan
- [ ] CI green
- [ ] REV review
- [ ] Manual: `https://willbuy.dev/r/1` shows "Page tested: https://postgres.ai/pricing" banner above the headline delta
- [ ] TypeScript: both `apps/api` and `apps/web` compile clean (`tsc --noEmit` exit 0)

Closes #194