### PR TITLE
ops: add willbuy-api and willbuy-web systemd unit templates

### DIFF
--- a/infra/systemd/willbuy-api.service
+++ b/infra/systemd/willbuy-api.service
@@ -1,0 +1,23 @@
+[Unit]
+# willbuy API — spec §5 REST layer.
+#
+# Binds to port 3001. PORT=3001 is set explicitly here to override any
+# PORT= in EnvironmentFile (which is shared with willbuy-web.service).
+# The environment file is provisioned out-of-band via 1Password +
+# scripts/push-secrets.sh and is NEVER in git.
+
+Description=willbuy API
+After=network.target
+
+[Service]
+Type=simple
+User=willbuy
+WorkingDirectory=/srv/willbuy
+EnvironmentFile=/etc/willbuy/app.env
+Environment=PORT=3001
+ExecStart=/home/willbuy/.bun/bin/bun run apps/api/src/index.ts
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/willbuy-web.service
+++ b/infra/systemd/willbuy-web.service
@@ -1,0 +1,22 @@
+[Unit]
+# willbuy Next.js web — spec §5 front-end layer.
+#
+# Runs `next start -p 3000` directly to guarantee port 3000, bypassing
+# the PORT env var in the shared EnvironmentFile (which is set to 3001
+# for the API). Using `-p` flag rather than Environment=PORT= because
+# `bun run --filter` does not propagate Environment overrides to Next.js.
+
+Description=willbuy web
+After=willbuy-api.service
+
+[Service]
+Type=simple
+User=willbuy
+WorkingDirectory=/srv/willbuy
+EnvironmentFile=/etc/willbuy/app.env
+ExecStart=/bin/bash -c "cd /srv/willbuy/apps/web && /home/willbuy/.bun/bin/bun run next start -p 3000"
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary
- Adds `infra/systemd/willbuy-api.service` and `infra/systemd/willbuy-web.service` to document the production service configuration
- Fixes a port conflict where both services were inheriting `PORT=3001` from the shared `/etc/willbuy/app.env`
- API uses `Environment=PORT=3001` override; web uses `next start -p 3000` because `bun run --filter` doesn't forward `Environment=` overrides to Next.js

## Context
The web service was crashing with `EADDRINUSE :3001` because:
1. `app.env` has `PORT=3001`
2. `bun run --filter @willbuy/web start` passes this to `next start`, which uses `PORT` env var
3. The API also needs 3001

Fix already applied on `willbuy-v01`. This PR just documents the correct config in the repo.

## Test plan
- [ ] CI green (ops change only — no app logic)
- [ ] `scp infra/systemd/willbuy-api.service infra/systemd/willbuy-web.service root@willbuy-v01:/etc/systemd/system/` → `systemctl daemon-reload` → services stay healthy