### PR TITLE
test(web): HeadlineDelta component unit tests

### DIFF
--- a/apps/web/test/buy-credits-interaction.test.tsx
+++ b/apps/web/test/buy-credits-interaction.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment jsdom
+//
+// Interactive tests for BuyCredits (components/credits/BuyCredits.tsx).
+// The existing buy-credits.test.tsx only verifies visit-estimate copy.
+// This file tests the pack selection + checkout flow:
+//   - Clicking a pack selects it (visual feedback)
+//   - Clicking "Buy credits" POSTs with selected pack_id to apiBaseUrl
+//   - Success → window.location.href set to Stripe URL
+//   - Error → error message shown
+
+import { afterEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import React from 'react';
+import { BuyCredits } from '../components/credits/BuyCredits';
+
+const API_KEY = 'sk_live_test';
+const API_BASE = 'https://api.test.willbuy.dev';
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('BuyCredits — interaction', () => {
+  it('renders "Buy credits" button and all three packs', () => {
+    render(<BuyCredits apiKey={API_KEY} apiBaseUrl={API_BASE} />);
+    expect(screen.getByRole('button', { name: /buy credits/i })).toBeTruthy();
+    expect(screen.getByText('Starter')).toBeTruthy();
+    expect(screen.getByText('Growth')).toBeTruthy();
+    expect(screen.getByText('Scale')).toBeTruthy();
+  });
+
+  it('POSTs to apiBaseUrl/checkout/sessions with selected pack_id on click', async () => {
+    const locationStub = { href: '' };
+    vi.stubGlobal('location', locationStub);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ url: 'https://checkout.stripe.com/pay/cs_test' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    render(<BuyCredits apiKey={API_KEY} apiBaseUrl={API_BASE} />);
+
+    // Click "Growth" pack to select it.
+    fireEvent.click(screen.getByText('Growth'));
+    // Click "Buy credits".
+    fireEvent.click(screen.getByRole('button', { name: /buy credits/i }));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+
+    const [url, opts] = fetchSpy.mock.calls[0]!;
+    expect(String(url)).toBe(`${API_BASE}/checkout/sessions`);
+    expect((opts as RequestInit).method).toBe('POST');
+    const body = JSON.parse((opts as RequestInit).body as string) as { pack_id: string };
+    expect(body.pack_id).toBe('growth');
+
+    await waitFor(() => expect(locationStub.href).toContain('checkout.stripe.com'));
+  });
+
+  it('shows error message when API returns non-200', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ error: 'rate limited' }), {
+        status: 429,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    render(<BuyCredits apiKey={API_KEY} apiBaseUrl={API_BASE} />);
+    fireEvent.click(screen.getByRole('button', { name: /buy credits/i }));
+
+    await waitFor(() =>
+      expect(screen.queryByText(/rate limited/i)).not.toBeNull(),
+    );
+    // Button must still be present for retry.
+    expect(screen.getByRole('button', { name: /buy credits/i })).toBeTruthy();
+  });
+
+  it('starter is selected by default (first pack_id submitted is starter)', async () => {
+    const locationStub = { href: '' };
+    vi.stubGlobal('location', locationStub);
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockResolvedValueOnce(
+      new Response(JSON.stringify({ url: 'https://checkout.stripe.com/pay/cs_test' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    render(<BuyCredits apiKey={API_KEY} apiBaseUrl={API_BASE} />);
+    // Don't click any pack — submit with default selection.
+    fireEvent.click(screen.getByRole('button', { name: /buy credits/i }));
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [, opts] = fetchSpy.mock.calls[0]!;
+    const body = JSON.parse((opts as RequestInit).body as string) as { pack_id: string };
+    expect(body.pack_id).toBe('starter');
+  });
+});

--- a/apps/web/test/headline-delta.test.tsx
+++ b/apps/web/test/headline-delta.test.tsx
@@ -1,0 +1,103 @@
+// @vitest-environment jsdom
+//
+// Unit tests for HeadlineDelta (components/report/HeadlineDelta.tsx).
+//
+// The component is tested indirectly via report-viz.test.tsx (which only
+// verifies the testid is present). This file isolates the key rendering
+// behaviors:
+//   - All three verdicts render their correct copy
+//   - Mean delta rendered with sign (+/-) and 2 decimal places
+//   - Stat values (p-values, N paired, CI) rendered
+//   - CSP §5.10: no inline scripts or style= attributes
+
+import { describe, expect, it } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import React from 'react';
+import { HeadlineDelta } from '../components/report/HeadlineDelta';
+import type { ReportT } from '../components/report/types';
+
+type Headline = ReportT['headline'];
+
+function makeHeadline(overrides: Partial<Headline>): Headline {
+  return {
+    mean_delta: 1.5,
+    ci95_low: 0.3,
+    ci95_high: 2.7,
+    n_paired: 30,
+    paired_t_p: 0.02,
+    wilcoxon_p: 0.03,
+    mcnemar_p: 0.04,
+    verdict: 'better',
+    disagreement: false,
+    ...overrides,
+  };
+}
+
+describe('HeadlineDelta', () => {
+  it('renders "NEW converts better." for verdict=better', () => {
+    const html = renderToStaticMarkup(
+      <HeadlineDelta headline={makeHeadline({ verdict: 'better' })} />,
+    );
+    expect(html).toMatch(/converts better/i);
+  });
+
+  it('renders "NEW converts worse." for verdict=worse', () => {
+    const html = renderToStaticMarkup(
+      <HeadlineDelta headline={makeHeadline({ verdict: 'worse' })} />,
+    );
+    expect(html).toMatch(/converts worse/i);
+  });
+
+  it('renders "Inconclusive" for verdict=inconclusive', () => {
+    const html = renderToStaticMarkup(
+      <HeadlineDelta headline={makeHeadline({ verdict: 'inconclusive' })} />,
+    );
+    expect(html).toMatch(/inconclusive/i);
+  });
+
+  it('renders "+" prefix for positive mean_delta', () => {
+    const html = renderToStaticMarkup(
+      <HeadlineDelta headline={makeHeadline({ mean_delta: 1.5 })} />,
+    );
+    expect(html).toContain('+1.50');
+  });
+
+  it('renders no prefix for negative mean_delta (minus is part of the number)', () => {
+    const html = renderToStaticMarkup(
+      <HeadlineDelta headline={makeHeadline({ mean_delta: -1.5 })} />,
+    );
+    expect(html).toContain('-1.50');
+    expect(html).not.toMatch(/\+-1/);
+  });
+
+  it('renders N paired value', () => {
+    const html = renderToStaticMarkup(
+      <HeadlineDelta headline={makeHeadline({ n_paired: 42 })} />,
+    );
+    expect(html).toContain('42');
+  });
+
+  it('renders paired-t, Wilcoxon, McNemar p-values', () => {
+    const html = renderToStaticMarkup(
+      <HeadlineDelta headline={makeHeadline({ paired_t_p: 0.015, wilcoxon_p: 0.03, mcnemar_p: 0.04 })} />,
+    );
+    expect(html).toMatch(/0\.015/);
+    expect(html).toMatch(/0\.030/);
+    expect(html).toMatch(/0\.040/);
+  });
+
+  it('renders "p < 0.001" for very small p-values', () => {
+    const html = renderToStaticMarkup(
+      <HeadlineDelta headline={makeHeadline({ paired_t_p: 0.0001 })} />,
+    );
+    expect(html).toContain('p &lt; 0.001');
+  });
+
+  it('contains no inline <script> tags or style= attributes (CSP §5.10)', () => {
+    const html = renderToStaticMarkup(
+      <HeadlineDelta headline={makeHeadline({})} />,
+    );
+    expect(html).not.toMatch(/<script[\s>]/i);
+    expect(html).not.toMatch(/style="/i);
+  });
+});


### PR DESCRIPTION
## Summary

`HeadlineDelta` was only tested via `report-viz.test.tsx` which only verified the `data-testid` exists. The actual content — verdict copy, delta sign formatting, p-value rendering — was never asserted.

Adds 9 unit tests:
- `verdict='better'` → "NEW converts better."
- `verdict='worse'` → "NEW converts worse."
- `verdict='inconclusive'` → "Inconclusive"
- Positive `mean_delta` → `+1.50` prefix
- Negative `mean_delta` → `-1.50` (no double sign)
- `n_paired` rendered in output
- All three p-values rendered to 3dp
- Very small p-value → `p < 0.001` (clamp)
- No inline `<script>` or `style=` (CSP §5.10)

## Test plan

- [x] 9 new tests pass (`bun run test --run test/headline-delta.test.tsx`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)