### PR TITLE
test(capture-worker): spec-pin SUPPORTED_RUNTIMES={'netns','firecracker'} (spec §5.13)

### DIFF
--- a/apps/capture-worker/src/runtime.ts
+++ b/apps/capture-worker/src/runtime.ts
@@ -168,3 +168,5 @@ export async function runCapture(
 // type RunWithNetnsOpts } from './runtime.js'` without reaching into
 // run-with-netns.ts directly.
 export type { RunWithNetnsOpts, RunWithNetnsResult };
+
+export const __test__ = { SUPPORTED_RUNTIMES };

--- a/apps/capture-worker/test/runtime.test.ts
+++ b/apps/capture-worker/test/runtime.test.ts
@@ -23,7 +23,10 @@ import {
   RuntimeNotImplementedError,
   runCapture,
   selectRuntime,
+  __test__,
 } from '../src/runtime.js';
+
+const { SUPPORTED_RUNTIMES } = __test__;
 
 let tmpRoot = '';
 let shimDir = '';
@@ -182,5 +185,22 @@ describe('runCapture dispatcher', () => {
     });
 
     expect(result.status).toBe('ok');
+  });
+});
+
+// ── SUPPORTED_RUNTIMES spec-pin (spec §5.13) ─────────────────────────────────
+
+describe('SUPPORTED_RUNTIMES spec-pin (spec §5.13)', () => {
+  it('contains exactly 2 runtimes: netns and firecracker', () => {
+    expect(new Set(SUPPORTED_RUNTIMES)).toEqual(new Set(['netns', 'firecracker']));
+    expect(SUPPORTED_RUNTIMES).toHaveLength(2);
+  });
+
+  it('netns is in SUPPORTED_RUNTIMES (current production runtime)', () => {
+    expect(SUPPORTED_RUNTIMES).toContain('netns');
+  });
+
+  it('firecracker is in SUPPORTED_RUNTIMES (v0.2 seam, issue #116)', () => {
+    expect(SUPPORTED_RUNTIMES).toContain('firecracker');
   });
 });


### PR DESCRIPTION
## Summary
- Exports `__test__ = { SUPPORTED_RUNTIMES }` from `runtime.ts`
- Adds 3 tests to `apps/capture-worker/test/runtime.test.ts` (14 total, 0 skipped)
- Pins exact set `{'netns', 'firecracker'}` + individual membership tests

## Why this matters
`SUPPORTED_RUNTIMES` controls which values `WILLBUY_CAPTURE_RUNTIME` accepts. Adding a 3rd runtime without tests could accidentally bypass the `RuntimeNotImplementedError` guard. The `firecracker` entry is currently a stub seam (issue #116) — its presence here documents that it's intentional, not a mistake.

## Test plan
- [x] `bun run test test/runtime.test.ts` → 14/14 pass (3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)