### PR TITLE
test(shared): spec-pin TeamSize literal quartiles {2, 6, 12, 20} (spec §2 #5)

### DIFF
--- a/packages/shared/test/backstory.test.ts
+++ b/packages/shared/test/backstory.test.ts
@@ -2,7 +2,7 @@ import { readFileSync } from 'node:fs';
 import { fileURLToPath } from 'node:url';
 import { dirname, resolve } from 'node:path';
 import { describe, expect, it } from 'vitest';
-import { Backstory } from '../src/backstory.js';
+import { Backstory, TeamSize } from '../src/backstory.js';
 
 const here = dirname(fileURLToPath(import.meta.url));
 const validFixture = JSON.parse(
@@ -18,5 +18,32 @@ describe('Backstory (spec §2 #5 + personas/backstories.md)', () => {
   it('rejects a backstory with a bad enum value', () => {
     const bad = { ...validFixture, managed_postgres: 'mongodb' };
     expect(() => Backstory.parse(bad)).toThrow();
+  });
+});
+
+// ── TeamSize spec-pin (spec §2 #5, personas/backstories.md) ──────────────────
+//
+// TeamSize is z.union([z.literal(2), z.literal(6), z.literal(12), z.literal(20)]).
+// The 4 fixed quartiles encode deliberate ICPs; adding a 5th or changing a value
+// silently changes what backstories the system accepts.
+
+describe('TeamSize spec-pin (spec §2 #5)', () => {
+  it('accepts all four valid literal values: 2, 6, 12, 20', () => {
+    for (const n of [2, 6, 12, 20]) {
+      expect(() => TeamSize.parse(n)).not.toThrow();
+      expect(TeamSize.parse(n)).toBe(n);
+    }
+  });
+
+  it('rejects team sizes not in the allowed set', () => {
+    for (const bad of [0, 1, 3, 5, 7, 10, 11, 15, 25, 50, 100]) {
+      expect(() => TeamSize.parse(bad)).toThrow();
+    }
+  });
+
+  it('rejects non-integer inputs (string, null, undefined)', () => {
+    expect(() => TeamSize.parse('12')).toThrow();
+    expect(() => TeamSize.parse(null)).toThrow();
+    expect(() => TeamSize.parse(undefined)).toThrow();
   });
 });


### PR DESCRIPTION
## Summary
- Adds 3 tests to `packages/shared/test/backstory.test.ts` (5 total, 0 skipped)
- Pins all four valid `TeamSize` literals: 2, 6, 12, 20
- Asserts 11 invalid sizes reject, and non-integer types (string, null, undefined) reject

## Why this matters
`TeamSize` is `z.union([z.literal(2), z.literal(6), z.literal(12), z.literal(20)])` — not an enum with `.options`. Adding a fifth literal would silently widen what backstories the system accepts. The `test/shared-backstory-enum-values` branch covers all the enums but skips this union type.

## Test plan
- [x] `bun run test test/backstory.test.ts` → 5/5 pass (3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)