### PR TITLE
feat(api+web): session-auth POST /api/studies — fix study creation from dashboard

### DIFF
--- a/apps/api/src/auth/session.ts
+++ b/apps/api/src/auth/session.ts
@@ -17,6 +17,7 @@
 
 import { createHmac, timingSafeEqual } from 'node:crypto';
 import type { FastifyReply, FastifyRequest } from 'fastify';
+import type { Pool } from 'pg';
 import type { AccountInfo } from './api-key.js';
 
 export const COOKIE_NAME_PROD = '__Host-wb_session';
@@ -84,9 +85,13 @@ export function decodeSession(
  * Build a Fastify preHandler that reads the wb_session cookie and populates
  * req.account. Sends 401 if cookie is missing, invalid, or expired.
  *
+ * When pool is provided, verified_domains is loaded from the DB so session
+ * users get the same req.account shape as API-key-authenticated callers.
+ * Without pool, verified_domains is [] (sufficient for read-only routes).
+ *
  * Usage: mount on /dashboard/* and /api/dashboard/* routes.
  */
-export function buildSessionMiddleware(hmacKey: string, nodeEnv: string) {
+export function buildSessionMiddleware(hmacKey: string, nodeEnv: string, pool?: Pool) {
   const name = cookieName(nodeEnv);
 
   return async function sessionMiddleware(
@@ -108,10 +113,19 @@ export function buildSessionMiddleware(hmacKey: string, nodeEnv: string) {
       return;
     }
 
+    let verified_domains: string[] = [];
+    if (pool) {
+      const result = await pool.query<{ verified_domains: string[] | null }>(
+        `SELECT verified_domains FROM accounts WHERE id = $1`,
+        [payload.account_id],
+      );
+      verified_domains = result.rows[0]?.verified_domains ?? [];
+    }
+
     req.account = {
       id: BigInt(payload.account_id),
       owner_email: payload.owner_email,
-      verified_domains: [],
+      verified_domains,
     } satisfies AccountInfo;
   };
 }

--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -339,7 +339,8 @@ export async function registerStudiesRoutes(
   //   WHERE (created_at, id) < (cursor.created_at, cursor.id)
   //
   // Returns 400 on a malformed cursor (per AC6) — never silently degrades.
-  const sessionMiddleware = buildSessionMiddleware(env.SESSION_HMAC_KEY, env.NODE_ENV);
+  // Pass pool so verified_domains is loaded from DB (needed for POST /api/studies).
+  const sessionMiddleware = buildSessionMiddleware(env.SESSION_HMAC_KEY, env.NODE_ENV, pool);
 
   // ── GET /api/studies/:id (issue #209) ─────────────────────────────────────
   //
@@ -391,6 +392,110 @@ export async function registerStudiesRoutes(
         started_at: study.created_at.toISOString(),
         finalized_at: study.finalized_at?.toISOString() ?? null,
       });
+    },
+  );
+
+  // ── POST /api/studies (issue #210) ────────────────────────────────────────
+  //
+  // Session-cookie mirror of POST /studies (API-key auth). Allows dashboard
+  // users to create studies from the browser without a programmatic API key.
+  // Identical logic to POST /studies; session middleware loads verified_domains
+  // from the DB (pool passed above) so domain verification works the same way.
+  app.post(
+    '/api/studies',
+    { preHandler: [sessionMiddleware] },
+    async (req: FastifyRequest, reply: FastifyReply) => {
+      const account = req.account!;
+
+      const bodyResult = CreateStudyBodySchema.safeParse(req.body);
+      if (!bodyResult.success) {
+        const msg = bodyResult.error.issues.map((i) => i.message).join('; ');
+        return reply.code(422).send({ error: msg });
+      }
+      const body = bodyResult.data;
+
+      for (const url of body.urls) {
+        const etld = getEtldPlusOne(url);
+        if (!etld) return reply.code(422).send({ error: `invalid URL: ${url}` });
+        if (!account.verified_domains.includes(etld)) {
+          return reply.code(422).send({ error: `unverified domain: ${etld}` });
+        }
+      }
+
+      const n = body.n_visits;
+      const estCents = body.urls.length * n * CENTS_PER_VISIT_EST + CENTS_PER_STUDY_CLUSTER_LABEL;
+      const today = new Date().toISOString().slice(0, 10);
+
+      const client = await pool.connect();
+      try {
+        await client.query('BEGIN');
+
+        const spendRows = await client.query<{ cents: number }>(
+          `INSERT INTO llm_spend_daily (account_id, date, kind, cents)
+             VALUES ($1, $2::date, 'visit', $3)
+             ON CONFLICT (account_id, date, kind)
+             DO UPDATE SET cents = llm_spend_daily.cents + EXCLUDED.cents
+             WHERE llm_spend_daily.cents + EXCLUDED.cents <= $4
+             RETURNING cents`,
+          [String(account.id), today, estCents, env.DAILY_CAP_CENTS],
+        );
+        if (spendRows.rows.length === 0) {
+          await client.query('ROLLBACK');
+          return reply.code(402).send({ error: 'daily spend cap exceeded' });
+        }
+
+        const kind = body.urls.length === 2 ? 'paired' : 'single';
+        const studyResult = await client.query<{ id: string }>(
+          `INSERT INTO studies (account_id, kind, status, urls)
+           VALUES ($1, $2, 'capturing', $3::text[])
+           RETURNING id`,
+          [String(account.id), kind, body.urls],
+        );
+        const studyId = studyResult.rows[0]!.id;
+
+        const icpPayload = JSON.stringify(body.icp);
+        for (let idx = 0; idx < n; idx++) {
+          await client.query(
+            `INSERT INTO backstories (study_id, idx, payload) VALUES ($1, $2, $3::jsonb)`,
+            [studyId, idx, icpPayload],
+          );
+        }
+
+        const backstoryRows = await client.query<{ id: string; idx: number }>(
+          `SELECT id, idx FROM backstories WHERE study_id = $1 ORDER BY idx`,
+          [studyId],
+        );
+        for (const bs of backstoryRows.rows) {
+          for (let variantIdx = 0; variantIdx < body.urls.length; variantIdx++) {
+            await client.query(
+              `INSERT INTO visits (study_id, backstory_id, variant_idx, status)
+               VALUES ($1, $2, $3, 'started')`,
+              [studyId, bs.id, variantIdx],
+            );
+          }
+        }
+
+        await client.query('COMMIT');
+
+        recordStudyStarted({ kind });
+        void maybeWarnCap({
+          sql,
+          account_id: account.id,
+          date: today,
+          new_cents: spendRows.rows[0]!.cents,
+          daily_cap_cents: env.DAILY_CAP_CENTS,
+          owner_email: account.owner_email,
+          study_id: studyId,
+          resend,
+        });
+
+        return reply.code(201).send({ study_id: Number(studyId), status: 'capturing' });
+      } catch (err) {
+        try { await client.query('ROLLBACK'); } catch { /* ignore */ }
+        throw err;
+      } finally {
+        client.release();
+      }
     },
   );
 

