### PR TITLE
test(web): ApiKeysView formatTimestamp — null/'never', valid ISO, invalid date passthrough

### DIFF
--- a/apps/web/test/api-keys.test.tsx
+++ b/apps/web/test/api-keys.test.tsx
@@ -160,3 +160,34 @@ describe('/dashboard/api-keys/create result view (issue #81)', () => {
     expect(html).not.toMatch(/\sstyle="/i);
   });
 });
+
+// ---------------------------------------------------------------------------
+// formatTimestamp — observable via ApiKeysView rendered output.
+// ---------------------------------------------------------------------------
+
+describe('ApiKeysView — formatTimestamp display', () => {
+  it('null last_used_at renders "never"', () => {
+    // REVOKED_KEY has last_used_at: null → formatTimestamp(null) → 'never'.
+    const html = renderToStaticMarkup(<ApiKeysView keys={[REVOKED_KEY]} />);
+    expect(html).toContain('never');
+  });
+
+  it('valid ISO timestamp renders in YYYY-MM-DD HH:MM UTC format', () => {
+    // FIXTURE_KEY.last_used_at = '2026-04-24T10:30:00.000Z'
+    // → formatTimestamp → '2026-04-24 10:30 UTC'
+    const html = renderToStaticMarkup(<ApiKeysView keys={[FIXTURE_KEY]} />);
+    expect(html).toContain('2026-04-24 10:30 UTC');
+  });
+
+  it('invalid date string is returned unchanged (no throw, no NaN)', () => {
+    const keyWithBadDate: ApiKeyRow = {
+      ...FIXTURE_KEY,
+      id: 99,
+      last_used_at: 'not-a-date',
+    };
+    const html = renderToStaticMarkup(<ApiKeysView keys={[keyWithBadDate]} />);
+    // formatTimestamp returns the original string when the Date is Invalid.
+    expect(html).toContain('not-a-date');
+    expect(html).not.toContain('NaN');
+  });
+});


### PR DESCRIPTION
## Summary

3 targeted tests for the private `formatTimestamp` helper in `ApiKeysView.tsx`, exercised via `renderToStaticMarkup`. The helper has 3 branches that were not explicitly covered:

- **`null` → `'never'`**: `REVOKED_KEY` with `last_used_at: null` → output contains `"never"`.
- **Valid ISO → UTC format**: `'2026-04-24T10:30:00.000Z'` → `"2026-04-24 10:30 UTC"` in rendered HTML.
- **Invalid date string → passthrough**: `'not-a-date'` → returned unchanged (`NaN` must not appear in output).

## Test plan

- [ ] `bun run test` in `apps/web` — all 3 new tests pass alongside existing 10

🤖 Generated with [Claude Code](https://claude.com/claude-code)