### PR TITLE
feat: study detail returns report_public; PublishButton init correctly

### DIFF
--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -246,9 +246,13 @@ export async function registerStudiesRoutes(
         status: string;
         created_at: Date;
         finalized_at: Date | null;
+        report_public: boolean | null;
       }>(
-        `SELECT id, account_id, status, created_at, finalized_at
-           FROM studies WHERE id = $1`,
+        `SELECT s.id, s.account_id, s.status, s.created_at, s.finalized_at,
+                r."public" AS report_public
+           FROM studies s
+           LEFT JOIN reports r ON r.study_id = s.id
+          WHERE s.id = $1`,
         [studyId],
       );
 
@@ -285,6 +289,7 @@ export async function registerStudiesRoutes(
         visit_progress: { ok: okCount, failed: failedCount, total },
         started_at: study.created_at.toISOString(),
         finalized_at: study.finalized_at?.toISOString() ?? null,
+        ...(study.report_public !== null ? { report_public: study.report_public } : {}),
       });
     },
   );
@@ -361,9 +366,14 @@ export async function registerStudiesRoutes(
         status: string;
         created_at: Date;
         finalized_at: Date | null;
+        slug: string | null;
+        report_public: boolean | null;
       }>(
-        `SELECT id, account_id, status, created_at, finalized_at
-           FROM studies WHERE id = $1`,
+        `SELECT s.id, s.account_id, s.status, s.created_at, s.finalized_at,
+                r.slug, r.public AS report_public
+           FROM studies s
+           LEFT JOIN reports r ON r.study_id = s.id
+          WHERE s.id = $1`,
         [studyId],
       );
 
@@ -391,6 +401,7 @@ export async function registerStudiesRoutes(
         visit_progress: { ok: okCount, failed: failedCount, total },
         started_at: study.created_at.toISOString(),
         finalized_at: study.finalized_at?.toISOString() ?? null,
+        ...(study.report_public !== null ? { report_public: study.report_public } : {}),
       });
     },
   );

--- a/apps/web/app/dashboard/studies/[id]/page.tsx
+++ b/apps/web/app/dashboard/studies/[id]/page.tsx
@@ -221,7 +221,7 @@ function StudyStatusInner({ id }: { id: string }) {
           >
             View report
           </a>
-          <PublishButton studyId={s.id} reportSlug={s.slug ?? String(s.id)} />
+          <PublishButton studyId={s.id} reportSlug={s.slug ?? String(s.id)} initialPublished={s.report_public ?? false} />
         </div>
       )}
 

--- a/apps/web/components/dashboard/PublishButton.tsx
+++ b/apps/web/components/dashboard/PublishButton.tsx
@@ -8,10 +8,12 @@ import React, { useState } from 'react';
 interface PublishButtonProps {
   studyId: string | number;
   reportSlug: string;
+  /** Pre-populate published state from the API so the button reflects reality on load. */
+  initialPublished?: boolean;
 }
 
-export function PublishButton({ studyId, reportSlug }: PublishButtonProps) {
-  const [published, setPublished] = useState(false);
+export function PublishButton({ studyId, reportSlug, initialPublished = false }: PublishButtonProps) {
+  const [published, setPublished] = useState(initialPublished);
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
 

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -68,6 +68,8 @@ const GetStudyResponseSchema = z.object({
   finalized_at: z.string().nullable(),
   // slug is present once study is ready (populated by the report row).
   slug: z.string().optional(),
+  // report_public present once study has a report row; true if already published.
+  report_public: z.boolean().optional(),
 });
 export type GetStudyResponse = z.infer<typeof GetStudyResponseSchema>;
 


### PR DESCRIPTION
## Summary

**Problem:** After publishing a report, refreshing the study detail page showed "Make report public" again — because the API never returned the report's published status, and the button always initialized as `published = false`.

**Fix:**

1. Both `GET /studies/:id` (API-key) and `GET /api/studies/:id` (session) now LEFT JOIN the reports table and return `report_public: boolean` when a report row exists.

2. `PublishButton` accepts an `initialPublished` prop (default `false`) and initializes `useState(initialPublished)` — so a page refresh correctly shows "Report is now public" when already published.

3. The study status page passes `report_public` from the API response.

## Test plan

- [ ] CI green (145 API + 110 web tests)
- [ ] Published study: page refresh shows "Report is now public" instead of "Make report public"
- [ ] Unpublished study: page refresh still shows "Make report public"

🤖 Generated with [Claude Code](https://claude.com/claude-code)