### PR TITLE
test(api): buildLogger service="api" label injection (1 test)

### DIFF
--- a/apps/api/test/logger.test.ts
+++ b/apps/api/test/logger.test.ts
@@ -135,3 +135,12 @@ describe('logger redaction (spec §5.12)', () => {
     expect(JSON.stringify(rec)).not.toContain('deep@x.com');
   });
 });
+
+describe('buildLogger — service label', () => {
+  it('injects service="api" into every log record', () => {
+    const { logger, logs } = captureLogs('a'.repeat(32));
+    logger.info({}, 'hello');
+    const [rec] = logs();
+    expect(rec!['service']).toBe('api');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 1 test to `test/logger.test.ts` verifying that `buildLogger()` in `apps/api/src/logger.ts` injects `service="api"` into every log record
- The API logger is a thin wrapper that adds `service: 'api'` to `@willbuy/log`'s factory — this pins that the label reaches the structured output

## Test plan
- [x] `bun run test test/logger.test.ts` — 9/9 pass (1 new)
- [x] Single commit from `main`, no production code changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)