### PR TITLE
test(web): ReportCtaBar dismiss behavior — click, pre-dismissed, storage unavailable

### DIFF
--- a/apps/web/test/report-cta.test.tsx
+++ b/apps/web/test/report-cta.test.tsx
@@ -3,18 +3,17 @@
 // Spec §3d (docs/launch/pricing-cta-audit.md) — buy CTA footer bar on /r/* pages.
 // Issue #146.
 //
-// These four assertions match the acceptance criteria in the issue:
+// Acceptance criteria:
 //   1. The CTA bar renders in the report page output.
 //   2. The CTA link points to /pricing.
 //   3. No email-capture form is present.
 //   4. The close / dismiss button is present.
-//
-// The dismiss interaction itself (localStorage writes) is intentionally
-// not tested here — it's a one-liner and JSDOM quirks make it fragile.
-// Presence of the button is sufficient per the issue spec.
+//   5. Clicking dismiss hides the bar.
+//   6. Pre-dismissed localStorage state hides bar on mount.
+//   7. localStorage unavailability (getItem throws) does not crash.
 
 import { describe, it, expect, beforeAll, afterEach } from 'vitest';
-import { cleanup, render, screen } from '@testing-library/react';
+import { act, cleanup, fireEvent, render, screen } from '@testing-library/react';
 import { ReportCtaBar } from '../components/report/ReportCtaBar';
 
 // jsdom in this project's Bun/Vitest config launches without a localStorage
@@ -36,6 +35,8 @@ beforeAll(() => {
 
 afterEach(() => {
   cleanup();
+  // Reset the localStorage shim between tests so dismiss state doesn't bleed.
+  window.localStorage.clear();
 });
 
 describe('§3d — report CTA bar (#146)', () => {
@@ -65,5 +66,45 @@ describe('§3d — report CTA bar (#146)', () => {
       screen.queryByRole('button', { name: /dismiss|close|×/i }) ??
       screen.queryByLabelText(/dismiss|close|×/i);
     expect(btn).toBeTruthy();
+  });
+
+  it('5. clicking dismiss hides the bar and writes localStorage key', async () => {
+    render(<ReportCtaBar />);
+    expect(screen.getByTestId('report-cta-bar')).toBeTruthy();
+
+    const btn =
+      screen.getByRole('button', { name: /dismiss|close|×/i }) ??
+      screen.getByLabelText(/dismiss|close|×/i);
+
+    await act(async () => { fireEvent.click(btn); });
+
+    expect(screen.queryByTestId('report-cta-bar')).toBeNull();
+    expect(window.localStorage.getItem('willbuy_report_cta_dismissed')).toBe('1');
+  });
+
+  it('6. pre-dismissed localStorage → bar is hidden on mount', async () => {
+    window.localStorage.setItem('willbuy_report_cta_dismissed', '1');
+    render(<ReportCtaBar />);
+
+    // The useEffect fires asynchronously after mount, so wait a tick.
+    await act(async () => {});
+
+    expect(screen.queryByTestId('report-cta-bar')).toBeNull();
+  });
+
+  it('7. localStorage.getItem throwing does not crash the bar', async () => {
+    const original = window.localStorage.getItem.bind(window.localStorage);
+    // Temporarily replace getItem with a throwing stub.
+    (window.localStorage as { getItem: (k: string) => string | null }).getItem = () => {
+      throw new Error('security error: localStorage unavailable');
+    };
+
+    // Should render without throwing.
+    render(<ReportCtaBar />);
+    await act(async () => {});
+    expect(screen.getByTestId('report-cta-bar')).toBeTruthy();
+
+    // Restore.
+    (window.localStorage as { getItem: (k: string) => string | null }).getItem = original;
   });
 });


### PR DESCRIPTION
## Summary

Adds 3 tests to `report-cta.test.tsx` that were explicitly deferred with the comment *"intentionally not tested here — JSDOM quirks make it fragile"*:

- **5**: Clicking `×` hides the bar and writes `willbuy_report_cta_dismissed=1` to localStorage.
- **6**: Pre-set localStorage key hides the bar on mount (hydration suppression path).
- **7**: `localStorage.getItem` throwing (private-browsing mode) does not crash the component.

The in-memory localStorage shim already installed in `beforeAll` makes these reliable without real DOM storage.

## Test plan

- [ ] `bun run test` in `apps/web` passes — all 7 report-cta tests green

🤖 Generated with [Claude Code](https://claude.com/claude-code)