### PR TITLE
test(api): constantTimeEquals() unit tests

### DIFF
--- a/apps/api/test/metrics-utils.test.ts
+++ b/apps/api/test/metrics-utils.test.ts
@@ -1,0 +1,62 @@
+/**
+ * metrics-utils.test.ts — unit tests for constantTimeEquals() from metrics/registry.ts.
+ *
+ * constantTimeEquals() is the timing-safe string comparator used to gate
+ * the /metrics endpoint behind a bearer token. It's security-critical and
+ * had no dedicated tests — it was only reachable through the full server
+ * integration test which uses Fastify inject (not suitable for timing analysis).
+ *
+ * The correctness invariants we test here:
+ *   - Equal strings → true
+ *   - Unequal strings → false
+ *   - Different lengths → false (short-circuit before the loop)
+ *   - Empty strings → true (vacuously equal)
+ *   - One empty, one non-empty → false
+ *   - Strings that differ only at one position → false
+ */
+
+import { describe, expect, it } from 'vitest';
+import { constantTimeEquals } from '../src/metrics/registry.js';
+
+describe('constantTimeEquals()', () => {
+  it('returns true for identical non-empty strings', () => {
+    expect(constantTimeEquals('abc', 'abc')).toBe(true);
+  });
+
+  it('returns false for strings that differ in content', () => {
+    expect(constantTimeEquals('abc', 'abd')).toBe(false);
+  });
+
+  it('returns false when strings have different lengths', () => {
+    expect(constantTimeEquals('abc', 'abcd')).toBe(false);
+    expect(constantTimeEquals('abcd', 'abc')).toBe(false);
+  });
+
+  it('returns true for two empty strings', () => {
+    expect(constantTimeEquals('', '')).toBe(true);
+  });
+
+  it('returns false for one empty and one non-empty string', () => {
+    expect(constantTimeEquals('', 'a')).toBe(false);
+    expect(constantTimeEquals('a', '')).toBe(false);
+  });
+
+  it('returns false when strings differ only at the last character', () => {
+    expect(constantTimeEquals('abcx', 'abcy')).toBe(false);
+  });
+
+  it('returns false when strings differ only at the first character', () => {
+    expect(constantTimeEquals('xbc', 'ybc')).toBe(false);
+  });
+
+  it('handles long strings that are identical', () => {
+    const s = 'A'.repeat(256);
+    expect(constantTimeEquals(s, s)).toBe(true);
+  });
+
+  it('handles long strings that differ at one byte', () => {
+    const a = 'A'.repeat(256);
+    const b = 'A'.repeat(255) + 'B';
+    expect(constantTimeEquals(a, b)).toBe(false);
+  });
+});


### PR DESCRIPTION
## Summary

`constantTimeEquals()` is the timing-safe string comparator used to gate the `/metrics` endpoint (compares bearer tokens without short-circuiting on mismatch). It's security-critical but had no direct unit tests — only reachable indirectly through the Fastify integration suite.

Adds 9 unit tests:
- Equal non-empty strings → `true`
- Unequal strings (same length) → `false`
- Different lengths → `false` (both orderings)
- Two empty strings → `true`
- One empty, one non-empty → `false`
- Differ at last character only → `false`
- Differ at first character only → `false`
- Long identical strings (256 chars) → `true`
- Long strings differing at one byte → `false`

## Test plan

- [x] 9 new tests pass (`bun run test --run test/metrics-utils.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)