### PR TITLE
test(web): ContextBanner component coverage

### DIFF
--- a/apps/web/test/context-banner.test.tsx
+++ b/apps/web/test/context-banner.test.tsx
@@ -1,0 +1,50 @@
+// @vitest-environment jsdom
+//
+// Tests for ContextBanner — three rendering states:
+//   1. Empty urls array → renders nothing
+//   2. Single URL → "Page tested: <url>" with link
+//   3. Paired A/B URLs → "A: <url-a> vs B: <url-b>" with both links
+
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+import { ContextBanner } from '../components/report/ContextBanner';
+
+describe('ContextBanner', () => {
+  it('renders nothing for empty urls array', () => {
+    const html = renderToStaticMarkup(<ContextBanner urls={[]} />);
+    expect(html).toBe('');
+  });
+
+  it('single URL: renders "Page tested" label and link to the URL', () => {
+    const url = 'https://example.com/pricing';
+    const html = renderToStaticMarkup(<ContextBanner urls={[url]} />);
+    expect(html).toMatch(/page tested/i);
+    expect(html).toContain(`href="${url}"`);
+    expect(html).toContain(url);
+    // Must NOT render "vs" or A/B labels.
+    expect(html).not.toMatch(/\bvs\b/i);
+    expect(html).not.toMatch(/font-semibold.*A:/);
+  });
+
+  it('paired URLs: renders A label, B label, "vs" separator, and both links', () => {
+    const urlA = 'https://example.com/pricing-v1';
+    const urlB = 'https://example.com/pricing-v2';
+    const html = renderToStaticMarkup(<ContextBanner urls={[urlA, urlB]} />);
+    // Both URLs must appear as link hrefs.
+    expect(html).toContain(`href="${urlA}"`);
+    expect(html).toContain(`href="${urlB}"`);
+    // A and B labels.
+    expect(html).toMatch(/A:/);
+    expect(html).toMatch(/B:/);
+    // Separator.
+    expect(html).toMatch(/vs/i);
+  });
+
+  it('links use target=_blank + rel=noopener noreferrer', () => {
+    const url = 'https://example.com/page';
+    const html = renderToStaticMarkup(<ContextBanner urls={[url]} />);
+    expect(html).toContain('target="_blank"');
+    expect(html).toContain('rel="noopener noreferrer"');
+  });
+});


### PR DESCRIPTION
## Summary

`ContextBanner` (displays which URL(s) were tested above the public report on `/r/:slug`) had no tests despite having three distinct rendering states.

Adds 4 tests:
- Empty `urls` array → renders nothing (`''`)
- Single URL → "Page tested:" label + link to the URL
- Paired A/B → both links, "A:" / "B:" labels, and "vs" separator
- Links carry `target="_blank"` + `rel="noopener noreferrer"`

## Test plan

- [x] 4 new tests pass (`bun run test --run test/context-banner.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)