### PR TITLE
feat(api): POST /studies/:id/publish — owner opt-in to public report (issue #204)

### DIFF
--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -289,6 +289,46 @@ export async function registerStudiesRoutes(
     },
   );
 
+  // ── POST /studies/:id/publish (issue #204) ────────────────────────────────
+  //
+  // Owner opt-in to public listing (spec §2 #20). Sets reports.public = true
+  // for the report linked to this study. Idempotent — safe to call repeatedly.
+  // 404 if study not owned by caller or has no report yet.
+  app.post<{ Params: { id: string } }>(
+    '/studies/:id/publish',
+    { preHandler: [apiKeyMiddleware] },
+    async (req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+      const account = req.account!;
+      const studyId = req.params.id;
+
+      // Verify ownership first — return 404 for non-owned studies (no existence leak).
+      const studyResult = await pool.query<{ id: string; account_id: string }>(
+        `SELECT id, account_id FROM studies WHERE id = $1`,
+        [studyId],
+      );
+      const study = studyResult.rows[0];
+      if (!study || study.account_id !== String(account.id)) {
+        return reply.code(404).send({ error: 'study not found' });
+      }
+
+      // Set public = true on the linked report. Returns 404 if no report yet.
+      const reportResult = await pool.query<{ study_id: string }>(
+        `UPDATE reports SET public = true
+            WHERE study_id = $1
+            RETURNING study_id`,
+        [studyId],
+      );
+      if (reportResult.rowCount === 0) {
+        return reply.code(404).send({ error: 'report not ready yet' });
+      }
+
+      return reply.code(200).send({
+        study_id: Number(studyId),
+        public: true,
+      });
+    },
+  );
+
   // ── GET /api/studies (issue #85) ───────────────────────────────────────────
   //
   // Session-cookie-authenticated paginated list of the caller's studies.

