### PR TITLE
test(shared): VisitorOutput list-item and list-length caps (4 tests, spec §2 #15)

### DIFF
--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -56,4 +56,30 @@ describe('VisitorOutput (spec §2 #15)', () => {
     const bad = { ...validFixture, reasoning: 'r'.repeat(1201) };
     expect(() => VisitorOutput.parse(bad)).toThrow();
   });
+
+  it('rejects a list item > 200 chars (§2 #15 per-item cap)', () => {
+    const longItem = 'q'.repeat(201);
+    const bad = { ...validFixture, questions: [longItem] };
+    expect(() => VisitorOutput.parse(bad)).toThrow();
+  });
+
+  it('rejects a list with more than 10 items (§2 #15 list-length cap)', () => {
+    const elevenItems = Array.from({ length: 11 }, (_, i) => `item ${i}`);
+    const bad = { ...validFixture, objections: elevenItems };
+    expect(() => VisitorOutput.parse(bad)).toThrow();
+  });
+
+  it('accepts a list with exactly 10 items (boundary, §2 #15)', () => {
+    const tenItems = Array.from({ length: 10 }, (_, i) => `item ${i}`);
+    const good = { ...validFixture, confusions: tenItems };
+    const parsed = VisitorOutput.parse(good);
+    expect(parsed.confusions).toHaveLength(10);
+  });
+
+  it('accepts a list item with exactly 200 chars (boundary)', () => {
+    const exactly200 = 'q'.repeat(200);
+    const good = { ...validFixture, questions: [exactly200] };
+    const parsed = VisitorOutput.parse(good);
+    expect(parsed.questions[0]).toHaveLength(200);
+  });
 });


### PR DESCRIPTION
## Summary
- Extends `packages/shared/test/visitor.test.ts` with 4 boundary tests for list constraints in `VisitorOutput` (spec §2 #15)
- Prior tests covered field-size (first_impression, reasoning) and enum (next_action) constraints, but the per-item and per-list caps were untested

Tests added:
1. List item > 200 chars → rejected
2. List with 11 items → rejected (max 10 per §2 #15)
3. List with exactly 10 items → accepted (upper boundary)
4. List item with exactly 200 chars → accepted (per-item boundary)

## Test plan
- [x] `bun run test test/visitor.test.ts` — 12/12 pass (4 new)
- [x] Single commit from `main`, no production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)