### PR TITLE
fix(web): api-keys pages return to correct page after session expiry

### DIFF
--- a/apps/web/app/dashboard/api-keys/new/page.tsx
+++ b/apps/web/app/dashboard/api-keys/new/page.tsx
@@ -37,7 +37,7 @@ export default function NewApiKeyPage({
     (c) => c.name === 'wb_session' || c.name === '__Host-wb_session',
   );
   if (!hasSession) {
-    redirect('/sign-in');
+    redirect('/sign-in?redirect=%2Fdashboard%2Fapi-keys%2Fnew');
   }
 
   // exactOptionalPropertyTypes: only pass error when it's a string (not undefined).

--- a/apps/web/app/dashboard/api-keys/page.tsx
+++ b/apps/web/app/dashboard/api-keys/page.tsx
@@ -55,13 +55,13 @@ export default async function ApiKeysPage(): Promise<JSX.Element> {
     (c) => c.name === 'wb_session' || c.name === '__Host-wb_session',
   );
   if (!hasSession) {
-    redirect('/sign-in');
+    redirect('/sign-in?redirect=%2Fdashboard%2Fapi-keys');
   }
 
   const result = await fetchKeys(cookieHeader);
 
   if (!result.ok) {
-    if (result.status === 401) redirect('/sign-in');
+    if (result.status === 401) redirect('/sign-in?redirect=%2Fdashboard%2Fapi-keys');
     return (
       <main className="mx-auto max-w-2xl px-6 py-16">
         <h1 className="text-2xl font-bold text-gray-900">API keys unavailable</h1>


### PR DESCRIPTION
## Summary

Follow-up to #224. The api-keys pages still used bare \`/sign-in\` redirects without a return path.

- `/dashboard/api-keys` → now redirects to `/sign-in?redirect=%2Fdashboard%2Fapi-keys`
- `/dashboard/api-keys/new` → now redirects to `/sign-in?redirect=%2Fdashboard%2Fapi-keys%2Fnew`

All dashboard pages now have correct return-path redirects except the root `/dashboard` which defaults to itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)