### PR TITLE
test(visitor-worker): spec-pin PRIOR_BAD_OUTPUT_MARKER sentinel strings (spec §2 #14)

### DIFF
--- a/apps/visitor-worker/test/runVisit.schemaRepair.test.ts
+++ b/apps/visitor-worker/test/runVisit.schemaRepair.test.ts
@@ -76,3 +76,26 @@ describe('runVisit — acceptance #2: invalid then valid JSON', () => {
     expect(secondCall.logicalRequestKey).not.toBe(firstCall.logicalRequestKey);
   });
 });
+
+// ── PRIOR_BAD_OUTPUT_MARKER spec-pin (spec §2 #14) ───────────────────────────
+//
+// The exact sentinel strings are the cross-cutting contract between:
+//   - prompt.ts  (embeds them in the repair tail)
+//   - visitor.ts (looks for them to detect the repair section)
+//   - tests      (grep on them to assert user-role placement)
+// Changing either value silently breaks the repair-tail assembly without
+// any other test failing.
+
+describe('PRIOR_BAD_OUTPUT_MARKER spec-pin (spec §2 #14)', () => {
+  it('PRIOR_BAD_OUTPUT_MARKER is "PRIOR_BAD_OUTPUT_BEGIN"', () => {
+    expect(PRIOR_BAD_OUTPUT_MARKER).toBe('PRIOR_BAD_OUTPUT_BEGIN');
+  });
+
+  it('PRIOR_BAD_OUTPUT_END_MARKER is "PRIOR_BAD_OUTPUT_END"', () => {
+    expect(PRIOR_BAD_OUTPUT_END_MARKER).toBe('PRIOR_BAD_OUTPUT_END');
+  });
+
+  it('the two markers are distinct', () => {
+    expect(PRIOR_BAD_OUTPUT_MARKER).not.toBe(PRIOR_BAD_OUTPUT_END_MARKER);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds 3 tests to `apps/visitor-worker/test/runVisit.schemaRepair.test.ts` (4 total, 0 skipped)
- Pins `PRIOR_BAD_OUTPUT_MARKER = 'PRIOR_BAD_OUTPUT_BEGIN'`
- Pins `PRIOR_BAD_OUTPUT_END_MARKER = 'PRIOR_BAD_OUTPUT_END'`
- Asserts the two are distinct

## Why this matters
These sentinel strings are the cross-cutting contract between `prompt.ts` (which embeds them in the repair tail) and `visitor.ts` (which greps on them to detect the repair section). The existing tests only used `.toContain()` — changing the value would still pass them but break repair-tail parsing.

## Test plan
- [x] `bun run test test/runVisit.schemaRepair.test.ts` → 4/4 pass (3 new)

🤖 Generated with [Claude Code](https://claude.com/claude-code)