### PR TITLE
fix(api)+test: remove non-existent r.slug from /api/studies/:id; session-auth integration tests

### DIFF
--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -366,11 +366,10 @@ export async function registerStudiesRoutes(
         status: string;
         created_at: Date;
         finalized_at: Date | null;
-        slug: string | null;
         report_public: boolean | null;
       }>(
         `SELECT s.id, s.account_id, s.status, s.created_at, s.finalized_at,
-                r.slug, r.public AS report_public
+                r."public" AS report_public
            FROM studies s
            LEFT JOIN reports r ON r.study_id = s.id
           WHERE s.id = $1`,

--- a/apps/api/test/studies-list.test.ts
+++ b/apps/api/test/studies-list.test.ts
@@ -368,3 +368,93 @@ describeIfDocker('GET /api/studies (issue #85, real DB)', () => {
     expect(res.statusCode).toBe(400);
   });
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// GET /api/studies/:id (issue #209) — session-cookie auth single-study endpoint
+// ─────────────────────────────────────────────────────────────────────────────
+describeIfDocker('GET /api/studies/:id (session-cookie auth, issue #209)', () => {
+  let container = '';
+  let dbUrl = '';
+  let app: FastifyInstance;
+  let studyAccount = '';
+  let studyAccountEmail = '';
+  let otherAccount = '';
+  let otherAccountEmail = '';
+  let studyId = '';
+
+  beforeAll(async () => {
+    const pg = await startPostgres({ containerPrefix: 'willbuy-studies-id-test-' });
+    container = pg.container;
+    dbUrl = pg.url;
+
+    await applyMigrations(dbUrl);
+    app = await buildServer({
+      // Use port 0 to avoid conflicting with the list test (PORT 3098).
+      env: { ...BASE_ENV, PORT: 0, DATABASE_URL: dbUrl },
+      resend: buildStubResend(),
+    });
+
+    studyAccountEmail = 'studies-id-owner@example.com';
+    otherAccountEmail = 'studies-id-other@example.com';
+    const db = new Client({ connectionString: dbUrl });
+    await db.connect();
+    try {
+      const a = await db.query<{ id: string }>(
+        `INSERT INTO accounts (owner_email) VALUES ($1) RETURNING id`,
+        [studyAccountEmail],
+      );
+      const b = await db.query<{ id: string }>(
+        `INSERT INTO accounts (owner_email) VALUES ($1) RETURNING id`,
+        [otherAccountEmail],
+      );
+      studyAccount = a.rows[0]!.id;
+      otherAccount = b.rows[0]!.id;
+
+      const s = await db.query<{ id: string }>(
+        `INSERT INTO studies (account_id, kind, status, urls)
+           VALUES ($1, 'single', 'ready', ARRAY['https://example.com/p']::text[]) RETURNING id`,
+        [studyAccount],
+      );
+      studyId = s.rows[0]!.id;
+    } finally {
+      await db.end();
+    }
+  }, 90_000);
+
+  afterAll(async () => {
+    await app?.close();
+    stopPostgres(container);
+  });
+
+  function cookieFor(accountId: string, email: string): string {
+    return buildSessionCookie({ accountId, ownerEmail: email, expiresAtIso: futureIso() });
+  }
+
+  it('200 with study data when owner requests their own study', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/studies/${studyId}`,
+      headers: { cookie: cookieFor(studyAccount, studyAccountEmail) },
+    });
+    expect(res.statusCode).toBe(200);
+    const body = res.json<{ id: number; status: string; visit_progress: object }>();
+    expect(body.id).toBe(Number(studyId));
+    expect(body.status).toBe('ready');
+    expect(body.visit_progress).toBeDefined();
+  });
+
+  it('401 without session cookie', async () => {
+    const res = await app.inject({ method: 'GET', url: `/api/studies/${studyId}` });
+    expect(res.statusCode).toBe(401);
+  });
+
+  it('404 when requesting another account\'s study (no existence leak)', async () => {
+    const res = await app.inject({
+      method: 'GET',
+      url: `/api/studies/${studyId}`,
+      headers: { cookie: cookieFor(otherAccount, otherAccountEmail) },
+    });
+    // Must be 404, not 403 — spec §2 #20 (no existence leak).
+    expect(res.statusCode).toBe(404);
+  });
+});


### PR DESCRIPTION
## Summary

- **Bug fix**: PR #227 introduced `r.slug` in the `GET /api/studies/:id` session-cookie route's SQL query, but the `reports` table has no `slug` column. Every call to this endpoint returned HTTP 500. Removed `r.slug` and aligned with the API-key sibling route which correctly uses `r."public"`.
- **Tests**: Adds a `describeIfDocker` integration test suite (issue #209) covering: 200 with study data for the owner, 401 without session cookie, 404 for cross-account isolation (no existence leak per spec §2 #20).

## Test plan

- [ ] CI passes (the 500 regression is confirmed fixed by the new integration tests)
- [ ] `GET /api/studies/:id` returns 200 in the dashboard when viewing a study

🤖 Generated with [Claude Code](https://claude.com/claude-code)