### PR TITLE
test(shared): barrel export completeness — 4 tests covering all 4 modules

### DIFF
--- a/packages/shared/test/index.test.ts
+++ b/packages/shared/test/index.test.ts
@@ -2,12 +2,27 @@ import { describe, expect, it } from 'vitest';
 import * as shared from '../src/index.js';
 
 describe('@willbuy/shared barrel export', () => {
-  it('exports VisitorOutput, Backstory, NextAction, NEXT_ACTION_WEIGHTS, PAID_TIERS, scoreVisit', () => {
+  it('exports visitor-output types: VisitorOutput', () => {
     expect(shared.VisitorOutput).toBeDefined();
-    expect(shared.Backstory).toBeDefined();
+    expect(typeof shared.VisitorOutput.parse).toBe('function');
+  });
+
+  it('exports scoring: NextAction, NEXT_ACTION_WEIGHTS, PAID_TIERS, scoreVisit', () => {
     expect(shared.NextAction).toBeDefined();
     expect(shared.NEXT_ACTION_WEIGHTS).toBeDefined();
     expect(shared.PAID_TIERS).toBeDefined();
-    expect(shared.scoreVisit).toBeDefined();
+    expect(typeof shared.scoreVisit).toBe('function');
+  });
+
+  it('exports report: Report schema', () => {
+    expect(shared.Report).toBeDefined();
+    expect(typeof shared.Report.parse).toBe('function');
+  });
+
+  it('exports backstory: Backstory and sub-schemas', () => {
+    expect(shared.Backstory).toBeDefined();
+    expect(shared.Stage).toBeDefined();
+    expect(shared.RoleArchetype).toBeDefined();
+    expect(shared.BudgetAuthority).toBeDefined();
   });
 });


### PR DESCRIPTION
## Summary
- Extends `packages/shared/test/index.test.ts` with 4 targeted tests (replacing the 1 broad test)
- Verifies that all 4 module sections are accessible via the package barrel: `visitor`, `scoring`, `report`, `backstory`

Prior test only checked visitor + scoring; a missing re-export for `Report` or the backstory sub-schemas would silently fail at import time without this.

## Test plan
- [x] `bun run test test/index.test.ts` — 4/4 pass
- [x] Single commit from `main`, no production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)