### PR TITLE
test(capture-worker): add selectRuntimeFromEnv unit tests

### DIFF
--- a/apps/capture-worker/test/runtime.test.ts
+++ b/apps/capture-worker/test/runtime.test.ts
@@ -23,6 +23,7 @@ import {
   RuntimeNotImplementedError,
   runCapture,
   selectRuntime,
+  selectRuntimeFromEnv,
 } from '../src/runtime.js';
 
 let tmpRoot = '';
@@ -182,5 +183,20 @@ describe('runCapture dispatcher', () => {
     });
 
     expect(result.status).toBe('ok');
+  });
+});
+
+describe('selectRuntimeFromEnv()', () => {
+  it('reads WILLBUY_CAPTURE_RUNTIME from the provided env object', () => {
+    expect(selectRuntimeFromEnv({ WILLBUY_CAPTURE_RUNTIME: 'netns' })).toBe('netns');
+    expect(selectRuntimeFromEnv({ WILLBUY_CAPTURE_RUNTIME: 'firecracker' })).toBe('firecracker');
+  });
+
+  it('defaults to "netns" when WILLBUY_CAPTURE_RUNTIME is unset', () => {
+    expect(selectRuntimeFromEnv({})).toBe('netns');
+  });
+
+  it('throws RuntimeConfigError for an unknown WILLBUY_CAPTURE_RUNTIME value', () => {
+    expect(() => selectRuntimeFromEnv({ WILLBUY_CAPTURE_RUNTIME: 'docker' })).toThrow(RuntimeConfigError);
   });
 });


### PR DESCRIPTION
## Summary
- Adds 3 unit tests for `selectRuntimeFromEnv()` in `apps/capture-worker/test/runtime.test.ts`
- Covers: reads `WILLBUY_CAPTURE_RUNTIME` from env object, defaults to `"netns"` when unset, throws `RuntimeConfigError` for unknown values
- Function was exported from `src/runtime.ts` but had zero test coverage

## Test plan
- [ ] `bun run --cwd apps/capture-worker test --run` — all 3 new tests pass (38 total pass, Docker integration skipped)
- [ ] No Docker daemon required for these unit tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)