### PR TITLE
test(web): pricing page authenticated-state coverage

### DIFF
--- a/apps/web/test/pricing.test.tsx
+++ b/apps/web/test/pricing.test.tsx
@@ -74,4 +74,17 @@ describe('/pricing page (issue #144)', () => {
     const html = await getHtml();
     expect(html).toMatch(/sign-in/i);
   });
+
+  it('authenticated: renders "Buy →" button (not sign-in redirect) when session cookie present', async () => {
+    // Override the mock to simulate an authenticated user.
+    const { cookies } = await import('next/headers');
+    (cookies as ReturnType<typeof vi.fn>).mockResolvedValueOnce({ has: () => true });
+    const html = await getHtml();
+    // BuyButton renders a <button> with "Buy →" text.
+    expect(html).toMatch(/Buy →/);
+    // The sign-in redirect link for unauthenticated users should NOT appear as the CTA.
+    // (The secondary "Already have credits? Sign in" link still appears — that's correct.)
+    // Assert no href pointing to /sign-in?redirect=/pricing which is the unauthenticated CTA.
+    expect(html).not.toMatch(/href="\/sign-in\?redirect=\/pricing/);
+  });
 });


### PR DESCRIPTION
## Summary

The pricing page is auth-aware: signed-in users see `BuyButton` (direct Stripe checkout) instead of the sign-in redirect CTA. Only the unauthenticated state was tested.

Adds one test that overrides the `next/headers` mock to simulate a session cookie present (`has: () => true`) and asserts:
- `BuyButton` renders ("Buy →" text visible)
- No `/sign-in?redirect=/pricing` href is emitted (the unauthenticated CTA)

## Test plan

- [x] New test passes (`bun run test --run test/pricing.test.tsx`)
- [x] All 11 pricing tests pass (was 10)

🤖 Generated with [Claude Code](https://claude.com/claude-code)