### PR TITLE
test(shared): VisitorOutput tier fields and passthrough

### DIFF
--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -56,4 +56,28 @@ describe('VisitorOutput (spec §2 #15)', () => {
     const bad = { ...validFixture, reasoning: 'r'.repeat(1201) };
     expect(() => VisitorOutput.parse(bad)).toThrow();
   });
+
+  it('tier fields default to "none" when absent (issue #173 passthrough compat)', () => {
+    const withoutTiers: Record<string, unknown> = { ...validFixture };
+    delete withoutTiers['tier_picked_if_buying_today'];
+    delete withoutTiers['highest_tier_willing_to_consider'];
+    const parsed = VisitorOutput.parse(withoutTiers);
+    expect(parsed.tier_picked_if_buying_today).toBe('none');
+    expect(parsed.highest_tier_willing_to_consider).toBe('none');
+  });
+
+  it('rejects an invalid tier_picked_if_buying_today value', () => {
+    const bad = { ...validFixture, tier_picked_if_buying_today: 'premium' };
+    expect(VisitorOutput.safeParse(bad).success).toBe(false);
+  });
+
+  it('.passthrough() allows extra unknown fields (old rows stay valid)', () => {
+    const withExtra = { ...validFixture, legacy_field: 'some_old_value', v0_flag: true };
+    const result = VisitorOutput.safeParse(withExtra);
+    expect(result.success).toBe(true);
+    if (result.success) {
+      // passthrough preserves unknown fields in the output
+      expect((result.data as Record<string, unknown>)['legacy_field']).toBe('some_old_value');
+    }
+  });
 });


### PR DESCRIPTION
## Summary

Issue #173 added `tier_picked_if_buying_today` and `highest_tier_willing_to_consider` fields with `.default('none')` and `.passthrough()` for backward compatibility with existing rows. None of these behaviors were tested.

Adds 3 tests:
- Tier fields **default to `'none'` when absent** (old rows without the field stay valid)
- Invalid `tier_picked_if_buying_today` value (e.g. `'premium'`) → rejected
- `.passthrough()` **preserves unknown fields** in parsed output (critical for not breaking old rows)

## Test plan

- [x] All 11 visitor tests pass (`bun run test --run test/visitor.test.ts`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)