--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -301,25 +301,23 @@ export async function registerStudiesRoutes(
       const account = req.account!;
       const studyId = req.params.id;
 
-      // Verify ownership first — return 404 for non-owned studies (no existence leak).
-      const studyResult = await pool.query<{ id: string; account_id: string }>(
-        `SELECT id, account_id FROM studies WHERE id = $1`,
-        [studyId],
+      // Single atomic UPDATE joining reports → studies enforces ownership in one
+      // round-trip (no TOCTOU). Returns 0 rows when: study doesn't exist, account
+      // mismatch, or no report exists yet — all map to 404 (no existence leak,
+      // spec §2 #20).
+      const result = await pool.query<{ study_id: string }>(
+        `UPDATE reports r
+            SET public = true
+           FROM studies s
+          WHERE r.study_id = s.id
+            AND s.id = $1
+            AND s.account_id = $2
+          RETURNING r.study_id`,
+        [studyId, String(account.id)],
       );
-      const study = studyResult.rows[0];
-      if (!study || study.account_id !== String(account.id)) {
-        return reply.code(404).send({ error: 'study not found' });
-      }
 
-      // Set public = true on the linked report. Returns 404 if no report yet.
-      const reportResult = await pool.query<{ study_id: string }>(
-        `UPDATE reports SET public = true
-            WHERE study_id = $1
-            RETURNING study_id`,
-        [studyId],
-      );
-      if (reportResult.rowCount === 0) {
-        return reply.code(404).send({ error: 'report not ready yet' });
+      if (result.rowCount === 0) {
+        return reply.code(404).send({ error: 'study not found' });
       }
 
       return reply.code(200).send({

--- a/apps/api/test/studies.api.test.ts
+++ b/apps/api/test/studies.api.test.ts
@@ -442,4 +442,96 @@ describeIfDocker('studies + reports API (issue #30, real DB)', () => {
     });
     expect(res.statusCode).toBe(404);
   });
+
+  // --- POST /studies/:id/publish (issue #204) ---
+  describe('POST /studies/:id/publish', () => {
+    let publishStudyId: bigint;
+
+    beforeAll(async () => {
+      const client = new Client({ connectionString: dbUrl });
+      await client.connect();
+      try {
+        const s = await client.query<{ id: bigint }>(
+          `INSERT INTO studies (account_id, kind, status)
+           VALUES ($1, 'single', 'ready') RETURNING id`,
+          [String(accountId)],
+        );
+        publishStudyId = s.rows[0]!.id;
+        await client.query(
+          `INSERT INTO reports (study_id, share_token_hash, conv_score, paired_delta_json, public)
+           VALUES ($1, $2, 0.5, '{}', false)`,
+          [String(publishStudyId), sha256hex(`publish-test-token-${uid()}`)],
+        );
+      } finally {
+        await client.end();
+      }
+    });
+
+    it('401 without API key', async () => {
+      const res = await app.inject({ method: 'POST', url: `/studies/${String(publishStudyId)}/publish` });
+      expect(res.statusCode).toBe(401);
+    });
+
+    it('404 when study belongs to a different account', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/studies/${String(publishStudyId)}/publish`,
+        headers: { Authorization: `Bearer ${otherApiKey}` },
+      });
+      expect(res.statusCode).toBe(404);
+    });
+
+    it('200 + public:true on happy path', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/studies/${String(publishStudyId)}/publish`,
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      expect(res.statusCode).toBe(200);
+      const body = res.json() as { study_id: number; public: boolean };
+      expect(body.study_id).toBe(Number(publishStudyId));
+      expect(body.public).toBe(true);
+    });
+
+    it('200 idempotent — second publish call also succeeds', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/studies/${String(publishStudyId)}/publish`,
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('report is now accessible without share token', async () => {
+      const res = await app.inject({
+        method: 'GET',
+        url: `/reports/${String(publishStudyId)}`,
+      });
+      expect(res.statusCode).toBe(200);
+    });
+
+    it('404 when study has no report yet', async () => {
+      // Insert a study with no report row.
+      const client = new Client({ connectionString: dbUrl });
+      await client.connect();
+      let noReportStudyId: bigint;
+      try {
+        const s = await client.query<{ id: bigint }>(
+          `INSERT INTO studies (account_id, kind, status)
+           VALUES ($1, 'single', 'aggregating') RETURNING id`,
+          [String(accountId)],
+        );
+        noReportStudyId = s.rows[0]!.id;
+      } finally {
+        await client.end();
+      }
+      const res = await app.inject({
+        method: 'POST',
+        url: `/studies/${String(noReportStudyId)}/publish`,
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      expect(res.statusCode).toBe(404);
+      expect((res.json() as { error: string }).error).toMatch(/not ready/i);
+    });
+  });
 });

--- a/apps/api/test/studies.api.test.ts
+++ b/apps/api/test/studies.api.test.ts
@@ -531,7 +531,16 @@ describeIfDocker('studies + reports API (issue #30, real DB)', () => {
         headers: { Authorization: `Bearer ${apiKey}` },
       });
       expect(res.statusCode).toBe(404);
-      expect((res.json() as { error: string }).error).toMatch(/not ready/i);
+      expect((res.json() as { error: string }).error).toMatch(/not found/i);
+    });
+
+    it('404 for completely unknown study id', async () => {
+      const res = await app.inject({
+        method: 'POST',
+        url: `/studies/999999999/publish`,
+        headers: { Authorization: `Bearer ${apiKey}` },
+      });
+      expect(res.statusCode).toBe(404);
     });
   });
 });


### PR DESCRIPTION
## Summary

Adds `POST /studies/:id/publish` to flip `reports.public = true` for a study the caller owns. This replaces the current workaround of setting `public=true` via raw SQL.

- Auth: API key middleware; returns 404 for non-owned studies (no existence leak, spec §2 #20)
- Idempotent: safe to call multiple times
- 404 with `{ error: "report not ready yet" }` if no report row exists
- 200 with `{ study_id, public: true }` on success

## Test plan
- [ ] CI green (Docker integration tests in `studies.api.test.ts`)
- [ ] REV review
- [ ] Manual: `POST /api/studies/1/publish` on production makes willbuy.dev/r/1 accessible without share token

Closes #204