### PR TITLE
feat(web): better onboarding for /bin/zsh-balance new users

### DIFF
--- a/apps/web/app/dashboard/DashboardView.tsx
+++ b/apps/web/app/dashboard/DashboardView.tsx
@@ -104,9 +104,15 @@ export function DashboardView({ summary }: { summary: DashboardSummary }): React
             {formatBalance(balance_cents)}
           </p>
           <p className="mt-1 text-sm text-gray-500">
-            Each visit costs up to 5¢. You can run up to{' '}
-            <span className="font-medium text-gray-700">{Math.floor(balance_cents / 5)}</span>{' '}
-            visits with this balance.
+            {balance_cents === 0 ? (
+              <>Buy credits to run your first study. Starts at $29 for ~828 visits.</>
+            ) : (
+              <>
+                Each visit costs up to 5¢. You can run up to{' '}
+                <span className="font-medium text-gray-700">{Math.floor(balance_cents / 5)}</span>{' '}
+                visits with this balance.
+              </>
+            )}
           </p>
         </div>
         <div className="flex flex-col gap-3">
@@ -136,13 +142,30 @@ export function DashboardView({ summary }: { summary: DashboardSummary }): React
 
         {recent_studies.length === 0 ? (
           <div className="rounded-lg border border-dashed border-gray-300 bg-gray-50 px-6 py-12 text-center">
-            <p className="text-sm text-gray-700">No studies yet — start one.</p>
-            <a
-              href="/dashboard/studies/new"
-              className="mt-3 inline-block text-sm font-medium text-indigo-600 hover:underline"
-            >
-              Create your first study
-            </a>
+            {balance_cents === 0 ? (
+              <>
+                <p className="text-sm font-medium text-gray-700">You need credits to run a study.</p>
+                <p className="mt-1 text-xs text-gray-500">
+                  Each study runs N synthetic visitors at avg 3.5¢ each.
+                </p>
+                <a
+                  href="/dashboard/credits"
+                  className="mt-3 inline-block rounded-md bg-gray-900 px-4 py-2 text-sm font-semibold text-white hover:bg-gray-700"
+                >
+                  Buy credits →
+                </a>
+              </>
+            ) : (
+              <>
+                <p className="text-sm text-gray-700">No studies yet — start one.</p>
+                <a
+                  href="/dashboard/studies/new"
+                  className="mt-3 inline-block text-sm font-medium text-indigo-600 hover:underline"
+                >
+                  Create your first study
+                </a>
+              </>
+            )}
           </div>
         ) : (
           <div className="overflow-hidden rounded-lg border border-gray-200 bg-white shadow-sm">

--- a/apps/web/test/dashboard.test.tsx
+++ b/apps/web/test/dashboard.test.tsx
@@ -67,8 +67,15 @@ describe('/dashboard view (issue #80)', () => {
   // -------------------------------------------------------------------------
   // 2: Empty state.
   // -------------------------------------------------------------------------
-  it('shows empty state when there are no studies', () => {
+  it('shows buy-credits prompt when balance is 0 and no studies', () => {
     const empty = { email: 'a@b.co', balance_cents: 0, recent_studies: [] };
+    const html = renderToStaticMarkup(<DashboardView summary={empty} />);
+    expect(html).toMatch(/buy credits/i);
+    expect(html).toMatch(/need credits to run a study/i);
+  });
+
+  it('shows empty state with "start one" link when balance > 0 and no studies', () => {
+    const empty = { email: 'a@b.co', balance_cents: 500, recent_studies: [] };
     const html = renderToStaticMarkup(<DashboardView summary={empty} />);
     expect(html).toMatch(/no studies yet/i);
   });


### PR DESCRIPTION
## Summary

New users signing up for the first time have `balance_cents = 0` and no studies. The old dashboard:
- Balance card said "You can run up to **0** visits with this balance" (confusing)
- Empty state said "No studies yet — start one" (clicking it leads to immediate 402)

**Fixed:**
- Balance card shows: "Buy credits to run your first study. Starts at \$29 for ~828 visits."
- Empty state (when balance = 0): shows "Buy credits →" button instead of a misleading New Study link
- Empty state (when balance > 0): unchanged — still shows "Create your first study"

## Test plan
- [ ] CI green (110 tests)
- [ ] New user with \$0 balance sees credits prompt in both card and empty state
- [ ] User with balance but no studies sees original "No studies yet" copy

🤖 Generated with [Claude Code](https://claude.com/claude-code)