### PR TITLE
feat(web): live cost estimate on new-study slider

### DIFF
--- a/apps/web/app/dashboard/studies/new/page.tsx
+++ b/apps/web/app/dashboard/studies/new/page.tsx
@@ -228,6 +228,11 @@ export default function StudyNewPage() {
             <span>5</span>
             <span>100</span>
           </div>
+          {/* Live cost estimate: avg 3.5¢/visit (ceiling 5¢ reserved by API §5.5) */}
+          <p className="mt-2 text-xs text-gray-500">
+            Estimated cost: ~${((isPaired ? 2 : 1) * nVisits * 3.5 / 100).toFixed(2)}
+            {' '}({(isPaired ? 2 : 1) * nVisits} visitor{(isPaired ? 2 : 1) * nVisits !== 1 ? 's' : ''} × avg 3.5¢)
+          </p>
         </section>
 
         {/* ── API error banners ── */}


### PR DESCRIPTION
## Summary

Adds a live cost estimate below the N-visitors slider on `/dashboard/studies/new`. Updates instantly as N or paired/single mode changes.

**Formula:** `urls × N × avg 3.5¢` — matches the pricing page's advertised avg-cost figure (ceiling 5¢ is reserved by the API but not shown to users, per §5.5).

**Example output:**
- N=30, single URL → "Estimated cost: ~$1.05 (30 visitors × avg 3.5¢)"
- N=30, paired A/B → "Estimated cost: ~$2.10 (60 visitors × avg 3.5¢)"
- N=100, paired → "Estimated cost: ~$7.00 (200 visitors × avg 3.5¢)"

## Test plan

- [ ] CI green
- [ ] Slider at N=30 single shows ~$1.05
- [ ] Toggle to paired → updates to ~$2.10
- [ ] Slider at N=5 → ~$0.18
- [ ] Slider at N=100 paired → ~$7.00

🤖 Generated with [Claude Code](https://claude.com/claude-code)