### PR TITLE
test(api): env validation gaps — DATABASE_URL format, NODE_ENV/RESEND_TEST_MODE enums, optional fields

### DIFF
--- a/apps/api/test/env.test.ts
+++ b/apps/api/test/env.test.ts
@@ -44,4 +44,55 @@ describe('env validation (spec §4.1, CLAUDE.md zod-at-boundaries)', () => {
     const parsed = parseEnv({ ...BASE_ENV, DAILY_CAP_CENTS: '5000' });
     expect(parsed.DAILY_CAP_CENTS).toBe(5000);
   });
+
+  it('throws when DATABASE_URL is not a valid URL', () => {
+    expect(() =>
+      parseEnv({ ...BASE_ENV, DATABASE_URL: 'not-a-url' }),
+    ).toThrow(/DATABASE_URL/);
+  });
+
+  it('rejects invalid NODE_ENV value', () => {
+    expect(() =>
+      parseEnv({ ...BASE_ENV, NODE_ENV: 'staging' }),
+    ).toThrow(/NODE_ENV/);
+  });
+
+  it('accepts all valid NODE_ENV values', () => {
+    for (const env of ['development', 'test', 'production'] as const) {
+      expect(() => parseEnv({ ...BASE_ENV, NODE_ENV: env })).not.toThrow();
+    }
+  });
+
+  it('rejects invalid RESEND_TEST_MODE value', () => {
+    expect(() =>
+      parseEnv({ ...BASE_ENV, RESEND_TEST_MODE: 'dry-run' }),
+    ).toThrow(/RESEND_TEST_MODE/);
+  });
+
+  it('STRIPE_SUCCESS_URL must be a valid URL when provided', () => {
+    expect(() =>
+      parseEnv({ ...BASE_ENV, STRIPE_SUCCESS_URL: 'not-a-url' }),
+    ).toThrow();
+    expect(() =>
+      parseEnv({ ...BASE_ENV, STRIPE_SUCCESS_URL: 'https://example.com/success' }),
+    ).not.toThrow();
+  });
+
+  it('WILLBUY_METRICS_TOKEN must be at least 16 chars when provided', () => {
+    expect(() =>
+      parseEnv({ ...BASE_ENV, WILLBUY_METRICS_TOKEN: 'short' }),
+    ).toThrow();
+    expect(() =>
+      parseEnv({ ...BASE_ENV, WILLBUY_METRICS_TOKEN: 'x'.repeat(16) }),
+    ).not.toThrow();
+  });
+
+  it('optional fields may be omitted without error', () => {
+    // All of these are optional with defaults.
+    const parsed = parseEnv(BASE_ENV);
+    expect(parsed.STRIPE_SUCCESS_URL).toBeUndefined();
+    expect(parsed.STRIPE_CANCEL_URL).toBeUndefined();
+    expect(parsed.WILLBUY_METRICS_TOKEN).toBeUndefined();
+    expect(parsed.WILLBUY_DEV_SESSION).toBeUndefined();
+  });
 });


### PR DESCRIPTION
## Summary

7 additional tests added to `env.test.ts`, covering untested validation branches in `parseEnv()`:

- **`DATABASE_URL` format**: `'not-a-url'` must throw (existing test only checks for missing key, not invalid format).
- **`NODE_ENV` enum** (2 tests): `'staging'` throws; all three valid values (`development`, `test`, `production`) accepted.
- **`RESEND_TEST_MODE` enum**: `'dry-run'` throws (only `'stub'` and `'live'` are valid).
- **`STRIPE_SUCCESS_URL` URL validation**: invalid string throws; valid HTTPS URL accepted.
- **`WILLBUY_METRICS_TOKEN` min-length**: `'short'` (< 16 chars) throws; 16-char string accepted.
- **Optional fields omitted**: `STRIPE_SUCCESS_URL`, `STRIPE_CANCEL_URL`, `WILLBUY_METRICS_TOKEN`, `WILLBUY_DEV_SESSION` all `undefined` when not supplied.

## Test plan

- [ ] `bun run test apps/api` — all 7 new tests pass alongside existing 7

🤖 Generated with [Claude Code](https://claude.com/claude-code)