### PR TITLE
test(aggregator): spec-pin CONVERTED_ACTIONS (amendment A1 McNemar binarization)

### DIFF
--- a/apps/aggregator/tests/test_stats.py
+++ b/apps/aggregator/tests/test_stats.py
@@ -152,3 +152,35 @@ def test_paired_delta_disagreement_rule_xor_contract() -> None:
     assert out_a.disagreement is False
     # conservative_p is still computed; it equals max(t, w) even when no disagreement.
     assert math.isclose(out_a.conservative_p, max(out_a.paired_t_p, out_a.wilcoxon_p))
+
+
+# ---------------------------------------------------------------------------
+# Spec-pin: CONVERTED_ACTIONS (amendment A1, McNemar binarization)
+# ---------------------------------------------------------------------------
+
+from aggregator.stats import CONVERTED_ACTIONS  # noqa: E402
+
+
+def test_converted_actions_contains_high_intent_actions() -> None:
+    """Amendment A1: converted=1 iff next_action is in this set."""
+    assert "purchase_paid_today" in CONVERTED_ACTIONS
+    assert "contact_sales" in CONVERTED_ACTIONS
+    assert "book_demo" in CONVERTED_ACTIONS
+    assert "start_paid_trial" in CONVERTED_ACTIONS
+
+
+def test_converted_actions_excludes_lower_intent_actions() -> None:
+    """Low-intent actions must not be treated as conversions."""
+    assert "bookmark_compare_later" not in CONVERTED_ACTIONS
+    assert "start_free_hobby" not in CONVERTED_ACTIONS
+    assert "ask_teammate" not in CONVERTED_ACTIONS
+    assert "leave" not in CONVERTED_ACTIONS
+
+
+def test_converted_actions_exactly_four_members() -> None:
+    """Amendment A1 names exactly 4 converted actions."""
+    assert len(CONVERTED_ACTIONS) == 4
+
+
+def test_converted_actions_is_frozenset() -> None:
+    assert isinstance(CONVERTED_ACTIONS, frozenset)


### PR DESCRIPTION
## Summary
- Adds 4 spec-pin tests for `CONVERTED_ACTIONS` in `apps/aggregator/tests/test_stats.py`
- Contains high-intent actions: `purchase_paid_today`, `contact_sales`, `book_demo`, `start_paid_trial`
- Excludes lower-intent: `bookmark_compare_later`, `start_free_hobby`, `ask_teammate`, `leave`
- Exactly 4 members; is a `frozenset`
- Catches regression from amendment A1 specification changes to the McNemar binarization rule

## Test plan
- [ ] `cd apps/aggregator && .venv/bin/python -m pytest tests/test_stats.py::test_converted_actions_* -v` → 4 passed
- Note: `test_paired_delta_disagreement_true` has a pre-existing scipy version mismatch failure unrelated to these changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)