### PR TITLE
test(web): spec-pin CATEGORIES + ROLE_LABEL in ThemeBoard/PersonaGrid (spec §5.18 #6/#7)

### DIFF
--- a/apps/web/components/report/PersonaGrid.tsx
+++ b/apps/web/components/report/PersonaGrid.tsx
@@ -141,3 +141,5 @@ export function PersonaGrid({ personas }: { personas: ReportT['personas'] }) {
     </section>
   );
 }
+
+export const __test__ = { ROLE_LABEL };

--- a/apps/web/components/report/ThemeBoard.tsx
+++ b/apps/web/components/report/ThemeBoard.tsx
@@ -97,3 +97,5 @@ export function ThemeBoard({ board }: { board: ReportT['theme_board'] }) {
     </section>
   );
 }
+
+export const __test__ = { CATEGORIES };

--- a/apps/web/test/report-theme-role-constants.test.ts
+++ b/apps/web/test/report-theme-role-constants.test.ts
@@ -1,0 +1,62 @@
+/**
+ * report-theme-role-constants.test.ts — spec-pins for ThemeBoard + PersonaGrid.
+ *
+ * CATEGORIES (ThemeBoard, spec §5.18 #6):
+ *   4 keys: blockers, objections, confusions, questions.
+ *   Keys must match CLUSTER_TO_THEME values in aggregator/main.py:
+ *   {"unanswered_blockers": "blockers", "objections": "objections",
+ *    "confusions": "confusions", "questions": "questions"}.
+ *   Adding a 5th category without updating the aggregator would render empty.
+ *
+ * ROLE_LABEL (PersonaGrid, spec §5.18 #7):
+ *   2 entries matching RoleArchetype in shared/src/backstory.ts.
+ *   'founder_or_eng_lead' and 'ic_engineer'.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ as themeBoardTest } from '../components/report/ThemeBoard';
+import { __test__ as personaGridTest } from '../components/report/PersonaGrid';
+
+const { CATEGORIES } = themeBoardTest;
+const { ROLE_LABEL } = personaGridTest;
+
+// ── CATEGORIES (spec §5.18 #6) ────────────────────────────────────────────────
+
+describe('CATEGORIES spec-pin (spec §5.18 #6)', () => {
+  it('has exactly 4 theme categories', () => {
+    expect(CATEGORIES).toHaveLength(4);
+  });
+
+  it('contains the exact 4 keys matching CLUSTER_TO_THEME values in aggregator/main.py', () => {
+    const keys = CATEGORIES.map((c) => c.key);
+    expect(new Set(keys)).toEqual(new Set(['blockers', 'objections', 'confusions', 'questions']));
+  });
+
+  it('has a non-empty label for every category', () => {
+    for (const c of CATEGORIES) {
+      expect(c.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('blockers category has label "Blockers"', () => {
+    const blockers = CATEGORIES.find((c) => c.key === 'blockers');
+    expect(blockers?.label).toBe('Blockers');
+  });
+});
+
+// ── ROLE_LABEL (spec §5.18 #7) ────────────────────────────────────────────────
+
+describe('ROLE_LABEL spec-pin (spec §5.18 #7)', () => {
+  it('has exactly 2 role labels matching RoleArchetype in shared/src/backstory.ts', () => {
+    const keys = Object.keys(ROLE_LABEL);
+    expect(new Set(keys)).toEqual(new Set(['founder_or_eng_lead', 'ic_engineer']));
+  });
+
+  it('founder_or_eng_lead → "founder / eng lead"', () => {
+    expect(ROLE_LABEL['founder_or_eng_lead']).toBe('founder / eng lead');
+  });
+
+  it('ic_engineer → "IC engineer"', () => {
+    expect(ROLE_LABEL['ic_engineer']).toBe('IC engineer');
+  });
+});


### PR DESCRIPTION
## Summary
- Exports `__test__ = { CATEGORIES }` from `ThemeBoard.tsx`
- Exports `__test__ = { ROLE_LABEL }` from `PersonaGrid.tsx`
- Adds `apps/web/test/report-theme-role-constants.test.ts` (7 tests, 0 skipped)

## Key cross-language constraint
`CATEGORIES` keys `{blockers, objections, confusions, questions}` must match the values of `CLUSTER_TO_THEME` in `aggregator/main.py`. Adding a 5th category without updating the aggregator would render empty charts.

`ROLE_LABEL` keys must match `RoleArchetype` enum in `shared/src/backstory.ts` (`founder_or_eng_lead`, `ic_engineer`).

## Test plan
- [x] `bun run test test/report-theme-role-constants.test.ts` → 7/7 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)