### PR TITLE
fix(capture-broker/test): wait for drain before socket.end() — fixes oversized payload flaky test

### DIFF
--- a/apps/capture-broker/test/helpers.ts
+++ b/apps/capture-broker/test/helpers.ts
@@ -114,8 +114,16 @@ function roundTrip(socketPath: string, raw: Buffer): Promise<BrokerAck> {
       }
     });
     socket.on('connect', () => {
-      socket.write(raw);
-      socket.end();
+      // For large payloads, socket.write() may return false (backpressure).
+      // Only send FIN after the write is flushed to avoid a race where the
+      // FIN arrives at the server before all data chunks, causing readOneFrame
+      // to resolve 'closed' instead of 'ok' and drop the connection silently.
+      const flushed = socket.write(raw);
+      if (flushed) {
+        socket.end();
+      } else {
+        socket.once('drain', () => socket.end());
+      }
     });
   });
 }


### PR DESCRIPTION
## Problem

`test/server.test.ts > rejects an oversized a11y_tree` was failing intermittently with:
```
Error: server closed without writing a frame; got 0B
```

For a 10+ MiB payload, `socket.write(raw)` returns `false` (backpressure). The immediate `socket.end()` call then races with the data flush — if the TCP FIN reaches the server before all data chunks, `readOneFrame` on the server resolves `{ kind: 'closed' }` and `handleConnection` calls `socket.destroy()` without sending an ack.

## Fix

In `roundTrip`, only call `socket.end()` after the write is fully flushed:
```typescript
const flushed = socket.write(raw);
if (flushed) socket.end();
else socket.once('drain', () => socket.end());
```

## Test plan
- [ ] CI green (build job should no longer fail on the oversized payload test)