### PR TITLE
test(capture-broker): spec-pin BYTE_CAPS constants + decodedBase64Bytes sanity

### DIFF
--- a/apps/capture-broker/test/byteCaps.test.ts
+++ b/apps/capture-broker/test/byteCaps.test.ts
@@ -1,0 +1,48 @@
+/**
+ * byteCaps.test.ts — spec-pin tests for BYTE_CAPS constants (spec §5.13).
+ *
+ * The broker rejects payloads that exceed these caps AFTER schema parse,
+ * BEFORE redaction + persistence. Pinning the values here catches a silent
+ * change that would silently loosen the defense-in-depth layer.
+ *
+ * Tests:
+ *   1. MESSAGE_BYTES is 32 MB (outer envelope + payload hard limit)
+ *   2. A11Y_TREE_BYTES is 10 MB (matches capture-worker CAPTURE_CEILINGS)
+ *   3. SCREENSHOT_BYTES is 5 MB (conservative v0.1 cap per spec §5.13 + §5.17)
+ *   4. decodedBase64Bytes works for a known 3-byte encoding (sanity check)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BYTE_CAPS, decodedBase64Bytes } from '../src/byteCaps.js';
+
+describe('BYTE_CAPS spec-pin (spec §5.13)', () => {
+  it('MESSAGE_BYTES is 32 MB', () => {
+    expect(BYTE_CAPS.MESSAGE_BYTES).toBe(32 * 1024 * 1024);
+  });
+
+  it('A11Y_TREE_BYTES is 10 MB', () => {
+    expect(BYTE_CAPS.A11Y_TREE_BYTES).toBe(10 * 1024 * 1024);
+  });
+
+  it('SCREENSHOT_BYTES is 5 MB', () => {
+    expect(BYTE_CAPS.SCREENSHOT_BYTES).toBe(5 * 1024 * 1024);
+  });
+
+  it('exactly 3 cap keys are defined', () => {
+    expect(Object.keys(BYTE_CAPS)).toHaveLength(3);
+  });
+});
+
+describe('decodedBase64Bytes sanity (spec §5.13)', () => {
+  it('"AAAA" (4-char no-pad) → 3 decoded bytes', () => {
+    expect(decodedBase64Bytes('AAAA')).toBe(3);
+  });
+
+  it('empty string → 0', () => {
+    expect(decodedBase64Bytes('')).toBe(0);
+  });
+
+  it('non-base64 input → null', () => {
+    expect(decodedBase64Bytes('!@#$')).toBeNull();
+  });
+});


### PR DESCRIPTION
## Summary
- Creates new `apps/capture-broker/test/byteCaps.test.ts` with 7 tests
- `BYTE_CAPS` spec-pins: `MESSAGE_BYTES=32 MB`, `A11Y_TREE_BYTES=10 MB`, `SCREENSHOT_BYTES=5 MB`, key count=3 (spec §5.13)
- `decodedBase64Bytes` sanity: valid 4-char no-pad → 3 bytes, empty → 0, non-base64 → null
- `BYTE_CAPS` values were used in `test/server.test.ts` but never spec-pinned

## Test plan
- [ ] `bun run --cwd apps/capture-broker test test/byteCaps.test.ts --run` → 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)