### PR TITLE
feat(api+web): session-auth /api/checkout/sessions + BuyButton — complete credits buy flow

### DIFF
--- a/apps/api/src/routes/checkout.ts
+++ b/apps/api/src/routes/checkout.ts
@@ -16,6 +16,7 @@ import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
 
 import { buildApiKeyMiddleware } from '../auth/api-key.js';
+import { buildSessionMiddleware } from '../auth/session.js';
 import type { Env } from '../env.js';
 import { PACKS, type PackId } from '../billing/packs.js';
 
@@ -71,6 +72,47 @@ export async function registerCheckoutRoutes(
         return reply
           .code(502)
           .send({ error: 'payment provider unavailable, try again' });
+      }
+
+      return reply.code(200).send({ url: session.url });
+    },
+  );
+
+  // ── POST /api/checkout/sessions (session-cookie auth) ─────────────────────
+  //
+  // Session-cookie mirror of POST /checkout/sessions. Allows dashboard users
+  // to initiate Stripe checkout without a programmatic API key in their browser.
+  // Identical Stripe session creation logic; only auth differs.
+  const sessionMiddleware = buildSessionMiddleware(env.SESSION_HMAC_KEY, env.NODE_ENV);
+
+  app.post(
+    '/api/checkout/sessions',
+    { preHandler: [sessionMiddleware] },
+    async (req: FastifyRequest, reply: FastifyReply) => {
+      const account = req.account!;
+
+      const bodyResult = CreateSessionBodySchema.safeParse(req.body);
+      if (!bodyResult.success) {
+        return reply.code(400).send({ error: 'invalid pack_id' });
+      }
+
+      const packId: PackId = bodyResult.data.pack_id;
+      const pack = PACKS[packId];
+
+      let session: Awaited<ReturnType<typeof stripe.checkout.sessions.create>>;
+      try {
+        session = await stripe.checkout.sessions.create({
+          mode: 'payment',
+          payment_method_types: ['card'],
+          line_items: [{ price: pack.price_id, quantity: 1 }],
+          client_reference_id: String(account.id),
+          metadata: { pack_id: packId },
+          success_url: env.STRIPE_SUCCESS_URL ?? 'https://willbuy.dev/credits?success=1',
+          cancel_url: env.STRIPE_CANCEL_URL ?? 'https://willbuy.dev/credits?cancelled=1',
+        });
+      } catch (err) {
+        req.log.error(err, 'stripe-checkout-create-failed');
+        return reply.code(502).send({ error: 'payment provider unavailable, try again' });
       }
 
       return reply.code(200).send({ url: session.url });

--- a/apps/web/app/dashboard/credits/BuyButton.tsx
+++ b/apps/web/app/dashboard/credits/BuyButton.tsx
@@ -1,0 +1,57 @@
+'use client';
+
+// BuyButton — initiates Stripe checkout for a credit pack.
+// Calls POST /api/checkout/sessions (session-cookie auth) and redirects
+// to the Stripe-hosted checkout page on success.
+
+import { useState } from 'react';
+
+interface BuyButtonProps {
+  packId: 'starter' | 'growth' | 'scale';
+  label: string;
+  usd: number;
+}
+
+export function BuyButton({ packId, label, usd }: BuyButtonProps) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  async function handleClick() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch('/api/checkout/sessions', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ pack_id: packId }),
+      });
+      if (!res.ok) {
+        const body = (await res.json()) as { error?: string };
+        setError(body.error ?? 'checkout failed');
+        return;
+      }
+      const { url } = (await res.json()) as { url: string };
+      window.location.href = url;
+    } catch {
+      setError('network error — please try again');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mt-6">
+      <button
+        onClick={() => { void handleClick(); }}
+        disabled={loading}
+        aria-label={`Buy ${label} pack — $${usd}`}
+        className="w-full rounded-md bg-blue-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {loading ? 'Redirecting…' : 'Buy →'}
+      </button>
+      {error && (
+        <p className="mt-2 text-xs text-red-600">{error}</p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/app/dashboard/credits/BuyButton.tsx
+++ b/apps/web/app/dashboard/credits/BuyButton.tsx
@@ -25,9 +25,12 @@ export function BuyButton({ packId, label, usd }: BuyButtonProps) {
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify({ pack_id: packId }),
       });
+      const isJson = res.headers.get('content-type')?.includes('application/json');
       if (!res.ok) {
-        const body = (await res.json()) as { error?: string };
-        setError(body.error ?? 'checkout failed');
+        const msg = isJson
+          ? ((await res.json()) as { error?: string }).error ?? 'checkout failed'
+          : 'payment provider unavailable — please try again';
+        setError(msg);
         return;
       }
       const { url } = (await res.json()) as { url: string };

--- a/apps/web/app/dashboard/credits/page.tsx
+++ b/apps/web/app/dashboard/credits/page.tsx
@@ -11,6 +11,7 @@
 
 import { cookies } from 'next/headers';
 import { redirect } from 'next/navigation';
+import { BuyButton } from './BuyButton';
 
 export const dynamic = 'force-dynamic';
 
@@ -102,13 +103,7 @@ export default async function CreditsPage() {
             >
               {pack.credits.toLocaleString()} credits (~{pack.visitEstimate.toLocaleString()} visits)
             </span>
-            <a
-              href={`/pricing#${pack.id}`}
-              aria-label={`Buy ${pack.label} pack — $${pack.usd}`}
-              className="mt-6 inline-block rounded-md bg-blue-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
-              Buy →
-            </a>
+            <BuyButton packId={pack.id} label={pack.label} usd={pack.usd} />
           </div>
         ))}
       </div>


### PR DESCRIPTION
## Summary

Completes the end-to-end buy flow for authenticated dashboard users:

**API**: `POST /api/checkout/sessions` (session-cookie auth) — identical Stripe session creation as `POST /checkout/sessions` (API-key), just uses `sessionMiddleware`. No `verified_domains` needed (checkout only needs `account.id`).

**Web**: `BuyButton` client component (`'use client'`) calls `POST /api/checkout/sessions`, redirects to Stripe checkout on success, shows inline error on 502. Replaces the old static link to `/pricing#pack-id` on the credits page.

**Flow** (after Stripe keys #195):
1. Sign in → `/dashboard/credits`
2. Click "Buy →" (Starter / Growth / Scale)  
3. → `POST /api/checkout/sessions` → Stripe session URL
4. → redirect to Stripe hosted checkout → card 4242 4242
5. → webhook fires → credits added → redirect to `/credits?success=1`

## Test plan
- [ ] CI green
- [ ] REV
- [ ] Manual (after #195): sign in → /dashboard/credits → Buy Starter → Stripe redirects correctly