### PR TITLE
fix(web): fix remaining sign-in redirect issues in route handlers

### DIFF
--- a/apps/web/app/dashboard/api-keys/[id]/revoke/route.ts
+++ b/apps/web/app/dashboard/api-keys/[id]/revoke/route.ts
@@ -50,7 +50,7 @@ export async function POST(
   }
 
   if (res.status === 401) {
-    return NextResponse.redirect(new URL('/sign-in', req.url), 303);
+    return NextResponse.redirect(new URL('/sign-in?redirect=%2Fdashboard%2Fapi-keys', req.url), 303);
   }
   // For 200 (success) and 404 (already revoked / not found) we redirect
   // back to the list either way. The list will reflect the current state.

--- a/apps/web/app/dashboard/api-keys/create/route.ts
+++ b/apps/web/app/dashboard/api-keys/create/route.ts
@@ -154,7 +154,7 @@ export async function POST(req: NextRequest): Promise<Response> {
   }
 
   if (res.status === 401) {
-    return NextResponse.redirect(new URL('/sign-in', req.url), 303);
+    return NextResponse.redirect(new URL('/sign-in?redirect=%2Fdashboard%2Fapi-keys%2Fnew', req.url), 303);
   }
   if (!res.ok) {
     let msg = `Could not create key (${res.status})`;

--- a/apps/web/app/dashboard/studies/new/page.tsx
+++ b/apps/web/app/dashboard/studies/new/page.tsx
@@ -83,7 +83,7 @@ export default function StudyNewPage() {
 
       // Map API error codes to inline error UI.
       if (result.status === 401) {
-        router.push('/dashboard/sign-in');
+        router.push('/sign-in?redirect=%2Fdashboard%2Fstudies%2Fnew');
         return;
       }
       if (result.status === 402) {


### PR DESCRIPTION
## Summary

Two remaining redirect problems after #224 + #225:

1. **`/dashboard/studies/new` 401 handler** — pushed to `/dashboard/sign-in` (404). Fixed to `/sign-in?redirect=%2Fdashboard%2Fstudies%2Fnew`.

2. **API-key route handlers** (`create`, `revoke`) — bare `/sign-in` with no return path. Fixed to include correct return paths.

This completes redirect coverage across all dashboard pages and handlers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)