### PR TITLE
test(web): spec-pin pricing page credits and visit estimates (issue #112)

### DIFF
--- a/apps/web/test/pricing.test.tsx
+++ b/apps/web/test/pricing.test.tsx
@@ -74,4 +74,30 @@ describe('/pricing page (issue #144)', () => {
     const html = await getHtml();
     expect(html).toMatch(/sign-in/i);
   });
+
+  // ── Credits and visit-estimate spec-pins (issue #112 — 3.5¢/visit avg) ──────
+  it('Starter shows 1,000 credits', async () => {
+    const html = await getHtml();
+    expect(html).toMatch(/1[,.]?000\s*credits/i);
+  });
+
+  it('Growth shows 4,000 credits', async () => {
+    const html = await getHtml();
+    expect(html).toMatch(/4[,.]?000\s*credits/i);
+  });
+
+  it('Scale shows 15,000 credits', async () => {
+    const html = await getHtml();
+    expect(html).toMatch(/15[,.]?000\s*credits/i);
+  });
+
+  it('Starter shows ~828 visit estimate (Math.floor(2900 / 3.5))', async () => {
+    const html = await getHtml();
+    expect(html).toMatch(/828\s*visits/i);
+  });
+
+  it('Growth shows ~2,828 visit estimate (Math.floor(9900 / 3.5))', async () => {
+    const html = await getHtml();
+    expect(html).toMatch(/2[,.]?828\s*visits/i);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds 5 spec-pin tests to `apps/web/test/pricing.test.tsx`
- `1,000 credits` (Starter), `4,000 credits` (Growth), `15,000 credits` (Scale)
- `~828 visits` (Starter at 3.5¢/visit), `~2,828 visits` (Growth at 3.5¢/visit)
- Catches divergence between the server-side `PACKS` object in `apps/api` and the pricing page's local `Pack[]` array

## Test plan
- [ ] `bun run --cwd apps/web test test/pricing.test.tsx --run` → 15 passed (5 new + 10 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)