### PR TITLE
test(capture-worker): checkRedirectAllowed — no_state, bad_url, dns_fail (3 tests)

### DIFF
--- a/apps/capture-worker/test/runWithNetns.test.ts
+++ b/apps/capture-worker/test/runWithNetns.test.ts
@@ -19,6 +19,7 @@ import { fileURLToPath } from 'node:url';
 import { afterEach, beforeEach, describe, expect, it } from 'vitest';
 import {
   NetnsBringupError,
+  checkRedirectAllowed,
   parseHostBudgetOutput,
   runWithNetns,
 } from '../src/run-with-netns.js';
@@ -155,3 +156,40 @@ describe('parseHostBudgetOutput', () => {
 
 // Pin INFRA so editor auto-imports don't drop it.
 void INFRA;
+
+// ── checkRedirectAllowed ──────────────────────────────────────────────────────
+
+describe('checkRedirectAllowed', () => {
+  let stateDir: string;
+
+  beforeEach(() => {
+    stateDir = mkdtempSync(join(tmpdir(), 'wb-check-redirect-'));
+  });
+
+  afterEach(() => {
+    rmSync(stateDir, { recursive: true, force: true });
+  });
+
+  it('returns { allowed: false, reason: "no_state" } when state file is missing', async () => {
+    const result = await checkRedirectAllowed('wb-abc12345678', 'https://example.com', stateDir);
+    expect(result).toEqual({ allowed: false, reason: 'no_state' });
+  });
+
+  it('returns { allowed: false, reason: "bad_url" } for a malformed redirect URL', async () => {
+    writeFileSync(join(stateDir, 'wb-abc12345678.state'), 'allowed_ipv4=1.2.3.4\n');
+    const result = await checkRedirectAllowed('wb-abc12345678', 'not-a-url', stateDir);
+    expect(result).toEqual({ allowed: false, reason: 'bad_url' });
+  });
+
+  it('returns { allowed: false, reason: "dns_fail" } when host does not resolve', async () => {
+    // Using a guaranteed-unresolvable hostname (RFC 2606 .invalid TLD) so DNS
+    // lookup throws ENOTFOUND and the function returns dns_fail without mocking.
+    writeFileSync(join(stateDir, 'wb-abc12345678.state'), 'allowed_ipv4=1.2.3.4\n');
+    const result = await checkRedirectAllowed(
+      'wb-abc12345678',
+      'https://this-hostname-definitely-does-not.exist.invalid',
+      stateDir,
+    );
+    expect(result).toEqual({ allowed: false, reason: 'dns_fail' });
+  });
+});


### PR DESCRIPTION
## Summary
- Extends `apps/capture-worker/test/runWithNetns.test.ts` with 3 tests for `checkRedirectAllowed()` (spec §5.13 cross-eTLD redirect guard)
- The function was exported but had zero test coverage

| Test | Scenario | Expected |
|------|----------|----------|
| no state file | stateDir empty | `{ allowed: false, reason: 'no_state' }` |
| bad URL | `'not-a-url'` | `{ allowed: false, reason: 'bad_url' }` |
| DNS failure | RFC 2606 `.invalid` TLD (guaranteed unresolvable) | `{ allowed: false, reason: 'dns_fail' }` |

The cross-eTLD IP-set check paths are exercised by the integration tests in `captureGolden.test.ts` (real netns environment).

## Test plan
- [x] `bun vitest run test/runWithNetns.test.ts` — 9/9 pass (3 new)
- [x] Single commit from `main`, no production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)