### PR TITLE
feat(aggregator): wire claude CLI as LLM caller for cluster labeling (issue #199)

### DIFF
--- a/apps/aggregator/src/aggregator/main.py
+++ b/apps/aggregator/src/aggregator/main.py
@@ -510,13 +510,15 @@ def _make_cli_llm_caller(llm_bin: str) -> LLMCaller:
     if not shutil.which(llm_bin):
         return _stub_llm_caller  # type: ignore[return-value]
 
+    timeout_s = int(os.environ.get("WILLBUY_LLM_LABEL_TIMEOUT_S", "30"))
+
     def _caller(prompt: str, *, kind: str) -> str:
         result = subprocess.run(
             [llm_bin],
             input=prompt,
             capture_output=True,
             text=True,
-            timeout=30,
+            timeout=timeout_s,
         )
         if result.returncode != 0:
             raise RuntimeError(

--- a/apps/aggregator/src/aggregator/main.py
+++ b/apps/aggregator/src/aggregator/main.py
@@ -492,14 +492,39 @@ def _connect_from_env() -> Any:
 
 
 def _stub_llm_caller(prompt: str, *, kind: str) -> str:  # pragma: no cover
-    """Fallback when no LLM provider is wired (offline smoke runs).
-
-    Production uses the TS LLMProvider via subprocess (spec §27); that wiring
-    lands in S2-6 (API service) — the API spawns the aggregator and passes
-    the LLM endpoint through env. Until then, we return a placeholder so the
-    pipeline shape is exercisable end-to-end.
-    """
+    """Fallback when no LLM provider is wired (offline smoke runs)."""
     return "unlabeled cluster"
+
+
+def _make_cli_llm_caller(llm_bin: str) -> LLMCaller:
+    """Build an LLM caller that pipes the prompt to the claude CLI via stdin.
+
+    Mirrors the LocalCliProvider pattern in packages/llm-adapter: the binary
+    reads the full prompt from stdin and writes the response to stdout.
+    WILLBUY_LLM_BIN defaults to 'claude' (Claude Code CLI), matching the
+    visitor-worker's LocalCliProvider default.
+    """
+    import shutil
+    import subprocess
+
+    if not shutil.which(llm_bin):
+        return _stub_llm_caller  # type: ignore[return-value]
+
+    def _caller(prompt: str, *, kind: str) -> str:
+        result = subprocess.run(
+            [llm_bin],
+            input=prompt,
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+        if result.returncode != 0:
+            raise RuntimeError(
+                f"{llm_bin} exited {result.returncode}: {result.stderr[:200]}"
+            )
+        return result.stdout.strip()
+
+    return _caller
 
 
 def cli(argv: list[str] | None = None) -> int:
@@ -507,9 +532,12 @@ def cli(argv: list[str] | None = None) -> int:
     parser.add_argument("--study-id", required=True)
     args = parser.parse_args(argv)
 
+    llm_bin = os.environ.get("WILLBUY_LLM_BIN", "claude")
+    llm_caller = _make_cli_llm_caller(llm_bin)
+
     conn = _connect_from_env()
     try:
-        run_study(study_id=args.study_id, conn=conn, llm_caller=_stub_llm_caller, ledger=_NoOpLedger())
+        run_study(study_id=args.study_id, conn=conn, llm_caller=llm_caller, ledger=_NoOpLedger())
     finally:
         conn.close()
     return 0

--- a/apps/aggregator/tests/test_cli_llm_caller.py
+++ b/apps/aggregator/tests/test_cli_llm_caller.py
@@ -6,7 +6,7 @@ when the binary is present (using a mock subprocess).
 
 from __future__ import annotations
 
-import subprocess
+import pytest
 from unittest.mock import MagicMock, patch
 
 from aggregator.main import _make_cli_llm_caller, _stub_llm_caller
@@ -48,9 +48,5 @@ def test_make_cli_llm_caller_raises_on_nonzero_exit() -> None:
     with patch("shutil.which", return_value="/usr/bin/claude"), \
          patch("subprocess.run", return_value=fake_result):
         caller = _make_cli_llm_caller("claude")
-        try:
+        with pytest.raises(RuntimeError, match="exited 1"):
             caller("some prompt", kind="cluster_label")
-            raise AssertionError("Expected RuntimeError")
-        except RuntimeError as e:
-            assert "exited 1" in str(e)
-            assert "authentication failed" in str(e)

--- a/apps/aggregator/tests/test_cli_llm_caller.py
+++ b/apps/aggregator/tests/test_cli_llm_caller.py
@@ -1,0 +1,56 @@
+"""Unit tests for _make_cli_llm_caller (issue #199 — cluster labeling).
+
+Tests the fallback-to-stub when binary is missing, and the happy-path
+when the binary is present (using a mock subprocess).
+"""
+
+from __future__ import annotations
+
+import subprocess
+from unittest.mock import MagicMock, patch
+
+from aggregator.main import _make_cli_llm_caller, _stub_llm_caller
+
+
+def test_make_cli_llm_caller_falls_back_to_stub_when_binary_missing() -> None:
+    """If llm_bin is not on PATH, fall back to _stub_llm_caller."""
+    with patch("shutil.which", return_value=None):
+        caller = _make_cli_llm_caller("nonexistent-binary")
+    # Should return the stub function itself
+    assert caller is _stub_llm_caller
+
+
+def test_make_cli_llm_caller_calls_binary_via_stdin() -> None:
+    """When the binary exists, the caller pipes prompt to stdin and returns stdout."""
+    fake_result = MagicMock()
+    fake_result.returncode = 0
+    fake_result.stdout = "  Pricing tiers unclear  \n"
+
+    with patch("shutil.which", return_value="/usr/bin/claude"), \
+         patch("subprocess.run", return_value=fake_result) as mock_run:
+        caller = _make_cli_llm_caller("claude")
+        label = caller("- pricing confusing\n- too many tiers", kind="cluster_label")
+
+    # Label should be stripped
+    assert label == "Pricing tiers unclear"
+    # subprocess.run should have been called with the prompt as stdin
+    call_kwargs = mock_run.call_args
+    assert call_kwargs.kwargs["input"] == "- pricing confusing\n- too many tiers"
+    assert call_kwargs.args[0] == ["claude"]
+
+
+def test_make_cli_llm_caller_raises_on_nonzero_exit() -> None:
+    """Non-zero exit from the binary raises RuntimeError."""
+    fake_result = MagicMock()
+    fake_result.returncode = 1
+    fake_result.stderr = "authentication failed"
+
+    with patch("shutil.which", return_value="/usr/bin/claude"), \
+         patch("subprocess.run", return_value=fake_result):
+        caller = _make_cli_llm_caller("claude")
+        try:
+            caller("some prompt", kind="cluster_label")
+            raise AssertionError("Expected RuntimeError")
+        except RuntimeError as e:
+            assert "exited 1" in str(e)
+            assert "authentication failed" in str(e)


### PR DESCRIPTION
## Summary

All theme clusters in the dogfood report were showing `\"unlabeled cluster\"` because `cli()` always used `_stub_llm_caller`. This PR:

- Adds `_make_cli_llm_caller(llm_bin)` that pipes label prompts to `WILLBUY_LLM_BIN` (default `claude`) via stdin — matches the `LocalCliProvider` pattern in `packages/llm-adapter`
- Falls back to `_stub_llm_caller` when the binary is not on PATH (CI hermetic, offline smoke runs)
- `cli()` now resolves the caller from env at runtime
- Adds 3 unit tests covering: binary missing → stub fallback, happy-path subprocess call, non-zero exit → RuntimeError

## Test plan
- [ ] CI green (aggregator job)
- [ ] REV review
- [ ] On production server: `aggregator --study-id 1` with `claude` on PATH produces real labels
- [ ] Local: `WILLBUY_LLM_BIN=claude aggregator --study-id 1` labels populated in report_json

## Acceptance
After deploy + re-run, `GET /reports/1` should return `theme_board.blockers[0].label` ≠ `"unlabeled cluster"`

Closes #199