### PR TITLE
test(api): spec-pin SESSION_7_DAYS_SECONDS=604800 and MAGIC_LINK_EXPIRY_MINUTES=30

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -197,3 +197,10 @@ export async function registerAuthRoutes(
     return reply.code(302).redirect('/sign-in');
   });
 }
+
+// Test-only export: session lifetime constants for spec-pin tests.
+export const __test__ = {
+  SESSION_7_DAYS_SECONDS,
+  MAGIC_LINK_EXPIRY_MINUTES,
+  safeRedirect,
+};

--- a/apps/api/test/auth-constants.test.ts
+++ b/apps/api/test/auth-constants.test.ts
@@ -1,0 +1,57 @@
+/**
+ * auth-constants.test.ts — spec-pin tests for auth route constants.
+ *
+ * SESSION_7_DAYS_SECONDS (604800): determines how long a session cookie
+ * is valid. A silent change shortens or extends session lifetime without
+ * the spec mandating it.
+ *
+ * MAGIC_LINK_EXPIRY_MINUTES (30): determines how long a sign-in link
+ * works. The email template explicitly says "30 minutes" — divergence
+ * would be a lie to the user.
+ *
+ * safeRedirect: open-redirect prevention used in two request handlers
+ * (magic-link POST and GET /api/auth/verify). Previously only covered
+ * by Docker-gated AC10/AC11 integration tests.
+ *
+ * Tests:
+ *   1. SESSION_7_DAYS_SECONDS is 604800 (7 × 24 × 60 × 60).
+ *   2. MAGIC_LINK_EXPIRY_MINUTES is 30.
+ *   3. safeRedirect(undefined) → '/dashboard'.
+ *   4. safeRedirect('/valid/path') → '/valid/path'.
+ *   5. safeRedirect('//evil.com') → '/dashboard'.
+ *   6. safeRedirect('https://evil.com') → '/dashboard'.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ } from '../src/routes/auth.js';
+
+const { SESSION_7_DAYS_SECONDS, MAGIC_LINK_EXPIRY_MINUTES, safeRedirect } = __test__;
+
+describe('auth session constants spec-pin', () => {
+  it('SESSION_7_DAYS_SECONDS is 604800 (7 days)', () => {
+    expect(SESSION_7_DAYS_SECONDS).toBe(7 * 24 * 60 * 60);
+    expect(SESSION_7_DAYS_SECONDS).toBe(604800);
+  });
+
+  it('MAGIC_LINK_EXPIRY_MINUTES is 30 (matches email copy)', () => {
+    expect(MAGIC_LINK_EXPIRY_MINUTES).toBe(30);
+  });
+});
+
+describe('safeRedirect (open-redirect prevention)', () => {
+  it('returns /dashboard for undefined input', () => {
+    expect(safeRedirect(undefined)).toBe('/dashboard');
+  });
+
+  it('passes through a valid relative path', () => {
+    expect(safeRedirect('/dashboard/studies')).toBe('/dashboard/studies');
+  });
+
+  it('blocks protocol-relative URLs', () => {
+    expect(safeRedirect('//evil.com')).toBe('/dashboard');
+  });
+
+  it('blocks absolute URLs', () => {
+    expect(safeRedirect('https://evil.com')).toBe('/dashboard');
+  });
+});


### PR DESCRIPTION
## Summary
- Exports `SESSION_7_DAYS_SECONDS`, `MAGIC_LINK_EXPIRY_MINUTES`, `safeRedirect` via `__test__` seam in `routes/auth.ts`
- Creates `apps/api/test/auth-constants.test.ts` with 6 tests
- `SESSION_7_DAYS_SECONDS=604800` (7-day session lifetime) and `MAGIC_LINK_EXPIRY_MINUTES=30` (matches "expires in 30 minutes" email copy)
- `safeRedirect` open-redirect prevention: 4 test cases
- A silent change to session lifetime is invisible in integration tests

## Test plan
- [ ] `bun run --cwd apps/api test test/auth-constants.test.ts --run` → 6 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)