### PR TITLE
test(web): spec-pin STATUS_LABELS + TERMINAL + POLL_INTERVAL_MS

### DIFF
--- a/apps/web/app/dashboard/studies/[id]/page.tsx
+++ b/apps/web/app/dashboard/studies/[id]/page.tsx
@@ -86,6 +86,8 @@ export const PROGRESS_CLASSES = [
   'w-full',
 ] as const;
 
+export const __test__ = { STATUS_LABELS, TERMINAL, POLL_INTERVAL_MS };
+
 export function progressClass(pct: number): string {
   // Clamp [0, 100] then round to nearest twelfth (13 buckets: 0..12).
   const clamped = Math.max(0, Math.min(100, pct));

--- a/apps/web/test/study-status-labels.test.ts
+++ b/apps/web/test/study-status-labels.test.ts
@@ -1,0 +1,60 @@
+/**
+ * study-status-labels.test.ts — spec-pins for STATUS_LABELS and TERMINAL.
+ *
+ * STATUS_LABELS maps all 6 StudyStatus values to human-readable strings.
+ * If a 7th status is added to STUDY_STATUSES (api-client.ts) but not to
+ * STATUS_LABELS, the UI silently renders 'undefined' on that status.
+ *
+ * TERMINAL = ['ready', 'failed'] — polling stops when status is in this set.
+ * Removing 'ready' would cause the status page to keep polling forever after
+ * a study completes.
+ *
+ * POLL_INTERVAL_MS = 5_000 — the study status page polls every 5 seconds.
+ * Changing this without updating the study-poll test could silently break SLO.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { STUDY_STATUSES } from '../lib/api-client';
+import { __test__ } from '../app/dashboard/studies/[id]/page';
+
+const { STATUS_LABELS, TERMINAL, POLL_INTERVAL_MS } = __test__;
+
+describe('STATUS_LABELS spec-pin (StudyStatus display strings)', () => {
+  it('has a label for every STUDY_STATUSES entry', () => {
+    for (const status of STUDY_STATUSES) {
+      expect(STATUS_LABELS[status]).toBeTruthy();
+    }
+  });
+
+  it('has exactly 6 entries (one per StudyStatus)', () => {
+    expect(Object.keys(STATUS_LABELS)).toHaveLength(6);
+  });
+
+  it('"ready" → "Ready"', () => {
+    expect(STATUS_LABELS['ready']).toBe('Ready');
+  });
+
+  it('"failed" → "Failed"', () => {
+    expect(STATUS_LABELS['failed']).toBe('Failed');
+  });
+});
+
+describe('TERMINAL spec-pin (polling stop condition)', () => {
+  it('contains "ready" — polling stops when study completes', () => {
+    expect(TERMINAL).toContain('ready');
+  });
+
+  it('contains "failed" — polling stops when study fails', () => {
+    expect(TERMINAL).toContain('failed');
+  });
+
+  it('has exactly 2 terminal statuses', () => {
+    expect(TERMINAL).toHaveLength(2);
+  });
+});
+
+describe('POLL_INTERVAL_MS spec-pin', () => {
+  it('is 5_000 (5-second polling interval)', () => {
+    expect(POLL_INTERVAL_MS).toBe(5_000);
+  });
+});


### PR DESCRIPTION
## Summary
- Pins the 6-entry `STATUS_LABELS` record — catches any new `StudyStatus` value added to `STUDY_STATUSES` without a corresponding label
- Pins `TERMINAL = ['ready', 'failed']` (length + members) — removing 'ready' would cause the status page to poll forever after a study completes
- Pins `POLL_INTERVAL_MS = 5_000` — a silent change here would break SLO guarantees without surfacing in other tests
- Adds `__test__` export seam to `apps/web/app/dashboard/studies/[id]/page.tsx` so the private constants are testable

## Test plan
- [x] `bun run test --reporter=verbose` in `apps/web` — 8 new assertions all pass
- [x] No changes to public API or component behavior

🤖 Generated with [Claude Code](https://claude.com/claude-code)