### PR TITLE
feat(web): return to current dashboard page after session expiry

### DIFF
--- a/apps/web/app/dashboard/credits/page.tsx
+++ b/apps/web/app/dashboard/credits/page.tsx
@@ -62,16 +62,16 @@ export default async function CreditsPage({
         headers: { cookie: `wb_session=${sessionCookie.value}` },
         cache: 'no-store',
       });
-      if (res.status === 401) redirect('/sign-in');
+      if (res.status === 401) redirect('/sign-in?redirect=%2Fdashboard%2Fcredits');
       if (res.ok) {
         const data = (await res.json()) as DashboardSummary;
         balance_cents = data.balance_cents;
       }
     } catch {
-      redirect('/sign-in');
+      redirect('/sign-in?redirect=%2Fdashboard%2Fcredits');
     }
   } else {
-    redirect('/sign-in');
+    redirect('/sign-in?redirect=%2Fdashboard%2Fcredits');
   }
 
   const balanceVisits = Math.max(0, Math.floor(balance_cents / 3.5));

--- a/apps/web/app/dashboard/domains/page.tsx
+++ b/apps/web/app/dashboard/domains/page.tsx
@@ -79,14 +79,14 @@ export default async function DomainsListPage(): Promise<JSX.Element> {
     (c) => c.name === 'wb_session' || c.name === '__Host-wb_session',
   );
   if (!hasSession) {
-    redirect('/sign-in');
+    redirect('/sign-in?redirect=%2Fdashboard%2Fdomains');
   }
 
   const result = await fetchDomains(cookieHeader);
 
   if (!result.ok) {
     if (result.status === 401) {
-      redirect('/sign-in');
+      redirect('/sign-in?redirect=%2Fdashboard%2Fdomains');
     }
     return (
       <main className="mx-auto max-w-2xl px-6 py-16">

--- a/apps/web/app/dashboard/studies/page.tsx
+++ b/apps/web/app/dashboard/studies/page.tsx
@@ -87,7 +87,7 @@ export default async function StudiesListPage(props: PageProps): Promise<JSX.Ele
     (c) => c.name === 'wb_session' || c.name === '__Host-wb_session',
   );
   if (!hasSession) {
-    redirect('/sign-in');
+    redirect('/sign-in?redirect=%2Fdashboard%2Fstudies');
   }
 
   // Resolve the cursor query param — handle both Promise- and plain-object
@@ -105,7 +105,7 @@ export default async function StudiesListPage(props: PageProps): Promise<JSX.Ele
 
   if (!result.ok) {
     if (result.status === 401) {
-      redirect('/sign-in');
+      redirect('/sign-in?redirect=%2Fdashboard%2Fstudies');
     }
     return (
       <main className="mx-auto max-w-2xl px-6 py-16">


### PR DESCRIPTION
## Summary

Session expiry on any sub-dashboard page redirected to \`/sign-in\` with no context. After re-authenticating, users always landed on \`/dashboard\` instead of where they were.

Now passes \`?redirect=<encoded-path>\` to the sign-in page so the magic-link verify handler (PR #219) sends them back to the right page.

Pages updated: `/dashboard/domains`, `/dashboard/studies`, `/dashboard/credits`

(The main `/dashboard` page already defaults to `/dashboard` after sign-in, so no change needed there.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)