### PR TITLE
feat(web): add Domains link to dashboard nav

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -34,6 +34,9 @@ export default function DashboardLayout({ children }: { children: ReactNode }): 
             <a href="/dashboard/studies/new" className="hover:text-gray-900">
               New study
             </a>
+            <a href="/dashboard/domains" className="hover:text-gray-900">
+              Domains
+            </a>
             <a href="/dashboard/credits" className="hover:text-gray-900">
               Credits
             </a>


### PR DESCRIPTION
## Summary

Domain verification is a prerequisite for creating studies. Without a nav link, new users could only find it via the error banner in the new-study form — poor discoverability.

Added "Domains" between "New study" and "Credits" in the dashboard header nav.

Nav before: Dashboard | New study | Credits | Sign out
Nav after:  Dashboard | New study | **Domains** | Credits | Sign out

🤖 Generated with [Claude Code](https://claude.com/claude-code)