### PR TITLE
feat(capture-worker): WILLBUY_CAPTURE_RUNTIME flag — netns default, firecracker stub seam (issue #116)

### DIFF
--- a/apps/capture-worker/src/index.ts
+++ b/apps/capture-worker/src/index.ts
@@ -18,6 +18,14 @@ export type {
 export { CAPTURE_CEILINGS } from './types.js';
 export { pollOnce, runPollingLoop } from './poller.js';
 export { sendToBroker } from './broker-client.js';
+export {
+  RuntimeConfigError,
+  RuntimeNotImplementedError,
+  runCapture,
+  selectRuntime,
+  selectRuntimeFromEnv,
+  type CaptureRuntime,
+} from './runtime.js';
 
 // ── production entrypoint ─────────────────────────────────────────────────────
 // Only runs when this file is executed directly (not when imported).
@@ -33,8 +41,33 @@ if (isMain) {
   const { Pool } = await import('pg');
   const { runPollingLoop: startLoop } = await import('./poller.js');
   const { buildCaptureWorkerLogger } = await import('./logger.js');
+  const { selectRuntimeFromEnv, RuntimeConfigError } = await import(
+    './runtime.js'
+  );
 
   const log = buildCaptureWorkerLogger();
+
+  // Validate WILLBUY_CAPTURE_RUNTIME at process-start (issue #116). A bad
+  // value here aborts the worker BEFORE any visit row is leased — better to
+  // crash-loop the deployment than to silently fall through to 'netns' or
+  // produce one 'indeterminate' visit per misconfig before crashing.
+  let captureRuntime: 'netns' | 'firecracker';
+  try {
+    captureRuntime = selectRuntimeFromEnv(process.env);
+  } catch (e) {
+    if (e instanceof RuntimeConfigError) {
+      log.error({ event: 'startup.invalid_runtime', value: (e as RuntimeConfigError).value }, e.message);
+      process.exit(2);
+    }
+    throw e;
+  }
+  log.info(
+    { event: 'startup.runtime', runtime: captureRuntime },
+    `WILLBUY_CAPTURE_RUNTIME=${captureRuntime}` +
+      (captureRuntime === 'firecracker'
+        ? ' (stub seam — actual VM launch lands in #117)'
+        : ''),
+  );
 
   const dbUrl = process.env['DATABASE_URL'];
   if (!dbUrl) {

--- a/apps/capture-worker/src/index.ts
+++ b/apps/capture-worker/src/index.ts
@@ -56,7 +56,7 @@ if (isMain) {
     captureRuntime = selectRuntimeFromEnv(process.env);
   } catch (e) {
     if (e instanceof RuntimeConfigError) {
-      log.error({ event: 'startup.invalid_runtime', value: (e as RuntimeConfigError).value }, e.message);
+      log.error({ event: 'startup.invalid_runtime', value: e.value }, e.message);
       process.exit(2);
     }
     throw e;

--- a/apps/capture-worker/src/runtime.ts
+++ b/apps/capture-worker/src/runtime.ts
@@ -1,0 +1,170 @@
+// runtime.ts — capture-worker runtime dispatcher (issue #116, spec §5.13).
+//
+// Selects between the v0.1 container-in-netns transport (current default)
+// and the v0.2 Firecracker microVM transport (stubbed seam in this PR;
+// jailer + vsock land in #117). The two paths share the same input shape
+// (RunWithNetnsOpts → opts here) and the same return contract for the
+// netns path. The firecracker path throws RuntimeNotImplementedError
+// until #117 wires it up — this commit is the dispatch surface only.
+//
+// Spec §5.13:
+//   v0.1 (container transport): per-container netns + iptables; broker
+//     reaches host via /run/willbuy/broker.sock (Unix socket).
+//   v0.2 (microVM upgrade): transport changes to vsock (cid=host, port=9000)
+//     with iptables on the microVM tap device. Request/response schema,
+//     broker validation, byte caps, retention all stay identical — the
+//     broker contract is transport-agnostic by design, so the v0.2 cutover
+//     is host-side + base-image only.
+//
+// Why a typed seam now (issue #116):
+//   - The Firecracker host bootstrap (#115) and base image (#114) are landing
+//     this sprint; #117 will wire the actual VM launch + vsock.
+//   - Until then, running with WILLBUY_CAPTURE_RUNTIME=firecracker must FAIL
+//     LOUDLY with a typed error (not silently fall through to netns) so that
+//     ops can verify the seam in staging without thinking they accidentally
+//     got the legacy path.
+//   - The selector validates at process-start (not at first request), so a
+//     misconfigured deploy fails the unit/health-check phase, not the first
+//     real visit.
+//
+// Default behavior preservation:
+//   selectRuntime(undefined) === 'netns'
+//   selectRuntime('') === 'netns'
+//   selectRuntime('netns') === 'netns'
+//   runCapture(opts) with no second arg → netns path → identical to
+//     runWithNetns(opts) (this is the regression guard in runtime.test.ts).
+
+import {
+  runWithNetns,
+  type RunWithNetnsOpts,
+  type RunWithNetnsResult,
+} from './run-with-netns.js';
+
+/**
+ * The set of supported capture runtimes.
+ *
+ * - 'netns'      : v0.1 — container in a hardened Linux network namespace,
+ *                  Unix-socket broker. This is the current production path.
+ * - 'firecracker': v0.2 — microVM with vsock-broker. Stubbed in #116;
+ *                  implementation lands in #117.
+ */
+export type CaptureRuntime = 'netns' | 'firecracker';
+
+const SUPPORTED_RUNTIMES: readonly CaptureRuntime[] = ['netns', 'firecracker'];
+
+/**
+ * Thrown at startup when WILLBUY_CAPTURE_RUNTIME is set to a value that is
+ * not in the supported set. Throwing here (not on first request) keeps a
+ * misconfigured process from polling the queue and producing one
+ * 'indeterminate' visit per misconfig before crashing.
+ */
+export class RuntimeConfigError extends Error {
+  constructor(
+    message: string,
+    public readonly value: string,
+  ) {
+    super(message);
+    this.name = 'RuntimeConfigError';
+  }
+}
+
+/**
+ * Thrown by a runtime path that is not yet wired (currently: 'firecracker').
+ * Distinct from RuntimeConfigError because the value IS supported by the
+ * type system — the seam exists but the implementation is deferred.
+ *
+ * Tests grep on `name === 'RuntimeNotImplementedError'` so callers in #117
+ * can land the actual impl by deleting the throw, without renaming.
+ */
+export class RuntimeNotImplementedError extends Error {
+  constructor(
+    public readonly runtime: CaptureRuntime,
+    message?: string,
+  ) {
+    super(
+      message ??
+        `capture runtime '${runtime}' is not yet implemented; expected to land in issue #117 (Firecracker jailer + vsock)`,
+    );
+    this.name = 'RuntimeNotImplementedError';
+  }
+}
+
+/**
+ * Validate a WILLBUY_CAPTURE_RUNTIME env value at process-start.
+ *
+ * @param value Raw env-var contents. `undefined` and `''` mean "unset" and
+ *              return the default ('netns').
+ * @returns The selected, type-narrowed CaptureRuntime.
+ * @throws RuntimeConfigError when `value` is set but not in the supported
+ *         set. The thrown error carries the offending value so the startup
+ *         banner can log it without re-reading process.env.
+ *
+ * Case-sensitivity: matches are exact. `'NETNS'`, `'FireCracker'`, etc.
+ * throw — typos in deploy manifests should fail loudly, not be silently
+ * normalized.
+ */
+export function selectRuntime(value: string | undefined): CaptureRuntime {
+  if (value === undefined || value === '') return 'netns';
+  if ((SUPPORTED_RUNTIMES as readonly string[]).includes(value)) {
+    return value as CaptureRuntime;
+  }
+  throw new RuntimeConfigError(
+    `WILLBUY_CAPTURE_RUNTIME='${value}' is not supported. ` +
+      `Expected one of: ${SUPPORTED_RUNTIMES.join(', ')} ` +
+      `(unset defaults to 'netns').`,
+    value,
+  );
+}
+
+/**
+ * Read WILLBUY_CAPTURE_RUNTIME from process.env and validate. Convenience
+ * wrapper for the production entrypoint; tests prefer the pure
+ * `selectRuntime(value)` form.
+ */
+export function selectRuntimeFromEnv(
+  env: NodeJS.ProcessEnv = process.env,
+): CaptureRuntime {
+  return selectRuntime(env['WILLBUY_CAPTURE_RUNTIME']);
+}
+
+/**
+ * Dispatch a capture to the selected runtime.
+ *
+ * - 'netns'       → delegates to `runWithNetns(opts)` verbatim. All public
+ *                   types and error semantics are preserved.
+ * - 'firecracker' → throws RuntimeNotImplementedError. Issue #117 will
+ *                   replace the throw with `runWithFirecracker(opts)`.
+ *
+ * @param runtime Optional override. When omitted, defaults to 'netns' so
+ *                callers that haven't migrated to the dispatcher get
+ *                pre-#116 behavior unchanged.
+ */
+export async function runCapture(
+  opts: RunWithNetnsOpts,
+  runtime: CaptureRuntime = 'netns',
+): Promise<RunWithNetnsResult> {
+  switch (runtime) {
+    case 'netns':
+      return runWithNetns(opts);
+    case 'firecracker':
+      // Stub seam — #117 lands the real impl. We accept the opts arg
+      // (instead of e.g. throwing before evaluating it) so a future change
+      // that drops the throw doesn't need a signature edit.
+      void opts;
+      throw new RuntimeNotImplementedError('firecracker');
+    default: {
+      // exhaustiveness check — if a future PR adds a new variant to
+      // CaptureRuntime without updating this switch, the compiler errors.
+      const _exhaustive: never = runtime;
+      throw new RuntimeConfigError(
+        `unhandled capture runtime: ${String(_exhaustive)}`,
+        String(runtime),
+      );
+    }
+  }
+}
+
+// Re-export the underlying types so callers can `import { runCapture,
+// type RunWithNetnsOpts } from './runtime.js'` without reaching into
+// run-with-netns.ts directly.
+export type { RunWithNetnsOpts, RunWithNetnsResult };

--- a/apps/capture-worker/test/runtime.test.ts
+++ b/apps/capture-worker/test/runtime.test.ts
@@ -1,0 +1,186 @@
+// runtime.test.ts — exercises the WILLBUY_CAPTURE_RUNTIME dispatcher
+// (issue #116, spec §5.13 v0.1→v0.2 transport-agnostic seam).
+//
+// Scope of THIS PR (the dispatcher seam only):
+//   - default (env unset) → 'netns' is selected,
+//   - 'netns' value preserves existing run-with-netns.ts behavior,
+//   - 'firecracker' value selects a stubbed runtime that throws
+//     RuntimeNotImplementedError (jailer/vsock land in #117),
+//   - any other value throws RuntimeConfigError at startup-time validation
+//     (NOT at first request).
+//
+// We do NOT exercise the actual firecracker VM bring-up here — that's #117.
+// We DO assert that the netns path is unchanged via a dry-run smoke that
+// reuses the same shim pattern as runWithNetns.test.ts.
+
+import { spawnSync } from 'node:child_process';
+import { mkdtempSync, rmSync, writeFileSync, chmodSync } from 'node:fs';
+import { tmpdir } from 'node:os';
+import { join } from 'node:path';
+import { afterEach, beforeEach, describe, expect, it } from 'vitest';
+import {
+  RuntimeConfigError,
+  RuntimeNotImplementedError,
+  runCapture,
+  selectRuntime,
+} from '../src/runtime.js';
+
+let tmpRoot = '';
+let shimDir = '';
+let stateDir = '';
+
+beforeEach(() => {
+  tmpRoot = mkdtempSync(join(tmpdir(), 'willbuy-runtime-'));
+  shimDir = join(tmpRoot, 'shim');
+  stateDir = join(tmpRoot, 'state');
+  spawnSync('mkdir', ['-p', shimDir, stateDir]);
+});
+
+afterEach(() => {
+  rmSync(tmpRoot, { recursive: true, force: true });
+});
+
+function writeGetentShim(body: string): void {
+  const path = join(shimDir, 'getent');
+  writeFileSync(path, body, 'utf8');
+  chmodSync(path, 0o755);
+}
+
+describe('selectRuntime (startup validation)', () => {
+  it('defaults to "netns" when env is unset', () => {
+    expect(selectRuntime(undefined)).toBe('netns');
+  });
+
+  it('defaults to "netns" when env is empty string', () => {
+    expect(selectRuntime('')).toBe('netns');
+  });
+
+  it('returns "netns" for explicit netns', () => {
+    expect(selectRuntime('netns')).toBe('netns');
+  });
+
+  it('returns "firecracker" for explicit firecracker', () => {
+    expect(selectRuntime('firecracker')).toBe('firecracker');
+  });
+
+  it('throws RuntimeConfigError on unknown value', () => {
+    let caught: unknown;
+    try {
+      selectRuntime('docker');
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(RuntimeConfigError);
+    expect((caught as RuntimeConfigError).message).toMatch(
+      /WILLBUY_CAPTURE_RUNTIME/,
+    );
+  });
+
+  it('throws RuntimeConfigError on garbage', () => {
+    expect(() => selectRuntime('xyz123')).toThrow(RuntimeConfigError);
+  });
+
+  it('is case-sensitive (rejects FIRECRACKER, NetNS, etc.)', () => {
+    expect(() => selectRuntime('FIRECRACKER')).toThrow(RuntimeConfigError);
+    expect(() => selectRuntime('NetNS')).toThrow(RuntimeConfigError);
+  });
+});
+
+describe('runCapture dispatcher', () => {
+  it('netns path: returns ok for a public-resolved target (existing behavior preserved)', async () => {
+    writeGetentShim(
+      [
+        '#!/usr/bin/env bash',
+        'case "$2" in',
+        '  example.com)',
+        '    printf "203.0.113.10  STREAM example.com\\n"',
+        '    ;;',
+        '  *)',
+        '    exit 2',
+        '    ;;',
+        'esac',
+      ].join('\n'),
+    );
+
+    process.env.PATH = `${shimDir}:${process.env.PATH ?? ''}`;
+    process.env.WILLBUY_STATE_DIR = stateDir;
+
+    const result = await runCapture(
+      {
+        captureId: 'feedfacecafe',
+        targetUrl: 'http://example.com/',
+        image: 'unused',
+        cmd: ['echo', 'unused'],
+        dryRun: true,
+      },
+      'netns',
+    );
+
+    expect(result.status).toBe('ok');
+    expect(result.netns).toBe('wb-feedfacecaf');
+    expect(result.bringupExit).toBe(0);
+  });
+
+  it('firecracker path: throws RuntimeNotImplementedError (stub seam for #117)', async () => {
+    let caught: unknown;
+    try {
+      await runCapture(
+        {
+          captureId: 'feedfacecafe',
+          targetUrl: 'http://example.com/',
+          image: 'unused',
+          cmd: ['echo', 'unused'],
+          dryRun: true,
+        },
+        'firecracker',
+      );
+    } catch (e) {
+      caught = e;
+    }
+    expect(caught).toBeInstanceOf(RuntimeNotImplementedError);
+    expect((caught as RuntimeNotImplementedError).runtime).toBe('firecracker');
+    expect((caught as RuntimeNotImplementedError).message).toMatch(
+      /firecracker/i,
+    );
+  });
+
+  it('firecracker error preserves its name for log-grep matching', async () => {
+    try {
+      await runCapture(
+        {
+          captureId: 'fc-stub',
+          targetUrl: 'http://example.com/',
+          image: 'unused',
+          cmd: ['echo'],
+          dryRun: true,
+        },
+        'firecracker',
+      );
+      // Should not reach here.
+      expect.fail('expected RuntimeNotImplementedError');
+    } catch (e) {
+      expect((e as Error).name).toBe('RuntimeNotImplementedError');
+    }
+  });
+
+  it('defaults to netns when no runtime override is passed', async () => {
+    writeGetentShim(
+      [
+        '#!/usr/bin/env bash',
+        'printf "203.0.113.20  STREAM default.example\\n"',
+      ].join('\n'),
+    );
+    process.env.PATH = `${shimDir}:${process.env.PATH ?? ''}`;
+    process.env.WILLBUY_STATE_DIR = stateDir;
+
+    const result = await runCapture({
+      captureId: 'defaulted',
+      targetUrl: 'http://default.example/',
+      image: 'unused',
+      cmd: ['echo'],
+      dryRun: true,
+    });
+
+    expect(result.status).toBe('ok');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the `WILLBUY_CAPTURE_RUNTIME` env-var dispatch surface between the v0.1 container-netns transport and the v0.2 Firecracker microVM transport.

**New module: `apps/capture-worker/src/runtime.ts`**
- `selectRuntime(value)` — validates the env var at process-start; throws `RuntimeConfigError` on unknown values
- `runCapture(opts, runtime)` — dispatches to `runWithNetns` (netns) or throws `RuntimeNotImplementedError` (firecracker stub, until #117)
- `CaptureRuntime` type: `'netns' | 'firecracker'`

**Updated: `apps/capture-worker/src/index.ts`**
- Calls `selectRuntimeFromEnv()` at startup — bad `WILLBUY_CAPTURE_RUNTIME` crashes the process before any visit row is leased (fail-loud at deploy time)
- Uses structured logger (not `console.log`) for the runtime banner

**Behavior preserved:**
- `WILLBUY_CAPTURE_RUNTIME` unset or `''` → `'netns'` (identical to pre-PR)
- `WILLBUY_CAPTURE_RUNTIME=netns` → `'netns'`
- `WILLBUY_CAPTURE_RUNTIME=firecracker` → `RuntimeNotImplementedError` (stub until #117)
- `WILLBUY_CAPTURE_RUNTIME=anything-else` → `RuntimeConfigError` → exit 2

## Test plan
- [ ] CI green
- [ ] REV review
- [ ] `runtime.test.ts` covers all dispatch branches

Depends on: #115 (Firecracker host bootstrap — not yet started)  
Closes #116