### PR TITLE
test(capture-broker): spec-pin SOCKET_MODE=0o660 (spec §5.13)

### DIFF
--- a/apps/capture-broker/test/server.test.ts
+++ b/apps/capture-broker/test/server.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from 'vitest';
 import { statSync } from 'node:fs';
-import { startBroker, type BrokerHandle } from '../src/server.js';
+import { startBroker, SOCKET_MODE, type BrokerHandle } from '../src/server.js';
 import { inMemoryStorage } from '../src/storage.js';
 import { inMemoryCaptureStore } from '../src/captureStore.js';
 import { BYTE_CAPS } from '../src/byteCaps.js';
@@ -278,5 +278,12 @@ describe('Capture Broker server — spec §5.13 acceptance scenarios', () => {
     expect(ack.ok).toBe(false);
     if (ack.ok) throw new Error('unreachable');
     expect(ack.error).toBe('schema_invalid');
+  });
+});
+
+// Spec-pin: SOCKET_MODE (spec §5.13)
+describe('SOCKET_MODE spec-pin (spec §5.13)', () => {
+  it('SOCKET_MODE is 0o660 (owner+group rw, others none)', () => {
+    expect(SOCKET_MODE).toBe(0o660);
   });
 });


### PR DESCRIPTION
## Summary
- Imports `SOCKET_MODE` export and adds 1 spec-pin test in `apps/capture-broker/test/server.test.ts`
- Asserts `SOCKET_MODE === 0o660` (Unix socket permission: owner+group rw, others none)
- The B1 server test already asserts the actual socket inode mode but hardcodes `0o660`; now the exported constant's value is also directly pinned

## Test plan
- [ ] `bun run --cwd apps/capture-broker test test/server.test.ts --run` → 14 passed (1 new + 13 existing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)