### PR TITLE
test(api): unit tests for safeRedirect open-redirect prevention (AC11)

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -45,6 +45,10 @@ function safeRedirect(raw: string | undefined): string {
   return raw;
 }
 
+// Test-only export so open-redirect prevention can be unit-tested without
+// spinning up a Fastify server + Postgres.
+export const __test__ = { safeRedirect };
+
 const SESSION_7_DAYS_SECONDS = 7 * 24 * 60 * 60; // 604800
 const MAGIC_LINK_EXPIRY_MINUTES = 30;
 

--- a/apps/api/test/safe-redirect.test.ts
+++ b/apps/api/test/safe-redirect.test.ts
@@ -1,0 +1,43 @@
+/**
+ * safe-redirect.test.ts — unit tests for the open-redirect prevention helper
+ * in routes/auth.ts (spec §4.1, AC11 from auth.test.ts).
+ *
+ * safeRedirect() is the security guard on the `redirect` query param passed
+ * through the magic-link verification flow. A bug here enables open-redirect
+ * attacks. These pure unit tests exercise all 6 branches without DB or network.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ } from '../src/routes/auth.js';
+
+const { safeRedirect } = __test__;
+
+describe('safeRedirect (open-redirect prevention, AC11)', () => {
+  it('returns /dashboard when input is undefined', () => {
+    expect(safeRedirect(undefined)).toBe('/dashboard');
+  });
+
+  it('returns /dashboard when input is empty string', () => {
+    expect(safeRedirect('')).toBe('/dashboard');
+  });
+
+  it('returns the path unchanged for a valid relative path', () => {
+    expect(safeRedirect('/dashboard/studies')).toBe('/dashboard/studies');
+  });
+
+  it('returns the path unchanged for the root path', () => {
+    expect(safeRedirect('/')).toBe('/');
+  });
+
+  it('blocks protocol-relative URLs (//evil.com)', () => {
+    expect(safeRedirect('//evil.com/phish')).toBe('/dashboard');
+  });
+
+  it('blocks absolute URLs with https://', () => {
+    expect(safeRedirect('https://evil.com/steal')).toBe('/dashboard');
+  });
+
+  it('blocks strings containing :// not at the start', () => {
+    expect(safeRedirect('/foo://bar')).toBe('/dashboard');
+  });
+});


### PR DESCRIPTION
## Summary
- Exports `safeRedirect` via `__test__` seam in `routes/auth.ts`
- Creates `apps/api/test/safe-redirect.test.ts` with 7 pure unit tests
- Tests: undefined/empty → fallback `/dashboard`, valid relative path → passthrough, `//evil.com` blocked, `https://` blocked, internal `://` blocked
- Previously only covered by Docker-gated AC10/AC11 integration tests — now has fast standalone unit coverage for a security-critical function

## Test plan
- [ ] `bun run --cwd apps/api test test/safe-redirect.test.ts --run` → 7 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)