### PR TITLE
test(log): spec-pin MAX_FIELD_BYTES=8192 (8 KiB per spec §5.12)

### DIFF
--- a/packages/log/test/oversize.test.ts
+++ b/packages/log/test/oversize.test.ts
@@ -114,3 +114,9 @@ describe('TDD #4 — pino formatter catches and emits alert event', () => {
     expect(raw()).not.toContain(big);
   });
 });
+
+describe('MAX_FIELD_BYTES spec-pin (spec §5.12)', () => {
+  it('MAX_FIELD_BYTES is 8192 (8 KiB)', () => {
+    expect(MAX_FIELD_BYTES).toBe(8192);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 1 spec-pin test for `MAX_FIELD_BYTES` in `packages/log/test/oversize.test.ts`
- Asserts the literal value is `8192` (8 KiB per spec §5.12)
- Previously imported and used as a dynamic threshold for test inputs but never asserted as a numeric literal

## Test plan
- [ ] `bun run --cwd packages/log test test/oversize.test.ts --run` → 7 passed (1 new + 6 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)