### PR TITLE
test(aggregator): spec-pin _truncate_to_eight_words cap = 8 words (spec §5.6)

### DIFF
--- a/apps/aggregator/tests/test_labeler.py
+++ b/apps/aggregator/tests/test_labeler.py
@@ -7,7 +7,7 @@ adapter contract (spec §27): a callable `(prompt: str, *, kind: str) -> str`.
 
 from __future__ import annotations
 
-from aggregator.labeler import label_cluster
+from aggregator.labeler import label_cluster, _truncate_to_eight_words
 
 
 class FakeLedger:
@@ -49,6 +49,33 @@ def test_label_cluster_truncates_to_eight_words() -> None:
     out = label_cluster(["a", "b", "c"], llm_caller=llm_caller, ledger=ledger)
     # ≤ 8 words.
     assert len(out.split()) <= 8
+
+
+# ── _truncate_to_eight_words spec-pin (spec §5.6) ────────────────────────────
+# The cap is exactly 8 words — spec §5.6 says "≤8-word label".
+
+def test_truncate_exactly_8_words_unchanged() -> None:
+    s = "pricing is unclear for enterprise customers in Europe"
+    assert _truncate_to_eight_words(s) == s
+    assert len(_truncate_to_eight_words(s).split()) == 8
+
+
+def test_truncate_9_word_input_drops_9th() -> None:
+    s = "this is a nine word label and the extra"
+    result = _truncate_to_eight_words(s)
+    assert len(result.split()) == 8
+    assert result == "this is a nine word label and the"
+
+
+def test_truncate_preserves_input_under_8_words() -> None:
+    s = "only five words here"
+    assert _truncate_to_eight_words(s) == "only five words here"
+
+
+def test_truncate_strips_leading_trailing_whitespace() -> None:
+    s = "  pricing is unclear  "
+    result = _truncate_to_eight_words(s)
+    assert result == "pricing is unclear"
 
 
 def test_label_cluster_records_failed_attempt_on_exception() -> None:


### PR DESCRIPTION
## Summary
- Adds 4 tests to `apps/aggregator/tests/test_labeler.py` (8 total, 0 skipped)
- Pins `_truncate_to_eight_words` contract: 8-word → unchanged, 9-word → first 8, <8-word → unchanged, whitespace stripping

## Why this matters
The existing test only asserted `len(out.split()) <= 8`. Changing the cap from 8 to 10 would pass the existing test but violate spec §5.6 which says "≤8-word label".

## Test plan
- [ ] CI runs in Python 3.12; no heavy deps needed for `_truncate_to_eight_words`

🤖 Generated with [Claude Code](https://claude.com/claude-code)