### PR TITLE
test(web): spec-pin ICP_PRESETS and STUDY_STATUSES constants

### DIFF
--- a/apps/web/test/studies-new.test.ts
+++ b/apps/web/test/studies-new.test.ts
@@ -339,3 +339,48 @@ describe('StudyStatusPage — polling', () => {
     expect(fetchSpy.mock.calls.length).toBeGreaterThan(callCount);
   }, 15_000);
 });
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Spec-pin: ICP_PRESETS and STUDY_STATUSES constant values
+// ─────────────────────────────────────────────────────────────────────────────
+
+describe('ICP_PRESETS spec-pin (api-client.ts)', () => {
+  it('contains exactly 5 ICP presets', async () => {
+    const { ICP_PRESETS } = await import('../lib/api-client.js');
+    expect(ICP_PRESETS).toHaveLength(5);
+  });
+
+  it('includes saas_founder_pre_pmf, saas_founder_post_pmf', async () => {
+    const { ICP_PRESETS } = await import('../lib/api-client.js');
+    expect(ICP_PRESETS).toContain('saas_founder_pre_pmf');
+    expect(ICP_PRESETS).toContain('saas_founder_post_pmf');
+  });
+
+  it('includes shopify_merchant, devtools_engineer, fintech_ops_buyer', async () => {
+    const { ICP_PRESETS } = await import('../lib/api-client.js');
+    expect(ICP_PRESETS).toContain('shopify_merchant');
+    expect(ICP_PRESETS).toContain('devtools_engineer');
+    expect(ICP_PRESETS).toContain('fintech_ops_buyer');
+  });
+});
+
+describe('STUDY_STATUSES spec-pin (api-client.ts)', () => {
+  it('contains exactly 6 statuses', async () => {
+    const { STUDY_STATUSES } = await import('../lib/api-client.js');
+    expect(STUDY_STATUSES).toHaveLength(6);
+  });
+
+  it('includes the 3 terminal statuses: ready, failed, and aggregating', async () => {
+    const { STUDY_STATUSES } = await import('../lib/api-client.js');
+    expect(STUDY_STATUSES).toContain('ready');
+    expect(STUDY_STATUSES).toContain('failed');
+    expect(STUDY_STATUSES).toContain('aggregating');
+  });
+
+  it('includes the 3 transient statuses: pending, capturing, visiting', async () => {
+    const { STUDY_STATUSES } = await import('../lib/api-client.js');
+    expect(STUDY_STATUSES).toContain('pending');
+    expect(STUDY_STATUSES).toContain('capturing');
+    expect(STUDY_STATUSES).toContain('visiting');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 6 spec-pin tests to `apps/web/test/studies-new.test.ts`
- `ICP_PRESETS`: 5 presets, all preset IDs present (`saas_founder_pre_pmf`, `saas_founder_post_pmf`, `shopify_merchant`, `devtools_engineer`, `fintech_ops_buyer`)
- `STUDY_STATUSES`: 6 statuses, 3 transient (`pending`, `capturing`, `visiting`), 3 terminal (`aggregating`, `ready`, `failed`)
- No mocks, no DOM — pure constant assertions from `apps/web/lib/api-client.ts`

## Test plan
- [ ] `bun run --cwd apps/web test test/studies-new.test.ts --run` → 14 passed (6 new + 8 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)