--- a/apps/api/test/dashboard.test.ts
+++ b/apps/api/test/dashboard.test.ts
@@ -255,10 +255,21 @@ describeIfDocker('GET /api/dashboard/summary (issue #80, real DB)', () => {
       ownerEmail: accountAEmail,
       expiresAtIso: futureIso(),
     });
-    // Flip the last byte of the MAC.
+    // Corrupt the MAC by changing a character in the middle of the HMAC portion.
+    // We avoid flipping the very last base64url character because for a 32-byte
+    // HMAC (43 base64url chars), the last char's bottom 2 bits are padding zeros —
+    // so some last-char flips don't change the decoded bytes and the MAC still
+    // verifies (intermittent false-pass). Changing a middle char guarantees all
+    // 6 bits are significant.
     const value = goodCookie.slice('wb_session='.length);
-    const tampered =
-      value.slice(0, -1) + (value.slice(-1) === 'A' ? 'B' : 'A');
+    const dot = value.lastIndexOf('.');
+    const mac = value.slice(dot + 1); // 43 chars for SHA-256
+    const midIdx = Math.floor(mac.length / 2);
+    const corruptedMac =
+      mac.slice(0, midIdx) +
+      (mac[midIdx] === 'A' ? 'B' : 'A') +
+      mac.slice(midIdx + 1);
+    const tampered = value.slice(0, dot + 1) + corruptedMac;
     const res = await app.inject({
       method: 'GET',
       url: '/api/dashboard/summary',

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -158,7 +158,10 @@ async function apiFetch<T>(
 export async function createStudy(
   body: CreateStudyBody,
 ): Promise<ApiResult<CreateStudyResponse>> {
-  return apiFetch('/studies', { method: 'POST', body: JSON.stringify(body) }, CreateStudyResponseSchema);
+  // Use /api/studies (session-cookie auth) so dashboard users can create
+  // studies without a browser API key. The API-key path POST /studies
+  // remains for programmatic callers.
+  return apiFetch('/api/studies', { method: 'POST', body: JSON.stringify(body) }, CreateStudyResponseSchema);
 }
 
 /**


### PR DESCRIPTION
## Problem

`POST /studies` requires an API key. `api-client.createStudy()` adds `Authorization: Bearer ${NEXT_PUBLIC_DEV_API_KEY}` — a dev-only env var. In production, no key → 401 → study creation form fails silently.

## Fix

Three changes:

**`auth/session.ts`**: `buildSessionMiddleware(hmacKey, nodeEnv, pool?)` — when `pool` is passed, loads `verified_domains` from the DB so session-auth routes see the same `req.account` shape as API-key routes.

**`routes/studies.ts`**: `POST /api/studies` using `sessionMiddleware` — mirrors `POST /studies` exactly (spend-cap check, study + backstory + visit-queue creation, `recordStudyStarted`, `maybeWarnCap`). The pool is passed to `buildSessionMiddleware` so verified_domains is populated.

**`api-client.ts`**: `createStudy()` calls `/api/studies` instead of `/studies`. The API-key path is unchanged for programmatic callers.

## Test plan
- [ ] CI green (existing studies API tests should still pass)
- [ ] REV
- [ ] Manual: sign in → dashboard → New Study → submit form → 201 (requires credits + verified domain)