### PR TITLE
test(web): DashboardView formatCreatedAt + formatBalance edge cases (4 tests)

### DIFF
--- a/apps/web/test/dashboard.test.tsx
+++ b/apps/web/test/dashboard.test.tsx
@@ -113,3 +113,59 @@ describe('/dashboard view (issue #80)', () => {
     expect(html).not.toMatch(/\sstyle="/i);
   });
 });
+
+// ── formatCreatedAt + formatBalance — observable via DashboardView rendered output ──
+
+describe('DashboardView — formatCreatedAt and formatBalance helpers', () => {
+  const base = {
+    email: 'x@example.com',
+    recent_studies: [],
+  };
+
+  it('formatCreatedAt: valid ISO renders in YYYY-MM-DD HH:MM UTC format', () => {
+    const summary = {
+      ...base,
+      balance_cents: 0,
+      recent_studies: [
+        {
+          id: 1,
+          status: 'ready' as const,
+          created_at: '2026-04-20T12:00:00.000Z',
+          n_visits: 1,
+          urls: ['https://example.com'],
+        },
+      ],
+    };
+    const html = renderToStaticMarkup(<DashboardView summary={summary} />);
+    expect(html).toContain('2026-04-20 12:00 UTC');
+  });
+
+  it('formatCreatedAt: invalid date string is returned unchanged (no NaN)', () => {
+    const summary = {
+      ...base,
+      balance_cents: 0,
+      recent_studies: [
+        {
+          id: 2,
+          status: 'capturing' as const,
+          created_at: 'not-a-date',
+          n_visits: 1,
+          urls: ['https://example.com'],
+        },
+      ],
+    };
+    const html = renderToStaticMarkup(<DashboardView summary={summary} />);
+    expect(html).toContain('not-a-date');
+    expect(html).not.toContain('NaN');
+  });
+
+  it('formatBalance: zero cents → $0.00', () => {
+    const html = renderToStaticMarkup(<DashboardView summary={{ ...base, balance_cents: 0 }} />);
+    expect(html).toContain('$0.00');
+  });
+
+  it('formatBalance: 1 cent → $0.01', () => {
+    const html = renderToStaticMarkup(<DashboardView summary={{ ...base, balance_cents: 1 }} />);
+    expect(html).toContain('$0.01');
+  });
+});


### PR DESCRIPTION
## Summary
- Extends `test/dashboard.test.tsx` with 4 tests for the private `formatCreatedAt` and `formatBalance` helpers in `DashboardView.tsx`
- Mirrors the timestamp-helper pattern from PR #296 (StudiesListView) and PR #292 (DomainsListView)

`formatCreatedAt`:
- Valid ISO `'2026-04-20T12:00:00.000Z'` → `'2026-04-20 12:00 UTC'`
- Invalid date string returned unchanged, no `NaN` in output

`formatBalance`:
- `0` cents → `'$0.00'` (zero boundary, `padStart` for cents)
- `1` cent → `'$0.01'` (single digit padded)

## Test plan
- [x] `bun run test test/dashboard.test.tsx` — 10/10 pass (4 new)
- [x] Single commit from `main`, no production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)