### PR TITLE
fix(web): broken domain-verify link in study creation error

### DIFF
--- a/apps/web/app/dashboard/studies/new/page.tsx
+++ b/apps/web/app/dashboard/studies/new/page.tsx
@@ -246,7 +246,7 @@ export default function StudyNewPage() {
                 <p className="mt-1 text-sm text-red-700">{apiError.message}</p>
                 <div className="mt-2 flex gap-3">
                   <a
-                    href="/dashboard/domains/verify"
+                    href="/dashboard/domains/new"
                     className="text-sm font-medium text-indigo-600 hover:underline"
                   >
                     Verify domain


### PR DESCRIPTION
## Summary

When a user submits the new-study form with a domain that isn't verified, the 422 error banner shows a "Verify domain" link. This link pointed to `/dashboard/domains/verify` which returns 404.

**Fix:** Changed to `/dashboard/domains/new` — the actual route for the domain verification flow (built in issue #82).

One-liner change, no test needed beyond existing 110 passing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)