### PR TITLE
test(shared): Backstory sub-schema enum value pins (8 tests, spec §2 #5)

### DIFF
--- a/packages/shared/test/backstory.test.ts
+++ b/packages/shared/test/backstory.test.ts
@@ -2,7 +2,17 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { Backstory } from '../src/backstory.js';
+import {
+  Backstory,
+  Stage,
+  ManagedPostgres,
+  CurrentPain,
+  EntryPoint,
+  Regulated,
+  PostgresDepth,
+  BudgetAuthority,
+  RoleArchetype,
+} from '../src/backstory.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const validFixture = JSON.parse(
@@ -18,5 +28,69 @@ describe('Backstory (spec §2 #5 + personas/backstories.md)', () => {
   it('rejects a backstory with a bad enum value', () => {
     const bad = { ...validFixture, managed_postgres: 'mongodb' };
     expect(() => Backstory.parse(bad)).toThrow();
+  });
+});
+
+// ── Backstory enum spec-pins (spec §2 #5, personas/backstories.md) ────────────
+
+describe('Backstory sub-schemas — enum value pins (spec §2 #5)', () => {
+  it('Stage has exactly 4 values: seed, seed+, series_a, series_b', () => {
+    const values = Stage.options;
+    expect(values).toEqual(['seed', 'seed+', 'series_a', 'series_b']);
+    expect(values).toHaveLength(4);
+  });
+
+  it('ManagedPostgres has 5 providers: supabase, neon, rds, aurora, cloud_sql', () => {
+    const values = ManagedPostgres.options;
+    expect(values).toContain('supabase');
+    expect(values).toContain('neon');
+    expect(values).toContain('rds');
+    expect(values).toContain('aurora');
+    expect(values).toContain('cloud_sql');
+    expect(values).toHaveLength(5);
+  });
+
+  it('CurrentPain has 6 pain points', () => {
+    const values = CurrentPain.options;
+    expect(values).toContain('recent_outage');
+    expect(values).toContain('slow_queries');
+    expect(values).toContain('bad_migration_fear');
+    expect(values).toContain('cost_creep');
+    expect(values).toContain('upcoming_scale_event');
+    expect(values).toContain('post_mortem_in_hand');
+    expect(values).toHaveLength(6);
+  });
+
+  it('EntryPoint has 6 sources', () => {
+    const values = EntryPoint.options;
+    expect(values).toContain('hacker_news');
+    expect(values).toContain('newsletter');
+    expect(values).toContain('vc_referral');
+    expect(values).toContain('google_search');
+    expect(values).toContain('postgres_blog_footer');
+    expect(values).toContain('conference_booth_followup');
+    expect(values).toHaveLength(6);
+  });
+
+  it('Regulated has 3 values: no, lightly, yes', () => {
+    expect(Regulated.options).toEqual(['no', 'lightly', 'yes']);
+  });
+
+  it('PostgresDepth has 3 values: light, medium, deep', () => {
+    expect(PostgresDepth.options).toEqual(['light', 'medium', 'deep']);
+  });
+
+  it('BudgetAuthority has 4 values', () => {
+    const values = BudgetAuthority.options;
+    expect(values).toContain('self');
+    expect(values).toContain('needs_founder_signoff');
+    expect(values).toContain('needs_manager_signoff');
+    expect(values).toContain('needs_board_visibility');
+    expect(values).toHaveLength(4);
+  });
+
+  it('RoleArchetype has exactly 2 values: founder_or_eng_lead and ic_engineer', () => {
+    expect(RoleArchetype.options).toEqual(['founder_or_eng_lead', 'ic_engineer']);
+    expect(RoleArchetype.options).toHaveLength(2);
   });
 });


### PR DESCRIPTION
## Summary
- Extends `packages/shared/test/backstory.test.ts` with 8 spec-pin tests for Backstory sub-schema enum values
- Prior tests only verified that a bad enum value was rejected; the valid set was never pinned

| Schema | Values | Count |
|---|---|---|
| `Stage` | seed, seed+, series_a, series_b | 4 |
| `ManagedPostgres` | supabase, neon, rds, aurora, cloud_sql | 5 |
| `CurrentPain` | recent_outage, slow_queries, bad_migration_fear, cost_creep, upcoming_scale_event, post_mortem_in_hand | 6 |
| `EntryPoint` | hacker_news, newsletter, vc_referral, google_search, postgres_blog_footer, conference_booth_followup | 6 |
| `Regulated` | no, lightly, yes | 3 |
| `PostgresDepth` | light, medium, deep | 3 |
| `BudgetAuthority` | self, needs_founder_signoff, needs_manager_signoff, needs_board_visibility | 4 |
| `RoleArchetype` | founder_or_eng_lead, ic_engineer | 2 |

Silent additions/removals to these enums would break the ICP-preset machinery without failing CI until now.

## Test plan
- [x] `bun run test test/backstory.test.ts` — 10/10 pass (8 new)
- [x] Single commit from `main`, no production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)