### PR TITLE
test(api): spec-pin COOKIE_NAME_PROD='__Host-wb_session' + COOKIE_NAME_DEV='wb_session' (spec §5.10)

### DIFF
--- a/apps/api/test/cookie-name-spec-pin.test.ts
+++ b/apps/api/test/cookie-name-spec-pin.test.ts
@@ -1,0 +1,43 @@
+/**
+ * cookie-name-spec-pin.test.ts — spec-pins for session cookie names (spec §5.10).
+ *
+ * COOKIE_NAME_PROD = '__Host-wb_session': the __Host- prefix mandates
+ *   Secure + Path=/ + no Domain= attribute per RFC 6265bis §4.1.3.
+ *   Removing it silently downgrades session cookie security in production.
+ *
+ * COOKIE_NAME_DEV = 'wb_session': the unprefixed name is correct for
+ *   HTTP localhost dev (where Secure cannot apply). The difference between
+ *   these two values is intentional — they must not accidentally match.
+ *
+ * cookieName(): maps 'production' → COOKIE_NAME_PROD, else → COOKIE_NAME_DEV.
+ */
+
+import { describe, expect, it } from 'vitest';
+
+import { COOKIE_NAME_PROD, COOKIE_NAME_DEV, cookieName } from '../src/auth/session.js';
+
+describe('session cookie name spec-pins (spec §5.10)', () => {
+  it('COOKIE_NAME_PROD is "__Host-wb_session"', () => {
+    expect(COOKIE_NAME_PROD).toBe('__Host-wb_session');
+  });
+
+  it('COOKIE_NAME_DEV is "wb_session"', () => {
+    expect(COOKIE_NAME_DEV).toBe('wb_session');
+  });
+
+  it('production and dev names are distinct', () => {
+    expect(COOKIE_NAME_PROD).not.toBe(COOKIE_NAME_DEV);
+  });
+
+  it('cookieName("production") returns COOKIE_NAME_PROD', () => {
+    expect(cookieName('production')).toBe(COOKIE_NAME_PROD);
+  });
+
+  it('cookieName("development") returns COOKIE_NAME_DEV', () => {
+    expect(cookieName('development')).toBe(COOKIE_NAME_DEV);
+  });
+
+  it('cookieName("test") returns COOKIE_NAME_DEV', () => {
+    expect(cookieName('test')).toBe(COOKIE_NAME_DEV);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `apps/api/test/cookie-name-spec-pin.test.ts` (6 tests, 0 skipped)
- Pins `COOKIE_NAME_PROD = '__Host-wb_session'` and `COOKIE_NAME_DEV = 'wb_session'`
- Asserts the two are distinct and `cookieName()` routes 'production' → PROD, everything else → DEV

## Why this matters
The `__Host-` prefix mandates `Secure + Path=/ + no Domain=` per RFC 6265bis §4.1.3. Accidentally using the dev name in production silently removes this protection. The exact strings appear in `auth.test.ts` but are never independently spec-pinned.

## Test plan
- [x] `bun run test test/cookie-name-spec-pin.test.ts` → 6/6 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)