### PR TITLE
fix(web): link pending report page to study status page

### DIFF
--- a/apps/web/app/r/[slug]/fetchReport.ts
+++ b/apps/web/app/r/[slug]/fetchReport.ts
@@ -14,7 +14,8 @@ import fixture from '../../../test/fixtures/report.fixture.json';
 const FIXTURE_SLUG = 'test-fixture';
 
 export type ReportPayload = { reportJson: unknown; urls: string[] | null };
-export type FetchReportResult = 'not_found' | 'pending' | ReportPayload;
+export type PendingReport = { status: 'pending'; studyId: number | null };
+export type FetchReportResult = 'not_found' | PendingReport | ReportPayload;
 
 function apiBaseUrl(): string {
   const explicit = process.env['WILLBUY_API_URL'] ?? process.env['NEXT_PUBLIC_API_URL'];
@@ -54,7 +55,10 @@ export async function fetchReport(slug: string): Promise<FetchReportResult> {
 
   const body = (await res.json()) as Record<string, unknown>;
   const reportJson = body['report_json'];
-  if (reportJson === null || reportJson === undefined) return 'pending';
+  if (reportJson === null || reportJson === undefined) {
+    const studyId = typeof body['study_id'] === 'number' ? body['study_id'] : null;
+    return { status: 'pending', studyId };
+  }
   const urls = Array.isArray(body['urls']) ? (body['urls'] as string[]) : null;
   return { reportJson, urls };
 }

--- a/apps/web/app/r/[slug]/page.tsx
+++ b/apps/web/app/r/[slug]/page.tsx
@@ -35,14 +35,25 @@ export default async function ReportPage({
     );
   }
 
-  if (result === 'pending') {
+  if ('status' in result) {
+    // result is PendingReport — report_json not yet populated by aggregator
     return (
       <>
         <main className="mx-auto max-w-3xl px-6 py-16">
           <h1 className="text-3xl font-bold tracking-tight">Report is being prepared</h1>
           <p className="mt-6 text-gray-700">
-            The analysis for <code>{slug}</code> is still running. Refresh in a moment.
+            The analysis for <code>{slug}</code> is still running.
           </p>
+          {result.studyId !== null ? (
+            <a
+              href={`/dashboard/studies/${result.studyId}`}
+              className="mt-4 inline-block text-sm font-medium text-indigo-600 hover:text-indigo-500"
+            >
+              Track progress on the study status page →
+            </a>
+          ) : (
+            <p className="mt-2 text-sm text-gray-500">Refresh in a moment.</p>
+          )}
         </main>
         <ReportCtaBar />
       </>

--- a/apps/web/test/pages.test.tsx
+++ b/apps/web/test/pages.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import LandingPage from '../app/page';
 import ReportPage, { metadata as reportMetadata } from '../app/r/[slug]/page';
@@ -33,6 +33,25 @@ describe('public report — GET /r/[slug]', () => {
     expect(html).toMatch(/converts better/i);
     // Slug rendered as <code> per §5.10.
     expect(html).toMatch(/<code[^>]*>test-fixture<\/code>/);
+  });
+
+  it('renders a "pending" body with a study status link when report_json is null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ study_id: 42, report_json: null, urls: null }),
+      }),
+    );
+    try {
+      const el = await ReportPage({ params: Promise.resolve({ slug: 'still-running' }) });
+      const html = renderToStaticMarkup(el);
+      expect(html).toMatch(/being prepared/i);
+      expect(html).toMatch(/dashboard\/studies\/42/);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('exports metadata with noindex (per SPEC §5.10 untrusted-content boundary)', () => {


### PR DESCRIPTION
## Summary

- When a user visits `/r/<slug>` while the study is still aggregating, they previously saw a dead-end "Refresh in a moment" message with no path forward
- The reports API already returns `study_id` in the 200 response even when `report_json` is null (pending state)
- Now `fetchReport` surfaces `studyId` in the `PendingReport` discriminant, and the page renders a "Track progress on the study status page →" link pointing to `/dashboard/studies/:id`
- Falls back to "Refresh in a moment" text if `study_id` is absent

## Test plan

- [x] `pages.test.tsx` — added pending-state test with stubbed fetch; asserts the study link is present
- [x] Full web test suite: 111 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)