### PR TITLE
feat(web): auth-aware Buy button on /pricing

### DIFF
--- a/apps/web/app/pricing/PricingCta.tsx
+++ b/apps/web/app/pricing/PricingCta.tsx
@@ -1,0 +1,28 @@
+'use client';
+
+// Client component so BuyButton can use useState/fetch.
+// Receives isAuthenticated from the server component (cookie check).
+
+import { BuyButton } from '../dashboard/credits/BuyButton';
+
+interface PricingCtaProps {
+  packId: 'starter' | 'growth' | 'scale';
+  label: string;
+  usd: number;
+  isAuthenticated: boolean;
+}
+
+export function PricingCta({ packId, label, usd, isAuthenticated }: PricingCtaProps) {
+  if (isAuthenticated) {
+    return <BuyButton packId={packId} label={label} usd={usd} />;
+  }
+  return (
+    <a
+      href={`/sign-in?redirect=/pricing&pack=${packId}`}
+      aria-label={`Buy ${label} pack — $${usd}`}
+      className="mt-4 inline-block w-full rounded-md bg-blue-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
+    >
+      Buy →
+    </a>
+  );
+}

--- a/apps/web/app/pricing/page.tsx
+++ b/apps/web/app/pricing/page.tsx
@@ -10,9 +10,15 @@
  * ceiling used in BuyCredits (which shows conservative estimates for
  * existing customers). The public pricing page shows the more compelling
  * avg-cost figure to optimise for conversion.
+ *
+ * Auth-aware CTA: server reads session cookie; authenticated users see the
+ * BuyButton (direct Stripe checkout); unauthenticated get sign-in redirect.
  */
 
 // React Server Component — no 'use client' directive.
+
+import { cookies } from 'next/headers';
+import { PricingCta } from './PricingCta';
 
 interface Pack {
   id: 'starter' | 'growth' | 'scale';
@@ -51,7 +57,11 @@ const PACKS: Pack[] = [
   },
 ];
 
-export default function PricingPage() {
+export default async function PricingPage() {
+  const jar = await cookies();
+  const isAuthenticated =
+    jar.has('__Host-wb_session') || jar.has('wb_session');
+
   return (
     <main className="mx-auto max-w-5xl px-6 py-16">
       <h1 className="text-3xl font-bold tracking-tight text-center">
@@ -88,19 +98,12 @@ export default function PricingPage() {
               See a sample report →
             </a>
 
-            {/*
-             * TODO (#144): unauthenticated checkout wiring deferred; see #144.
-             * /checkout/sessions requires API key auth. For now we send the
-             * visitor to sign-in with a redirect back to /pricing so they can
-             * complete purchase after authenticating.
-             */}
-            <a
-              href={`/sign-in?redirect=/pricing&pack=${pack.id}`}
-              aria-label={`Buy ${pack.label} pack — $${pack.usd}`}
-              className="mt-4 inline-block rounded-md bg-blue-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
-            >
-              Buy →
-            </a>
+            <PricingCta
+              packId={pack.id}
+              label={pack.label}
+              usd={pack.usd}
+              isAuthenticated={isAuthenticated}
+            />
           </div>
         ))}
       </div>

--- a/apps/web/test/pricing.test.tsx
+++ b/apps/web/test/pricing.test.tsx
@@ -11,50 +11,67 @@
  * Visit estimates use 3.5¢/visit avg (issue #112 manager decision).
  */
 
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi, beforeEach } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import PricingPage from '../app/pricing/page';
 
+// Mock next/headers so cookies() works outside a request scope in unit tests.
+vi.mock('next/headers', () => ({
+  cookies: vi.fn().mockResolvedValue({
+    has: () => false,
+  }),
+}));
+
 describe('/pricing page (issue #144)', () => {
-  function getHtml(): string {
-    return renderToStaticMarkup(<PricingPage />);
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  async function getHtml(): Promise<string> {
+    const el = await PricingPage();
+    return renderToStaticMarkup(el);
   }
 
-  it('renders pack name "Starter"', () => {
-    expect(getHtml()).toMatch(/Starter/i);
+  it('renders pack name "Starter"', async () => {
+    expect(await getHtml()).toMatch(/Starter/i);
   });
 
-  it('renders pack name "Growth"', () => {
-    expect(getHtml()).toMatch(/Growth/i);
+  it('renders pack name "Growth"', async () => {
+    expect(await getHtml()).toMatch(/Growth/i);
   });
 
-  it('renders pack name "Scale"', () => {
-    expect(getHtml()).toMatch(/Scale/i);
+  it('renders pack name "Scale"', async () => {
+    expect(await getHtml()).toMatch(/Scale/i);
   });
 
-  it('renders Starter price "$29"', () => {
-    expect(getHtml()).toMatch(/\$29/);
+  it('renders Starter price "$29"', async () => {
+    expect(await getHtml()).toMatch(/\$29/);
   });
 
-  it('renders Growth price "$99"', () => {
-    expect(getHtml()).toMatch(/\$99/);
+  it('renders Growth price "$99"', async () => {
+    expect(await getHtml()).toMatch(/\$99/);
   });
 
-  it('renders Scale price "$299"', () => {
-    expect(getHtml()).toMatch(/\$299/);
+  it('renders Scale price "$299"', async () => {
+    expect(await getHtml()).toMatch(/\$299/);
   });
 
-  it('contains no "start free" copy (paid-conversion page)', () => {
-    expect(getHtml()).not.toMatch(/start free/i);
+  it('contains no "start free" copy (paid-conversion page)', async () => {
+    expect(await getHtml()).not.toMatch(/start free/i);
   });
 
-  it('renders "Already have credits? Sign in" link', () => {
-    expect(getHtml()).toMatch(/already have credits/i);
+  it('renders "Already have credits? Sign in" link', async () => {
+    expect(await getHtml()).toMatch(/already have credits/i);
   });
 
-  it('"See a sample report" link points to /r/test-fixture', () => {
-    const html = getHtml();
+  it('"See a sample report" link points to /r/test-fixture', async () => {
+    const html = await getHtml();
     expect(html).toMatch(/see a sample report/i);
     expect(html).toMatch(/href="\/r\/test-fixture"/i);
+  });
+
+  it('unauthenticated: shows sign-in redirect link (no session cookie)', async () => {
+    const html = await getHtml();
+    expect(html).toMatch(/sign-in/i);
   });
 });


### PR DESCRIPTION
## Summary

Previously, all visitors to `/pricing` saw a sign-in redirect for the Buy button — even authenticated users who already had a session. After authenticating via the magic link and returning to `/pricing`, they'd click Buy and be redirected to sign-in *again*.

**Fix:** Server component checks for `wb_session` / `__Host-wb_session` cookie. Authenticated users get the `BuyButton` (direct Stripe checkout); unauthenticated get the sign-in redirect with `?redirect=/pricing&pack=<id>`.

New file: `app/pricing/PricingCta.tsx` — thin client wrapper that switches between BuyButton and sign-in link based on the `isAuthenticated` prop.

## Test plan

- [ ] CI green
- [ ] Unauthenticated: Buy → redirects to `/sign-in?redirect=/pricing&pack=starter`
- [ ] Authenticated (session cookie set): Buy → calls `/api/checkout/sessions` (Stripe, requires #195)
- [ ] 109 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)