### PR TITLE
ops(nginx): add /studies/ and /checkout/ proxy rules — fix production study polling

### DIFF
--- a/infra/nginx/willbuy.conf
+++ b/infra/nginx/willbuy.conf
@@ -1,0 +1,52 @@
+server {
+    listen 80;
+    server_name willbuy.dev;
+
+    # API routes (no auth prefix — matched before the catch-all / block).
+    # Each block proxies to the API on port 3001.
+
+    location /api/ {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /reports/ {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /studies/ {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /checkout/ {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
+    location /health {
+        proxy_pass http://127.0.0.1:3001/health;
+    }
+
+    # Web app catch-all (port 3000 — Next.js server started with next start -p 3000).
+    location / {
+        proxy_pass http://127.0.0.1:3000;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+}


### PR DESCRIPTION
## Bugs fixed

1. **`/studies/:id` → 404** from Next.js — breaks the study status polling in `/dashboard/studies/[id]`. The client component calls `GET /studies/:id` which was not proxied to the API; nginx served it to the Next.js catch-all which returned 404.

2. **`/checkout/sessions` → 404** from Next.js — Stripe checkout session creation was not reachable from the browser.

## Change

Adds proxy rules in nginx for `/studies/` and `/checkout/` (matching the existing pattern for `/api/` and `/reports/`). Also adds `infra/nginx/willbuy.conf` as the canonical config to replace the ad-hoc SSH heredoc used during bootstrap.

Already applied on `willbuy-v01` and verified:
```
curl https://willbuy.dev/studies/1  → 401 (from API, not 404 from Next.js)
curl https://willbuy.dev/checkout/sessions -X POST → 401 (from API)
```

## Test plan
- [ ] CI green (ops-only change)
- [ ] Deploy by copying `infra/nginx/willbuy.conf` → `/etc/nginx/sites-available/willbuy` + `nginx -t && systemctl reload nginx`