### PR TITLE
fix(web): serve test-fixture demo report in production (no env var needed)

### DIFF
--- a/apps/web/app/r/[slug]/fetchReport.ts
+++ b/apps/web/app/r/[slug]/fetchReport.ts
@@ -1,6 +1,7 @@
 // Server-only seam — fetches the §5.18 report_json blob for a given slug.
-// Fixture path (WILLBUY_REPORT_FIXTURE=enabled + slug=test-fixture) stays
-// active for dev/preview; all other slugs hit the real API.
+// Fixture path (slug=test-fixture) always serves the static demo report.
+// WILLBUY_REPORT_FIXTURE env var is no longer required — the fixture slug
+// is treated as a public demo, not guarded by env.
 //
 // Return value is a discriminated union:
 //   - 'not_found'  API returned 404 (study_id invalid, report expired, or fetch error)
@@ -22,10 +23,7 @@ function apiBaseUrl(): string {
 }
 
 export async function fetchReport(slug: string): Promise<FetchReportResult> {
-  if (
-    process.env.WILLBUY_REPORT_FIXTURE === 'enabled' &&
-    slug === FIXTURE_SLUG
-  ) {
+  if (slug === FIXTURE_SLUG) {
     return { reportJson: fixture, urls: null };
   }
 

--- a/apps/web/test/pages.test.tsx
+++ b/apps/web/test/pages.test.tsx
@@ -21,24 +21,18 @@ describe('marketing landing — GET /', () => {
 
 describe('public report — GET /r/[slug]', () => {
   it('renders a "not found" body when no report exists for the slug', async () => {
-    delete process.env.WILLBUY_REPORT_FIXTURE;
     const el = await ReportPage({ params: Promise.resolve({ slug: 'no-such-slug' }) });
     const html = renderToStaticMarkup(el);
     expect(html).toMatch(/report not found/i);
   });
 
-  it('renders the report when the fixture seam is enabled and the slug matches', async () => {
-    process.env.WILLBUY_REPORT_FIXTURE = 'enabled';
-    try {
-      const el = await ReportPage({ params: Promise.resolve({ slug: 'test-fixture' }) });
-      const html = renderToStaticMarkup(el);
-      // Element 1 — headline delta — uses the verdict copy from the fixture.
-      expect(html).toMatch(/converts better/i);
-      // Slug rendered as <code> per §5.10.
-      expect(html).toMatch(/<code[^>]*>test-fixture<\/code>/);
-    } finally {
-      delete process.env.WILLBUY_REPORT_FIXTURE;
-    }
+  it('renders the report for the public demo slug (test-fixture)', async () => {
+    const el = await ReportPage({ params: Promise.resolve({ slug: 'test-fixture' }) });
+    const html = renderToStaticMarkup(el);
+    // Element 1 — headline delta — uses the verdict copy from the fixture.
+    expect(html).toMatch(/converts better/i);
+    // Slug rendered as <code> per §5.10.
+    expect(html).toMatch(/<code[^>]*>test-fixture<\/code>/);
   });
 
   it('exports metadata with noindex (per SPEC §5.10 untrusted-content boundary)', () => {


### PR DESCRIPTION
## Summary

The "See a sample report" CTA on the homepage and pricing page links to `/r/test-fixture`, but in production the fixture was gated behind `WILLBUY_REPORT_FIXTURE=enabled`. Visitors clicking the link saw "Report not found" instead of the demo.

**Root cause:** `fetchReport.ts` had `if (process.env.WILLBUY_REPORT_FIXTURE === 'enabled' && slug === FIXTURE_SLUG)` — the env var was never set in the production web service.

**Fix:** Remove the env var guard. The `test-fixture` slug serves static JSON from the bundled fixture file — there's no security or data concern; it's purely a public demo.

**Test:** Updated `pages.test.tsx` to not require the env var setup/teardown.

## Test plan

- [ ] CI green
- [ ] After deploy: `https://willbuy.dev/r/test-fixture` renders the demo report (not "Report not found")
- [ ] All 108 existing web tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)