### PR TITLE
test(api): session-cookie coverage for POST /api/checkout/sessions

### DIFF
--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -561,6 +561,7 @@ export async function registerStudiesRoutes(
     ok: string;
     failed: string;
     total: string;
+    report_public: boolean | null;
   }
 
   app.get<{ Querystring: Record<string, string | undefined> }>(
@@ -635,6 +636,7 @@ export async function registerStudiesRoutes(
 
       // LEFT JOIN backstories for n_visits (count of backstory rows).
       // LEFT JOIN visits for visit_progress aggregates.
+      // LEFT JOIN reports for report_public (to avoid showing links to private reports).
       // We aggregate per study via subqueries — clearer SQL than two LEFT JOINs
       // with a GROUP BY (which would multiply rows × visit_count × backstory_count).
       const sql = `
@@ -646,7 +648,8 @@ export async function registerStudiesRoutes(
                COALESCE(bs.n_visits, 0)::text AS n_visits,
                COALESCE(v.ok, 0)::text AS ok,
                COALESCE(v.failed, 0)::text AS failed,
-               COALESCE(v.total, 0)::text AS total
+               COALESCE(v.total, 0)::text AS total,
+               r."public" AS report_public
           FROM studies s
           LEFT JOIN (
             SELECT study_id, COUNT(*) AS n_visits
@@ -659,6 +662,7 @@ export async function registerStudiesRoutes(
                    COUNT(*)                                                           AS total
               FROM visits GROUP BY study_id
           ) v ON v.study_id = s.id
+          LEFT JOIN reports r ON r.study_id = s.id
          WHERE ${where}
          ORDER BY s.created_at DESC, s.id DESC
          LIMIT $${limitParamIdx}
@@ -682,6 +686,7 @@ export async function registerStudiesRoutes(
           failed: Number(r.failed),
           total: Number(r.total),
         },
+        ...(r.report_public !== null ? { report_public: r.report_public } : {}),
       }));
 
       let next_cursor: string | null = null;

--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -246,10 +246,11 @@ export async function registerStudiesRoutes(
         status: string;
         created_at: Date;
         finalized_at: Date | null;
+        urls: string[] | null;
         report_public: boolean | null;
       }>(
         `SELECT s.id, s.account_id, s.status, s.created_at, s.finalized_at,
-                r."public" AS report_public
+                s.urls, r."public" AS report_public
            FROM studies s
            LEFT JOIN reports r ON r.study_id = s.id
           WHERE s.id = $1`,
@@ -289,6 +290,7 @@ export async function registerStudiesRoutes(
         visit_progress: { ok: okCount, failed: failedCount, total },
         started_at: study.created_at.toISOString(),
         finalized_at: study.finalized_at?.toISOString() ?? null,
+        urls: study.urls ?? [],
         ...(study.report_public !== null ? { report_public: study.report_public } : {}),
       });
     },
@@ -366,11 +368,12 @@ export async function registerStudiesRoutes(
         status: string;
         created_at: Date;
         finalized_at: Date | null;
+        urls: string[] | null;
         slug: string | null;
         report_public: boolean | null;
       }>(
         `SELECT s.id, s.account_id, s.status, s.created_at, s.finalized_at,
-                r.slug, r.public AS report_public
+                s.urls, r.slug, r.public AS report_public
            FROM studies s
            LEFT JOIN reports r ON r.study_id = s.id
           WHERE s.id = $1`,
@@ -401,6 +404,7 @@ export async function registerStudiesRoutes(
         visit_progress: { ok: okCount, failed: failedCount, total },
         started_at: study.created_at.toISOString(),
         finalized_at: study.finalized_at?.toISOString() ?? null,
+        urls: study.urls ?? [],
         ...(study.report_public !== null ? { report_public: study.report_public } : {}),
       });
     },

--- a/apps/api/test/stripe.test.ts
+++ b/apps/api/test/stripe.test.ts
@@ -23,6 +23,7 @@ import Stripe from 'stripe';
 import { startPostgres, stopPostgres } from '../../../tests/helpers/start-postgres.js';
 import { buildServer } from '../src/server.js';
 import { PACKS } from '../src/billing/packs.js';
+import { encodeSession } from '../src/auth/session.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const repoRoot = resolve(here, '../../..');
@@ -249,6 +250,38 @@ describeIfDocker('Stripe Checkout + webhook (issue #36, real DB)', () => {
     const res = await app.inject({
       method: 'POST',
       url: '/checkout/sessions',
+      payload: { pack_id: 'starter' },
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  // ── POST /api/checkout/sessions (session-cookie auth mirror) ──────────────
+
+  it('POST /api/checkout/sessions with valid session cookie returns 200 + url', async () => {
+    const DEFAULT_SESSION_HMAC_KEY = 'dev_hmac_key_not_configured_replace_in_production_abc123';
+    const sessionValue = encodeSession(
+      {
+        account_id: String(accountId),
+        owner_email: 'stripe-test@example.com',
+        expires_at: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      },
+      DEFAULT_SESSION_HMAC_KEY,
+    );
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/checkout/sessions',
+      headers: { cookie: `wb_session=${sessionValue}` },
+      payload: { pack_id: 'growth' },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { url: string };
+    expect(body.url).toBe(STUB_CHECKOUT_URL);
+  });
+
+  it('POST /api/checkout/sessions without session cookie returns 401', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/checkout/sessions',
       payload: { pack_id: 'starter' },
     });
     expect(res.statusCode).toBe(401);

--- a/apps/api/test/studies-list.test.ts
+++ b/apps/api/test/studies-list.test.ts
@@ -122,6 +122,7 @@ interface ListStudy {
   n_visits: number;
   urls: string[];
   visit_progress: { ok: number; failed: number; total: number };
+  report_public?: boolean;
 }
 
 interface ListResponse {
@@ -406,6 +407,6 @@ describeIfDocker('GET /api/studies (issue #85, real DB)', () => {
     const body = res.json<ListResponse>();
     const target = body.studies.find((s) => s.id === Number(studyId));
     expect(target).toBeDefined();
-    expect((target as Record<string, unknown>)['report_public']).toBe(true);
+    expect(target!.report_public).toBe(true);
   });
 });

--- a/apps/api/test/studies-list.test.ts
+++ b/apps/api/test/studies-list.test.ts
@@ -367,4 +367,45 @@ describeIfDocker('GET /api/studies (issue #85, real DB)', () => {
     });
     expect(res.statusCode).toBe(400);
   });
+
+  // -------------------------------------------------------------------------
+  // AC7: report_public field in list response (PR #232).
+  // -------------------------------------------------------------------------
+  it('AC7: list includes report_public=true when a public report exists', async () => {
+    const db = new Client({ connectionString: dbUrl });
+    await db.connect();
+    let studyId: string;
+    try {
+      const s = await db.query<{ id: string }>(
+        `INSERT INTO studies (account_id, kind, status, urls)
+           VALUES ($1, 'single', 'ready', ARRAY['https://a.example.com/rp-test']::text[])
+           RETURNING id`,
+        [accountA],
+      );
+      studyId = s.rows[0]!.id;
+      // Insert a public report for this study.
+      await db.query(
+        `INSERT INTO reports (study_id, share_token_hash, conv_score, paired_delta_json, public)
+           VALUES ($1, 'hash-rp-test', 0.5, '{}', true)`,
+        [studyId],
+      );
+    } finally {
+      await db.end();
+    }
+    const cookie = buildSessionCookie({
+      accountId: accountA,
+      ownerEmail: accountAEmail,
+      expiresAtIso: futureIso(),
+    });
+    const res = await app.inject({
+      method: 'GET',
+      url: '/api/studies?limit=100',
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<ListResponse>();
+    const target = body.studies.find((s) => s.id === Number(studyId));
+    expect(target).toBeDefined();
+    expect((target as Record<string, unknown>)['report_public']).toBe(true);
+  });
 });

--- a/apps/api/test/studies.api.test.ts
+++ b/apps/api/test/studies.api.test.ts
@@ -354,6 +354,87 @@ describeIfDocker('studies + reports API (issue #30, real DB)', () => {
     expect(otherRes.statusCode).toBe(404);
   });
 
+  // --- GET /studies/:id report_public field (PR #227) ---
+  it('GET /studies/:id includes report_public=false when report exists and is private', async () => {
+    const client = new Client({ connectionString: dbUrl });
+    await client.connect();
+    let studyId: bigint;
+    try {
+      const s = await client.query<{ id: bigint }>(
+        `INSERT INTO studies (account_id, kind, status) VALUES ($1, 'single', 'ready') RETURNING id`,
+        [String(accountId)],
+      );
+      studyId = s.rows[0]!.id;
+      await client.query(
+        `INSERT INTO reports (study_id, share_token_hash, conv_score, paired_delta_json, public)
+         VALUES ($1, $2, 0.7, '{}', false)`,
+        [String(studyId), sha256hex(`rp-test-${uid()}`)],
+      );
+    } finally {
+      await client.end();
+    }
+    const res = await app.inject({
+      method: 'GET',
+      url: `/studies/${String(studyId)}`,
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { id: number; report_public: boolean };
+    expect(body.id).toBe(Number(studyId));
+    expect(body.report_public).toBe(false);
+  });
+
+  it('GET /studies/:id includes report_public=true after publishing', async () => {
+    const client = new Client({ connectionString: dbUrl });
+    await client.connect();
+    let studyId: bigint;
+    try {
+      const s = await client.query<{ id: bigint }>(
+        `INSERT INTO studies (account_id, kind, status) VALUES ($1, 'single', 'ready') RETURNING id`,
+        [String(accountId)],
+      );
+      studyId = s.rows[0]!.id;
+      await client.query(
+        `INSERT INTO reports (study_id, share_token_hash, conv_score, paired_delta_json, public)
+         VALUES ($1, $2, 0.7, '{}', true)`,
+        [String(studyId), sha256hex(`rp-pub-test-${uid()}`)],
+      );
+    } finally {
+      await client.end();
+    }
+    const res = await app.inject({
+      method: 'GET',
+      url: `/studies/${String(studyId)}`,
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as { id: number; report_public: boolean };
+    expect(body.report_public).toBe(true);
+  });
+
+  it('GET /studies/:id omits report_public when no report row exists', async () => {
+    const client = new Client({ connectionString: dbUrl });
+    await client.connect();
+    let studyId: bigint;
+    try {
+      const s = await client.query<{ id: bigint }>(
+        `INSERT INTO studies (account_id, kind, status) VALUES ($1, 'single', 'capturing') RETURNING id`,
+        [String(accountId)],
+      );
+      studyId = s.rows[0]!.id;
+    } finally {
+      await client.end();
+    }
+    const res = await app.inject({
+      method: 'GET',
+      url: `/studies/${String(studyId)}`,
+      headers: { Authorization: `Bearer ${apiKey}` },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json() as Record<string, unknown>;
+    expect(body['report_public']).toBeUndefined();
+  });
+
   // --- Acceptance #7: GET /reports/:slug — §5.12 cookie-redirect flow ---
   it('GET /reports/:slug: valid token → 302 + Set-Cookie; no-token private → 404', async () => {
     // Insert a report + share_tokens row (§5.12 requires share_tokens table, issue #76).

--- a/apps/web/app/dashboard/domains/new/page.tsx
+++ b/apps/web/app/dashboard/domains/new/page.tsx
@@ -13,8 +13,7 @@
  *   2. Loading → POST /api/domains → server returns token + 3 instructions.
  *   3. Instructions → display TXT / well-known / <meta> options.
  *      "Verify now" button → POST /api/domains/<domain>/verify.
- *   4. Verified → show "✅ Verified" message + redirect to /dashboard/domains
- *      (issue #83 will build that route — for now it's a placeholder link).
+ *   4. Verified → show "✅ Verified" message + redirect to /dashboard/domains.
  *
  * Auth: requires a valid wb_session cookie (set by /sign-in flow). The API
  * returns 401 if missing — we surface that with a "Please sign in" link.
@@ -111,7 +110,7 @@ export default function DomainsNewPage() {
       const body = (await res.json()) as { verified: boolean; method?: string };
       if (body.verified) {
         setStage('verified');
-        // Redirect to dashboard list (placeholder — issue #83 will own this route).
+        // Redirect to dashboard list.
         setTimeout(() => router.push('/dashboard/domains'), 1500);
         return;
       }

--- a/apps/web/app/dashboard/studies/StudiesListView.tsx
+++ b/apps/web/app/dashboard/studies/StudiesListView.tsx
@@ -35,6 +35,7 @@ export interface StudyListRow {
   n_visits: number;
   urls: string[];
   visit_progress: { ok: number; failed: number; total: number };
+  report_public?: boolean;
 }
 
 export interface StudiesListResponse {
@@ -223,12 +224,19 @@ export function StudiesListView({
                       {s.n_visits}
                     </td>
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
-                      {s.status === 'ready' ? (
+                      {s.status === 'ready' && s.report_public ? (
                         <a
                           href={`/r/${s.id}`}
                           className="font-medium text-indigo-600 hover:underline"
                         >
                           View report
+                        </a>
+                      ) : s.status === 'ready' ? (
+                        <a
+                          href={`/dashboard/studies/${s.id}`}
+                          className="text-xs text-indigo-500 hover:underline"
+                        >
+                          Publish →
                         </a>
                       ) : (
                         <span className="text-xs text-gray-400">—</span>

--- a/apps/web/app/dashboard/studies/[id]/page.tsx
+++ b/apps/web/app/dashboard/studies/[id]/page.tsx
@@ -12,7 +12,7 @@
  * (ready | failed).
  *
  * When ready → links to /r/:slug (report viz, PR #44).
- * When failed → shows error message + retry CTA (placeholder for Sprint 3).
+ * When failed → shows error message + retry CTA (pre-populates the URL in the create form).
  *
  * Note: Next.js 14 App Router passes `params` as a Promise in newer builds.
  * We unwrap it safely via useEffect on mount for client-component compat.

--- a/apps/web/app/dashboard/studies/[id]/page.tsx
+++ b/apps/web/app/dashboard/studies/[id]/page.tsx
@@ -183,10 +183,30 @@ function StudyStatusInner({ id }: { id: string }) {
   const isTerminal = TERMINAL.includes(status);
   const progress = s.visit_progress;
 
+  // Build retry URL pre-populated with the study's URL(s).
+  const studyUrls = s.urls ?? [];
+  const retryParams = new URLSearchParams();
+  if (studyUrls[0]) retryParams.set('urlA', studyUrls[0]);
+  if (studyUrls[1]) retryParams.set('urlB', studyUrls[1]);
+  const retryHref = studyUrls.length > 0
+    ? `/dashboard/studies/new?${retryParams.toString()}`
+    : '/dashboard/studies/new';
+
   return (
     <main className="mx-auto max-w-2xl px-6 py-16">
       {/* Study ID header */}
       <h1 className="text-3xl font-bold tracking-tight">Study #{s.id}</h1>
+
+      {/* URL(s) under test */}
+      {studyUrls.length > 0 && (
+        <ul className="mt-2 space-y-0.5">
+          {studyUrls.map((u) => (
+            <li key={u} className="truncate font-mono text-xs text-gray-500">
+              {u}
+            </li>
+          ))}
+        </ul>
+      )}
 
       {/* Status badge */}
       <div className="mt-4 flex items-center gap-2">
@@ -210,11 +230,6 @@ function StudyStatusInner({ id }: { id: string }) {
           <p className="text-sm font-medium text-green-800">
             Your study is ready! View the report to see results.
           </p>
-          {/* Issue #74 MINOR-2: GET /studies/:id returns the study's slug
-              field (per PR #102 dashboard-summary endpoint pattern). Use it
-              when available; fall back to /r/${s.id} (matches the bare-id
-              shape used by /dashboard/studies/StudiesListView). The previous
-              fallback (/r/study-${s.id}) would 404. */}
           <a
             href={s.slug ? `/r/${s.slug}` : `/r/${s.id}`}
             className="mt-3 inline-block rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
@@ -232,9 +247,8 @@ function StudyStatusInner({ id }: { id: string }) {
             This study failed. This can happen if the page was unreachable or
             the domain was blocked.
           </p>
-          {/* Retry is a Sprint 3 feature; placeholder link */}
           <a
-            href="/dashboard/studies/new"
+            href={retryHref}
             className="mt-3 inline-block rounded-md bg-gray-100 px-4 py-2 text-sm font-semibold text-gray-700 hover:bg-gray-200"
           >
             Try again with a new study

--- a/apps/web/app/dashboard/studies/[id]/page.tsx
+++ b/apps/web/app/dashboard/studies/[id]/page.tsx
@@ -228,14 +228,18 @@ function StudyStatusInner({ id }: { id: string }) {
       {status === 'ready' && (
         <div className="mt-8 rounded-lg border border-green-200 bg-green-50 px-5 py-4">
           <p className="text-sm font-medium text-green-800">
-            Your study is ready! View the report to see results.
+            Your study is ready!
+            {s.report_public ? ' View or share the public report.' : ' Publish the report to view and share it.'}
           </p>
-          <a
-            href={s.slug ? `/r/${s.slug}` : `/r/${s.id}`}
-            className="mt-3 inline-block rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
-          >
-            View report
-          </a>
+          {/* Only show the link once the report is public — private reports return 404 on /r/:slug */}
+          {s.report_public && (
+            <a
+              href={s.slug ? `/r/${s.slug}` : `/r/${s.id}`}
+              className="mt-3 inline-block rounded-md bg-indigo-600 px-4 py-2 text-sm font-semibold text-white hover:bg-indigo-500"
+            >
+              View report
+            </a>
+          )}
           <PublishButton studyId={s.id} reportSlug={s.slug ?? String(s.id)} initialPublished={s.report_public ?? false} />
         </div>
       )}

--- a/apps/web/app/dashboard/studies/new/page.tsx
+++ b/apps/web/app/dashboard/studies/new/page.tsx
@@ -10,7 +10,7 @@
  *   §3     — Mira, Kenji, Dana, dogfood user stories.
  *   §5.10  — CSP: no dangerouslySetInnerHTML; all text escaped by React.
  *
- * Auth: Sprint 3. For v0.1 the api-client reads NEXT_PUBLIC_DEV_API_KEY.
+ * Auth: session-cookie auth via POST /api/studies (no API key needed in browser).
  *
  * On success → router.push(/dashboard/studies/:id).
  * On 401     → router.push(/dashboard/sign-in) (placeholder).

--- a/apps/web/app/dashboard/studies/new/page.tsx
+++ b/apps/web/app/dashboard/studies/new/page.tsx
@@ -19,7 +19,7 @@
  */
 
 import React from 'react';
-import { useState, type FormEvent } from 'react';
+import { useState, useEffect, type FormEvent } from 'react';
 import { useRouter } from 'next/navigation';
 import { createStudy, ICP_PRESETS, type IcpPresetId } from '../../../../lib/api-client';
 
@@ -39,6 +39,15 @@ export default function StudyNewPage() {
   const [urlA, setUrlA] = useState('');
   const [urlB, setUrlB] = useState('');
   const [isPaired, setIsPaired] = useState(false);
+
+  // Pre-populate from ?urlA=&urlB= (passed by the retry link on the study status page).
+  useEffect(() => {
+    const params = new URLSearchParams(window.location.search);
+    const a = params.get('urlA');
+    const b = params.get('urlB');
+    if (a) setUrlA(a);
+    if (b) { setUrlB(b); setIsPaired(true); }
+  }, []);
   const [icpId, setIcpId] = useState<IcpPresetId>('saas_founder_pre_pmf');
   const [nVisits, setNVisits] = useState(30);
 

--- a/apps/web/app/not-found.tsx
+++ b/apps/web/app/not-found.tsx
@@ -1,0 +1,25 @@
+export default function NotFound() {
+  return (
+    <main className="mx-auto max-w-2xl px-6 py-24 text-center">
+      <p className="text-sm font-medium uppercase tracking-wide text-gray-400">404</p>
+      <h1 className="mt-2 text-3xl font-bold tracking-tight text-gray-900">Page not found</h1>
+      <p className="mt-4 text-gray-600">
+        The page you were looking for doesn&apos;t exist or has been moved.
+      </p>
+      <div className="mt-8 flex flex-wrap justify-center gap-4">
+        <a
+          href="/"
+          className="rounded-md bg-indigo-600 px-5 py-2.5 text-sm font-semibold text-white shadow-sm hover:bg-indigo-500 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-indigo-600"
+        >
+          Go home
+        </a>
+        <a
+          href="/dashboard"
+          className="rounded-md border border-gray-300 px-5 py-2.5 text-sm font-medium text-gray-700 hover:bg-gray-50"
+        >
+          Dashboard
+        </a>
+      </div>
+    </main>
+  );
+}

--- a/apps/web/app/pricing/PricingCta.tsx
+++ b/apps/web/app/pricing/PricingCta.tsx
@@ -16,9 +16,10 @@ export function PricingCta({ packId, label, usd, isAuthenticated }: PricingCtaPr
   if (isAuthenticated) {
     return <BuyButton packId={packId} label={label} usd={usd} />;
   }
+  const redirectPath = encodeURIComponent(`/pricing?pack=${packId}`);
   return (
     <a
-      href={`/sign-in?redirect=/pricing&pack=${packId}`}
+      href={`/sign-in?redirect=${redirectPath}`}
       aria-label={`Buy ${label} pack — $${usd}`}
       className="mt-4 inline-block w-full rounded-md bg-blue-600 px-5 py-2.5 text-center text-sm font-medium text-white hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-blue-500 focus:ring-offset-2"
     >

--- a/apps/web/app/r/[slug]/fetchReport.ts
+++ b/apps/web/app/r/[slug]/fetchReport.ts
@@ -14,7 +14,8 @@ import fixture from '../../../test/fixtures/report.fixture.json';
 const FIXTURE_SLUG = 'test-fixture';
 
 export type ReportPayload = { reportJson: unknown; urls: string[] | null };
-export type FetchReportResult = 'not_found' | 'pending' | ReportPayload;
+export type PendingReport = { status: 'pending'; studyId: number | null };
+export type FetchReportResult = 'not_found' | PendingReport | ReportPayload;
 
 function apiBaseUrl(): string {
   const explicit = process.env['WILLBUY_API_URL'] ?? process.env['NEXT_PUBLIC_API_URL'];
@@ -54,7 +55,10 @@ export async function fetchReport(slug: string): Promise<FetchReportResult> {
 
   const body = (await res.json()) as Record<string, unknown>;
   const reportJson = body['report_json'];
-  if (reportJson === null || reportJson === undefined) return 'pending';
+  if (reportJson === null || reportJson === undefined) {
+    const studyId = typeof body['study_id'] === 'number' ? body['study_id'] : null;
+    return { status: 'pending', studyId };
+  }
   const urls = Array.isArray(body['urls']) ? (body['urls'] as string[]) : null;
   return { reportJson, urls };
 }

--- a/apps/web/app/r/[slug]/page.tsx
+++ b/apps/web/app/r/[slug]/page.tsx
@@ -35,14 +35,25 @@ export default async function ReportPage({
     );
   }
 
-  if (result === 'pending') {
+  if ('status' in result) {
+    // result is PendingReport — report_json not yet populated by aggregator
     return (
       <>
         <main className="mx-auto max-w-3xl px-6 py-16">
           <h1 className="text-3xl font-bold tracking-tight">Report is being prepared</h1>
           <p className="mt-6 text-gray-700">
-            The analysis for <code>{slug}</code> is still running. Refresh in a moment.
+            The analysis for <code>{slug}</code> is still running.
           </p>
+          {result.studyId !== null ? (
+            <a
+              href={`/dashboard/studies/${result.studyId}`}
+              className="mt-4 inline-block text-sm font-medium text-indigo-600 hover:text-indigo-500"
+            >
+              Track progress on the study status page →
+            </a>
+          ) : (
+            <p className="mt-2 text-sm text-gray-500">Refresh in a moment.</p>
+          )}
         </main>
         <ReportCtaBar />
       </>

--- a/apps/web/components/report/HeadlineDelta.tsx
+++ b/apps/web/components/report/HeadlineDelta.tsx
@@ -31,6 +31,21 @@ const VERDICT_COPY: Record<ReportT['headline']['verdict'], string> = {
 export function HeadlineDelta({ headline }: { headline: ReportT['headline'] }) {
   const { mean_delta, ci95_low, ci95_high, n_paired, paired_t_p, wilcoxon_p, mcnemar_p, verdict } =
     headline;
+
+  // Single-URL studies have no paired comparison — show a minimal summary instead.
+  if (n_paired === 0) {
+    return (
+      <section
+        data-testid="headline-delta"
+        className="rounded-lg border border-gray-200 bg-white p-6 shadow-sm"
+      >
+        <p className="text-sm text-gray-500">
+          Single-URL study — see visitor responses and theme analysis below.
+        </p>
+      </section>
+    );
+  }
+
   return (
     <section
       data-testid="headline-delta"

--- a/apps/web/components/report/PairedDots.tsx
+++ b/apps/web/components/report/PairedDots.tsx
@@ -88,6 +88,9 @@ export function PairedDots({ rows }: { rows: ReportT['paired_dots'] }) {
   const [active, setActive] = useState<string | null>(null);
   const data = buildData(rows);
 
+  // Single-URL studies have no paired visitors — nothing to plot.
+  if (data.length === 0) return null;
+
   const activeRow = rows.find((r) => r.backstory_id === active) ?? null;
 
   return (

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -70,6 +70,8 @@ const GetStudyResponseSchema = z.object({
   slug: z.string().optional(),
   // report_public present once study has a report row; true if already published.
   report_public: z.boolean().optional(),
+  // urls is the list of URLs under test (1 for single, 2 for paired A/B).
+  urls: z.array(z.string()).optional(),
 });
 export type GetStudyResponse = z.infer<typeof GetStudyResponseSchema>;
 

--- a/apps/web/test/pages.test.tsx
+++ b/apps/web/test/pages.test.tsx
@@ -1,4 +1,4 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { renderToStaticMarkup } from 'react-dom/server';
 import LandingPage from '../app/page';
 import ReportPage, { metadata as reportMetadata } from '../app/r/[slug]/page';
@@ -33,6 +33,25 @@ describe('public report — GET /r/[slug]', () => {
     expect(html).toMatch(/converts better/i);
     // Slug rendered as <code> per §5.10.
     expect(html).toMatch(/<code[^>]*>test-fixture<\/code>/);
+  });
+
+  it('renders a "pending" body with a study status link when report_json is null', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve({ study_id: 42, report_json: null, urls: null }),
+      }),
+    );
+    try {
+      const el = await ReportPage({ params: Promise.resolve({ slug: 'still-running' }) });
+      const html = renderToStaticMarkup(el);
+      expect(html).toMatch(/being prepared/i);
+      expect(html).toMatch(/dashboard\/studies\/42/);
+    } finally {
+      vi.unstubAllGlobals();
+    }
   });
 
   it('exports metadata with noindex (per SPEC §5.10 untrusted-content boundary)', () => {

--- a/apps/web/test/pricing.test.tsx
+++ b/apps/web/test/pricing.test.tsx
@@ -74,4 +74,14 @@ describe('/pricing page (issue #144)', () => {
     const html = await getHtml();
     expect(html).toMatch(/sign-in/i);
   });
+
+  it('unauthenticated: sign-in URLs encode the pack param inside the redirect', async () => {
+    const html = await getHtml();
+    // The ?pack=<id> must be encoded INSIDE the redirect param, not as a
+    // sibling param on the sign-in URL — otherwise it gets dropped after
+    // sign-in because the sign-in page only reads "redirect".
+    expect(html).toMatch(/sign-in\?redirect=%2Fpricing%3Fpack%3Dstarter/);
+    expect(html).toMatch(/sign-in\?redirect=%2Fpricing%3Fpack%3Dgrowth/);
+    expect(html).toMatch(/sign-in\?redirect=%2Fpricing%3Fpack%3Dscale/);
+  });
 });

--- a/apps/web/test/report-viz.test.tsx
+++ b/apps/web/test/report-viz.test.tsx
@@ -305,6 +305,17 @@ describe('§5.18 — report visualization', () => {
   });
 
 
+  it('§5.18 #4 v0.1.1 — next-actions Sankey toggle renders and switches view (#175)', () => {
+    // data-testid="next-actions-mode-toggle" must be present by default.
+    render(<NextActions rows={fixture.next_actions} />);
+    expect(screen.getByTestId('next-actions-mode-toggle')).toBeTruthy();
+    // Sankey view should not be visible initially (bar mode is default).
+    expect(screen.queryByTestId('next-actions-sankey')).toBeNull();
+    // Clicking "Sankey" button shows the Sankey view.
+    fireEvent.click(screen.getByRole('button', { name: /sankey/i }));
+    expect(screen.getByTestId('next-actions-sankey')).toBeTruthy();
+  });
+
   it('F1 — paired-dot plot renders one SVG <line> connector per backstory (§5.18 #2)', () => {
     // Spec §5.18 #2: "Per-visitor dots showing A-score vs B-score with a
     // thin connecting segment." The connector is the entire point of the

--- a/apps/web/test/report-viz.test.tsx
+++ b/apps/web/test/report-viz.test.tsx
@@ -272,6 +272,7 @@ describe('§5.18 — report visualization', () => {
     // schema was relaxed from .length(2) to .min(1).max(2) in PR #171.
     const singleVariant: ReportT = {
       ...fixture,
+      headline: { ...fixture.headline, n_paired: 0 },
       histograms: [fixture.histograms[0]!],
       next_actions: [fixture.next_actions[0]!],
       tier_picked: [fixture.tier_picked[0]!],
@@ -290,6 +291,12 @@ describe('§5.18 — report visualization', () => {
     const { container } = render(<ReportView report={parsed} mode="public" />);
     await act(async () => { await Promise.resolve(); });
     expect(container.querySelectorAll('[data-testid="persona-grid"]').length).toBe(1);
+    // Single-URL studies: HeadlineDelta shows informational message, not paired stats.
+    expect(container.querySelector('[data-testid="headline-delta"]')!.textContent).toMatch(
+      /single-url study/i,
+    );
+    // PairedDots returns null when empty — its section should not appear.
+    expect(container.querySelectorAll('[data-testid="paired-dots"]').length).toBe(0);
   });
 
 

--- a/apps/web/test/studies-list.test.tsx
+++ b/apps/web/test/studies-list.test.tsx
@@ -32,6 +32,7 @@ const FIXTURE_STUDIES = [
     n_visits: 30,
     urls: ['https://example.com/pricing'],
     visit_progress: { ok: 30, failed: 0, total: 30 },
+    report_public: true,
   },
   {
     id: 102,
@@ -111,18 +112,40 @@ describe('/dashboard/studies view (issue #85)', () => {
   });
 
   // -------------------------------------------------------------------------
-  // 4: Per-row "View report" link only when status=ready.
+  // 4: "View report" → /r/:id only when ready AND report_public=true.
+  //    "Publish" link → /dashboard/studies/:id when ready but not yet public.
   // -------------------------------------------------------------------------
-  it('renders "View report" → /r/:id only for status=ready rows', () => {
+  it('renders "View report" → /r/:id only when ready AND report_public=true', () => {
     const html = renderToStaticMarkup(
       <StudiesListView studies={FIXTURE_STUDIES} nextCursor={null} />,
     );
-    // Ready row (id=101) has a /r/101 link.
+    // Ready + public row (id=101) has a /r/101 link.
     expect(html).toMatch(/href="\/r\/101"/);
     // Capturing row (id=102) does NOT have /r/102.
     expect(html).not.toMatch(/href="\/r\/102"/);
     // Failed row (id=103) does NOT have /r/103 (failed studies have no report).
     expect(html).not.toMatch(/href="\/r\/103"/);
+  });
+
+  it('renders "Publish →" link for ready studies with report_public=false', () => {
+    const privateReadyStudy = {
+      id: 104,
+      status: 'ready' as const,
+      created_at: '2026-04-21T08:00:00.000Z',
+      finalized_at: '2026-04-21T08:30:00.000Z',
+      n_visits: 10,
+      urls: ['https://example.com/new'],
+      visit_progress: { ok: 10, failed: 0, total: 10 },
+      report_public: false,
+    };
+    const html = renderToStaticMarkup(
+      <StudiesListView studies={[privateReadyStudy]} nextCursor={null} />,
+    );
+    // No direct /r/ link (would 404).
+    expect(html).not.toMatch(/href="\/r\/104"/);
+    // Shows a "Publish" CTA pointing to the study status page.
+    expect(html).toMatch(/href="\/dashboard\/studies\/104"/);
+    expect(html).toMatch(/publish/i);
   });
 
   // -------------------------------------------------------------------------

--- a/apps/web/test/studies-new.test.ts
+++ b/apps/web/test/studies-new.test.ts
@@ -229,6 +229,7 @@ describe('StudyStatusPage — polling', () => {
             visit_progress: { ok: 30, failed: 0, total: 30 },
             started_at: new Date().toISOString(),
             finalized_at: new Date().toISOString(),
+            report_public: true,
           }),
           { status: 200, headers: { 'Content-Type': 'application/json' } },
         ),


### PR DESCRIPTION
## Summary

`POST /api/checkout/sessions` (session-cookie auth, added in PR #211) had no dedicated tests. The existing Stripe tests only covered the API-key route (`POST /checkout/sessions`).

Adds 2 tests:
- Valid `wb_session` cookie → 200 + Stripe stub URL
- No cookie → 401

## Test plan

- [x] All 151 API tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)