### PR TITLE
test(api): SESSION_HMAC_KEY + SHARE_TOKEN_HMAC_KEY env validation

### DIFF
--- a/apps/api/test/env.test.ts
+++ b/apps/api/test/env.test.ts
@@ -44,4 +44,26 @@ describe('env validation (spec §4.1, CLAUDE.md zod-at-boundaries)', () => {
     const parsed = parseEnv({ ...BASE_ENV, DAILY_CAP_CENTS: '5000' });
     expect(parsed.DAILY_CAP_CENTS).toBe(5000);
   });
+
+  it('throws when SESSION_HMAC_KEY is shorter than 32 chars', () => {
+    expect(() =>
+      parseEnv({ ...BASE_ENV, SESSION_HMAC_KEY: 'too-short' }),
+    ).toThrow(/SESSION_HMAC_KEY/);
+  });
+
+  it('throws when SHARE_TOKEN_HMAC_KEY is shorter than 32 chars', () => {
+    expect(() =>
+      parseEnv({ ...BASE_ENV, SHARE_TOKEN_HMAC_KEY: 'too-short' }),
+    ).toThrow(/SHARE_TOKEN_HMAC_KEY/);
+  });
+
+  it('accepts 32-char SESSION_HMAC_KEY and SHARE_TOKEN_HMAC_KEY', () => {
+    const parsed = parseEnv({
+      ...BASE_ENV,
+      SESSION_HMAC_KEY: 'a'.repeat(32),
+      SHARE_TOKEN_HMAC_KEY: 'b'.repeat(32),
+    });
+    expect(parsed.SESSION_HMAC_KEY).toBe('a'.repeat(32));
+    expect(parsed.SHARE_TOKEN_HMAC_KEY).toBe('b'.repeat(32));
+  });
 });


### PR DESCRIPTION
## Summary

Both `SESSION_HMAC_KEY` and `SHARE_TOKEN_HMAC_KEY` have a 32-character minimum enforced by Zod at startup, but neither was exercised in `env.test.ts`. A misconfiguration (e.g., short key in `.env.local`) would fail at runtime with a cryptic Zod error rather than being caught at test time.

Adds 3 tests:
- Short `SESSION_HMAC_KEY` → throws with message matching `/SESSION_HMAC_KEY/`
- Short `SHARE_TOKEN_HMAC_KEY` → throws with message matching `/SHARE_TOKEN_HMAC_KEY/`
- Valid 32-char values for both → accepted and passed through

## Test plan

- [x] 3 new tests pass (`bun run test --run test/env.test.ts`)
- [x] All 10 env tests pass (was 7)

🤖 Generated with [Claude Code](https://claude.com/claude-code)