### PR TITLE
feat(api+web): GET /api/studies/:id with session auth — fix production study polling

### DIFF
--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -341,6 +341,59 @@ export async function registerStudiesRoutes(
   // Returns 400 on a malformed cursor (per AC6) — never silently degrades.
   const sessionMiddleware = buildSessionMiddleware(env.SESSION_HMAC_KEY, env.NODE_ENV);
 
+  // ── GET /api/studies/:id (issue #209) ─────────────────────────────────────
+  //
+  // Session-cookie mirror of GET /studies/:id (which uses API-key auth).
+  // Used by the dashboard's client component — browsers send session cookies
+  // but no API key, so the apiKey-authenticated route always returns 401
+  // in production. Same ownership guard and response shape.
+  app.get<{ Params: { id: string } }>(
+    '/api/studies/:id',
+    { preHandler: [sessionMiddleware] },
+    async (req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+      const account = req.account!;
+      const studyId = req.params.id;
+
+      const studyResult = await pool.query<{
+        id: string;
+        account_id: string;
+        status: string;
+        created_at: Date;
+        finalized_at: Date | null;
+      }>(
+        `SELECT id, account_id, status, created_at, finalized_at
+           FROM studies WHERE id = $1`,
+        [studyId],
+      );
+
+      const study = studyResult.rows[0];
+      if (!study || study.account_id !== String(account.id)) {
+        return reply.code(404).send({ error: 'study not found' });
+      }
+
+      const progressResult = await pool.query<{ status: string; cnt: string }>(
+        `SELECT status, count(*) AS cnt FROM visits WHERE study_id = $1 GROUP BY status`,
+        [studyId],
+      );
+
+      let okCount = 0, failedCount = 0, total = 0;
+      for (const row of progressResult.rows) {
+        const cnt = Number(row.cnt);
+        total += cnt;
+        if (row.status === 'ok') okCount += cnt;
+        else if (row.status === 'failed' || row.status === 'indeterminate') failedCount += cnt;
+      }
+
+      return reply.code(200).send({
+        id: Number(study.id),
+        status: study.status,
+        visit_progress: { ok: okCount, failed: failedCount, total },
+        started_at: study.created_at.toISOString(),
+        finalized_at: study.finalized_at?.toISOString() ?? null,
+      });
+    },
+  );
+
   const ListQuerySchema = z.object({
     limit: z.coerce.number().int().positive().optional(),
     cursor: z.string().optional(),

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -169,5 +169,8 @@ export async function createStudy(
 export async function getStudy(
   id: string | number,
 ): Promise<ApiResult<GetStudyResponse>> {
-  return apiFetch(`/studies/${id}`, { method: 'GET' }, GetStudyResponseSchema);
+  // Use /api/studies/:id (session-cookie auth) so authenticated dashboard users
+  // can poll study status without needing an API key. The API-key path
+  // /studies/:id remains for programmatic callers.
+  return apiFetch(`/api/studies/${id}`, { method: 'GET' }, GetStudyResponseSchema);
 }


### PR DESCRIPTION
## Problem

The dashboard `/dashboard/studies/[id]` polls `GET /studies/:id` every 5s. The client adds `Authorization: Bearer ${NEXT_PUBLIC_DEV_API_KEY}` — a dev-only env var. In production this is empty, so every poll returns 401 and the study status never updates.

## Fix

- **API**: add `GET /api/studies/:id` using `sessionMiddleware` (same ownership guard + response shape as the API-key version)  
- **Web**: `getStudy()` in `api-client.ts` now calls `/api/studies/:id` instead of `/studies/:id`

The existing `GET /studies/:id` (API-key auth) is untouched for programmatic callers.

## Test plan
- [ ] CI green
- [ ] REV
- [ ] Manual: sign in → create study → status page polls correctly without 401 errors in browser console