### PR TITLE
feat(web): /dashboard/credits page — balance display + pack top-up (issue #206)

### DIFF
--- a/apps/web/app/dashboard/credits/page.tsx
+++ b/apps/web/app/dashboard/credits/page.tsx
@@ -1,0 +1,117 @@
+/**
+ * /dashboard/credits — credit balance + pack purchase (issue #206).
+ *
+ * Server Component. Fetches /api/dashboard/summary for the current balance,
+ * redirects to /sign-in if unauthenticated (401), and renders the pack tiles.
+ *
+ * Pack buy buttons link to /pricing (the public pack-selection page).
+ * After Stripe keys are configured (#195), this page can be upgraded to
+ * initiate a checkout session directly for already-authenticated users.
+ */
+
+import { cookies } from 'next/headers';
+import { redirect } from 'next/navigation';
+
+export const dynamic = 'force-dynamic';
+
+interface DashboardSummary {
+  balance_cents: number;
+}
+
+interface Pack {
+  id: 'starter' | 'growth' | 'scale';
+  label: string;
+  usd: number;
+  credits: number;
+  visitEstimate: number;
+}
+
+const PACKS: Pack[] = [
+  { id: 'starter', label: 'Starter', usd: 29, credits: 1_000, visitEstimate: Math.floor(2900 / 3.5) },
+  { id: 'growth', label: 'Growth', usd: 99, credits: 4_000, visitEstimate: Math.floor(9900 / 3.5) },
+  { id: 'scale', label: 'Scale', usd: 299, credits: 15_000, visitEstimate: Math.floor(29900 / 3.5) },
+];
+
+function apiBaseUrl(): string {
+  const explicit = process.env['WILLBUY_API_URL'] ?? process.env['NEXT_PUBLIC_API_URL'];
+  if (explicit) return explicit.replace(/\/$/, '');
+  return 'http://localhost:3001';
+}
+
+function formatCents(cents: number): string {
+  const dollars = Math.floor(cents / 100);
+  const remaining = cents % 100;
+  return `$${dollars}.${String(remaining).padStart(2, '0')}`;
+}
+
+export default async function CreditsPage() {
+  const cookieStore = await cookies();
+  const sessionCookie = cookieStore.get('wb_session');
+
+  let balance_cents = 0;
+  if (sessionCookie) {
+    try {
+      const res = await fetch(`${apiBaseUrl()}/api/dashboard/summary`, {
+        headers: { cookie: `wb_session=${sessionCookie.value}` },
+        cache: 'no-store',
+      });
+      if (res.status === 401) redirect('/sign-in');
+      if (res.ok) {
+        const data = (await res.json()) as DashboardSummary;
+        balance_cents = data.balance_cents;
+      }
+    } catch {
+      redirect('/sign-in');
+    }
+  } else {
+    redirect('/sign-in');
+  }
+
+  const balanceVisits = Math.floor(balance_cents / 3.5);
+
+  return (
+    <div className="mx-auto max-w-5xl px-6 py-10">
+      {/* Balance card */}
+      <div className="rounded-xl border border-gray-200 bg-white p-6 shadow-sm">
+        <p className="text-sm font-medium text-gray-500">Current balance</p>
+        <p className="mt-1 text-4xl font-bold text-gray-900">
+          {formatCents(balance_cents)}
+        </p>
+        <p className="mt-1 text-sm text-gray-500">
+          ≈ {balanceVisits.toLocaleString()} visits remaining
+        </p>
+      </div>
+
+      {/* Top-up section */}
+      <h2 className="mt-10 text-xl font-semibold text-gray-900">Top up credits</h2>
+      <p className="mt-1 text-sm text-gray-600">
+        Credits are consumed per visit (avg 3.5¢, ceiling 5¢).
+      </p>
+
+      <div className="mt-6 grid grid-cols-1 gap-6 md:grid-cols-3">
+        {PACKS.map((pack) => (
+          <div
+            key={pack.id}
+            className="flex flex-col rounded-xl border border-gray-200 bg-white px-6 py-8 shadow-sm"
+          >
+            <span className="text-lg font-semibold text-gray-900">{pack.label}</span>
+            <span className="mt-2 text-4xl font-bold text-gray-900">${pack.usd}</span>
+            <span
+              className="mt-3 text-sm text-gray-600"
+              title="avg 3.5¢/visit; ceiling 5¢"
+            >
+              {pack.credits.toLocaleString()} credits (~{pack.visitEstimate.toLocaleString()} visits)
+            </span>
+            <a
+              href={`/pricing#${pack.id}`}
+              aria-label={`Buy ${pack.label} pack — $${pack.usd}`}
+              className="mt-6 inline-block rounded-md bg-blue-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+            >
+              Buy →
+            </a>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/credits/page.tsx
+++ b/apps/web/app/dashboard/credits/page.tsx
@@ -67,7 +67,7 @@ export default async function CreditsPage() {
     redirect('/sign-in');
   }
 
-  const balanceVisits = Math.floor(balance_cents / 3.5);
+  const balanceVisits = Math.max(0, Math.floor(balance_cents / 3.5));
 
   return (
     <div className="mx-auto max-w-5xl px-6 py-10">


### PR DESCRIPTION
## Problem
`/dashboard/credits` is linked from the dashboard nav ("Credits") but returns 404 — the page doesn't exist.

## Solution
Adds `apps/web/app/dashboard/credits/page.tsx` (Server Component):
- Fetches `/api/dashboard/summary` with the session cookie — redirects to `/sign-in` if unauthenticated
- Shows current balance in USD + visit estimate at avg 3.5¢/visit
- Shows the 3 pack tiles (Starter $29, Growth $99, Scale $299) with buy links to `/pricing`

Buy links go to `/pricing` for now. After Stripe keys are configured (#195), this page can be upgraded to call `/checkout/sessions` directly.

## Test plan
- [ ] CI green
- [ ] REV review
- [ ] Manual: `https://willbuy.dev/dashboard/credits` returns 200 after deploy
- [ ] Unauthenticated: redirects to `/sign-in`
- [ ] Authenticated: shows balance + pack tiles

Closes #206