### PR TITLE
test(shared): Backstory schema coverage

### DIFF
--- a/packages/shared/test/backstory.test.ts
+++ b/packages/shared/test/backstory.test.ts
@@ -19,4 +19,31 @@ describe('Backstory (spec §2 #5 + personas/backstories.md)', () => {
     const bad = { ...validFixture, managed_postgres: 'mongodb' };
     expect(() => Backstory.parse(bad)).toThrow();
   });
+
+  it('rejects an invalid TeamSize (must be 2, 6, 12, or 20)', () => {
+    const bad = { ...validFixture, team_size: 5 };
+    expect(Backstory.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects an empty name', () => {
+    const bad = { ...validFixture, name: '' };
+    expect(Backstory.safeParse(bad).success).toBe(false);
+  });
+
+  it('rejects a missing required field', () => {
+    const { role_archetype: _omit, ...incomplete } = validFixture as Record<string, unknown>;
+    expect(Backstory.safeParse(incomplete).success).toBe(false);
+  });
+
+  it('rejects an extra unknown field (.strict())', () => {
+    const bad = { ...validFixture, unknown_field: 'unexpected' };
+    expect(Backstory.safeParse(bad).success).toBe(false);
+  });
+
+  it('accepts all four valid TeamSize values (2, 6, 12, 20)', () => {
+    for (const size of [2, 6, 12, 20]) {
+      const ok = { ...validFixture, team_size: size };
+      expect(Backstory.safeParse(ok).success, `team_size=${size} should be valid`).toBe(true);
+    }
+  });
 });


### PR DESCRIPTION
## Summary

`Backstory` (the spec §2 #5 persona schema) had only 2 tests covering the happy path and one bad enum. The `.strict()` constraint, `TeamSize` union, required fields, and name validation were untested.

Adds 5 tests:
- Invalid `TeamSize` (5 is not 2/6/12/20) → rejected
- Empty `name` (`min(1)`) → rejected
- Missing `role_archetype` → rejected
- Extra unknown field → rejected by `.strict()`
- All four valid `TeamSize` values (2, 6, 12, 20) accepted

## Test plan

- [x] All 7 backstory tests pass (`bun run test --run test/backstory.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)