### PR TITLE
fix(checkout): correct Stripe redirect URLs to /dashboard/credits

### DIFF
--- a/apps/api/src/routes/checkout.ts
+++ b/apps/api/src/routes/checkout.ts
@@ -61,8 +61,8 @@ export async function registerCheckoutRoutes(
           metadata: { pack_id: packId },
           // success_url and cancel_url are required by Stripe; use env if set,
           // otherwise use fallback placeholders (adequate for test mode).
-          success_url: env.STRIPE_SUCCESS_URL ?? 'https://willbuy.dev/credits?success=1',
-          cancel_url: env.STRIPE_CANCEL_URL ?? 'https://willbuy.dev/credits?cancelled=1',
+          success_url: env.STRIPE_SUCCESS_URL ?? 'https://willbuy.dev/dashboard/credits?success=1',
+          cancel_url: env.STRIPE_CANCEL_URL ?? 'https://willbuy.dev/dashboard/credits?cancelled=1',
         });
       } catch (err) {
         // Log with Fastify's logger (Fastify logger pattern: req.log.error).
@@ -107,8 +107,8 @@ export async function registerCheckoutRoutes(
           line_items: [{ price: pack.price_id, quantity: 1 }],
           client_reference_id: String(account.id),
           metadata: { pack_id: packId },
-          success_url: env.STRIPE_SUCCESS_URL ?? 'https://willbuy.dev/credits?success=1',
-          cancel_url: env.STRIPE_CANCEL_URL ?? 'https://willbuy.dev/credits?cancelled=1',
+          success_url: env.STRIPE_SUCCESS_URL ?? 'https://willbuy.dev/dashboard/credits?success=1',
+          cancel_url: env.STRIPE_CANCEL_URL ?? 'https://willbuy.dev/dashboard/credits?cancelled=1',
         });
       } catch (err) {
         req.log.error(err, 'stripe-checkout-create-failed');


### PR DESCRIPTION
## Summary

- Default `success_url` and `cancel_url` in both checkout routes (API-key + session) pointed to `/credits` which is a 404 — the credits page lives at `/dashboard/credits`
- Affects only the env-var-free fallback; production can override with `STRIPE_SUCCESS_URL` / `STRIPE_CANCEL_URL` in `app.env`

## Test plan

- [ ] CI green
- [ ] After Stripe keys are wired (#195): complete sandbox payment → lands on `/dashboard/credits?success=1` with the success banner
- [ ] Cancel → lands on `/dashboard/credits?cancelled=1` with the cancel banner

🤖 Generated with [Claude Code](https://claude.com/claude-code)