### PR TITLE
test(web): StudiesListView formatCreatedAt — valid ISO, invalid date passthrough (2 tests)

### DIFF
--- a/apps/web/test/studies-list.test.tsx
+++ b/apps/web/test/studies-list.test.tsx
@@ -136,3 +136,38 @@ describe('/dashboard/studies view (issue #85)', () => {
     expect(html).not.toMatch(/\sstyle="/i);
   });
 });
+
+// ── formatCreatedAt — observable via StudiesListView rendered output ────────
+
+describe('StudiesListView — formatCreatedAt timestamp display', () => {
+  const base = {
+    id: 200,
+    status: 'ready' as const,
+    finalized_at: null,
+    n_visits: 1,
+    urls: ['https://example.com'],
+    visit_progress: { ok: 1, failed: 0, total: 1 },
+  };
+
+  it('valid ISO created_at renders in YYYY-MM-DD HH:MM UTC format', () => {
+    // '2026-04-20T12:00:00.000Z' → '2026-04-20 12:00 UTC'
+    const html = renderToStaticMarkup(
+      <StudiesListView
+        studies={[{ ...base, created_at: '2026-04-20T12:00:00.000Z' }]}
+        nextCursor={null}
+      />,
+    );
+    expect(html).toContain('2026-04-20 12:00 UTC');
+  });
+
+  it('invalid date string is returned unchanged (no NaN)', () => {
+    const html = renderToStaticMarkup(
+      <StudiesListView
+        studies={[{ ...base, created_at: 'not-a-date' }]}
+        nextCursor={null}
+      />,
+    );
+    expect(html).toContain('not-a-date');
+    expect(html).not.toContain('NaN');
+  });
+});


### PR DESCRIPTION
## Summary
- Extends `test/studies-list.test.tsx` with a `formatCreatedAt` describe block (2 new tests)
- Pins the UTC formatting contract: `'2026-04-20T12:00:00.000Z'` → `'2026-04-20 12:00 UTC'`
- Verifies invalid date strings are returned unchanged with no `NaN` in output

Mirrors the timestamp-helper pattern established in PR #292 (DomainsListView) and PR #283 (ApiKeysView), closing the same gap in StudiesListView's private `formatCreatedAt` helper.

## Test plan
- [x] `bun run test test/studies-list.test.tsx` — 8/8 pass (2 new)
- [x] Single commit from `main`, no production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)