### PR TITLE
feat(api+web): Publish Report button in study dashboard + session-auth endpoint

### DIFF
--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -499,6 +499,36 @@ export async function registerStudiesRoutes(
     },
   );
 
+  // ── POST /api/studies/:id/publish (session-cookie auth) ───────────────────
+  //
+  // Session-cookie mirror of POST /studies/:id/publish (API-key auth).
+  // Allows dashboard users to make a report public without a programmatic key.
+  app.post<{ Params: { id: string } }>(
+    '/api/studies/:id/publish',
+    { preHandler: [sessionMiddleware] },
+    async (req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+      const account = req.account!;
+      const studyId = req.params.id;
+
+      const result = await pool.query<{ study_id: string }>(
+        `UPDATE reports r
+            SET public = true
+           FROM studies s
+          WHERE r.study_id = s.id
+            AND s.id = $1
+            AND s.account_id = $2
+          RETURNING r.study_id`,
+        [studyId, String(account.id)],
+      );
+
+      if (result.rowCount === 0) {
+        return reply.code(404).send({ error: 'study not found' });
+      }
+
+      return reply.code(200).send({ study_id: Number(studyId), public: true });
+    },
+  );
+
   const ListQuerySchema = z.object({
     limit: z.coerce.number().int().positive().optional(),
     cursor: z.string().optional(),

--- a/apps/web/app/dashboard/studies/[id]/page.tsx
+++ b/apps/web/app/dashboard/studies/[id]/page.tsx
@@ -21,6 +21,7 @@
 import React from 'react';
 import { useState, useEffect } from 'react';
 import { getStudy, type GetStudyResponse, type StudyStatus } from '../../../../lib/api-client';
+import { PublishButton } from '../../../../components/dashboard/PublishButton';
 
 // Poll interval in milliseconds (spec: 5 s).
 const POLL_INTERVAL_MS = 5_000;
@@ -220,6 +221,7 @@ function StudyStatusInner({ id }: { id: string }) {
           >
             View report
           </a>
+          <PublishButton studyId={s.id} reportSlug={s.slug ?? String(s.id)} />
         </div>
       )}
 

--- a/apps/web/components/dashboard/PublishButton.tsx
+++ b/apps/web/components/dashboard/PublishButton.tsx
@@ -3,7 +3,7 @@
 // PublishButton — makes a ready study's report publicly accessible.
 // Calls POST /api/studies/:id/publish (session-cookie auth).
 
-import { useState } from 'react';
+import React, { useState } from 'react';
 
 interface PublishButtonProps {
   studyId: string | number;

--- a/apps/web/components/dashboard/PublishButton.tsx
+++ b/apps/web/components/dashboard/PublishButton.tsx
@@ -1,0 +1,64 @@
+'use client';
+
+// PublishButton — makes a ready study's report publicly accessible.
+// Calls POST /api/studies/:id/publish (session-cookie auth).
+
+import { useState } from 'react';
+
+interface PublishButtonProps {
+  studyId: string | number;
+  reportSlug: string;
+}
+
+export function PublishButton({ studyId, reportSlug }: PublishButtonProps) {
+  const [published, setPublished] = useState(false);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  if (published) {
+    return (
+      <div className="mt-3">
+        <p className="text-sm text-green-700 font-medium">
+          Report is now public —{' '}
+          <a href={`/r/${reportSlug}`} className="underline hover:text-green-900">
+            share this link
+          </a>
+        </p>
+      </div>
+    );
+  }
+
+  async function handlePublish() {
+    setLoading(true);
+    setError(null);
+    try {
+      const res = await fetch(`/api/studies/${studyId}/publish`, { method: 'POST' });
+      if (res.ok) {
+        setPublished(true);
+      } else {
+        const isJson = res.headers.get('content-type')?.includes('application/json');
+        const msg = isJson
+          ? ((await res.json()) as { error?: string }).error ?? 'publish failed'
+          : 'publish failed — please try again';
+        setError(msg);
+      }
+    } catch {
+      setError('network error — please try again');
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="mt-3">
+      <button
+        onClick={() => { void handlePublish(); }}
+        disabled={loading}
+        className="rounded-md border border-indigo-300 px-4 py-2 text-sm font-medium text-indigo-700 hover:bg-indigo-50 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {loading ? 'Publishing…' : 'Make report public'}
+      </button>
+      {error && <p className="mt-1 text-xs text-red-600">{error}</p>}
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary

Adds the ability to make a report public directly from the dashboard without needing a raw API call.

**API**: `POST /api/studies/:id/publish` using `sessionMiddleware` — same atomic `UPDATE reports SET public = true FROM studies WHERE ...` as the API-key path (`POST /studies/:id/publish`).

**Web**: `PublishButton` client component — appears below "View report" when study is ready. On success, shows a shareable link to `/r/:slug`. On error, inline message.

## Test plan
- [ ] CI green
- [ ] REV
- [ ] Manual: sign in → study that is ready → click "Make report public" → report accessible at /r/:id without auth