### PR TITLE
test(llm-adapter): spec-pin LOCAL_CLI_CAPABILITIES flag values

### DIFF
--- a/packages/llm-adapter/test/capabilities.test.ts
+++ b/packages/llm-adapter/test/capabilities.test.ts
@@ -54,4 +54,24 @@ describe('LocalCliProvider — capabilities()', () => {
       }
     }
   });
+
+  // Spec-pin: LOCAL_CLI_CAPABILITIES flag values
+  // These flags gate behavior in the visitor-worker: if idempotency were
+  // true, the worker would send idempotency keys to the provider (which
+  // the local CLI doesn't support, silently breaking retry deduplication).
+  it('idempotency is false (local CLI does not support idempotency keys)', () => {
+    expect(LOCAL_CLI_CAPABILITIES.idempotency).toBe(false);
+  });
+
+  it('zero_retention is false (local CLI may retain context across runs)', () => {
+    expect(LOCAL_CLI_CAPABILITIES.zero_retention).toBe(false);
+  });
+
+  it('structured_output is false (v0.1 uses string output)', () => {
+    expect(LOCAL_CLI_CAPABILITIES.structured_output).toBe(false);
+  });
+
+  it('prompt_caching is false (not yet implemented for local CLI)', () => {
+    expect(LOCAL_CLI_CAPABILITIES.prompt_caching).toBe(false);
+  });
 });


### PR DESCRIPTION
## Summary
- Adds 4 spec-pin tests for `LOCAL_CLI_CAPABILITIES` flag values in `packages/llm-adapter/test/capabilities.test.ts`
- `idempotency=false`, `zero_retention=false`, `structured_output=false`, `prompt_caching=false`
- Previously only checked that flags are boolean types; now pinned to specific values
- If `idempotency` were set `true`, the visitor-worker would try to send idempotency keys to a CLI that doesn't support them

## Test plan
- [ ] `bun run --cwd packages/llm-adapter test test/capabilities.test.ts --run` → 9 passed (4 new + 5 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)