### PR TITLE
test(api): spec-pin domain probe timeout + report cookie TTL + study pricing

### DIFF
--- a/apps/api/src/routes/domains.ts
+++ b/apps/api/src/routes/domains.ts
@@ -122,6 +122,8 @@ export function __test_resetProbes(): void {
 const PROBE_TIMEOUT_MS = 5000;
 const TOKEN_LENGTH = 22;
 
+export const __test__ = { PROBE_TIMEOUT_MS, TOKEN_LENGTH };
+
 // ─── Schemas ─────────────────────────────────────────────────────────────────
 
 const CreateDomainBody = z.object({

--- a/apps/api/src/routes/reports.ts
+++ b/apps/api/src/routes/reports.ts
@@ -45,6 +45,8 @@ import type { Pool } from 'pg';
 // "Two-tier TTL" note above. Sprint 3 retro audit finding F2.
 const MAX_COOKIE_SECONDS = 2 * 60 * 60; // 2 hours per spec §2 #20
 
+export const __test__ = { MAX_COOKIE_SECONDS };
+
 // ---------------------------------------------------------------------------
 // Crypto helpers
 // ---------------------------------------------------------------------------

--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -46,6 +46,8 @@ const CENTS_PER_VISIT_EST = 5;
 // Once-per-study cost for the cluster_label LLM call per spec §5.5.
 const CENTS_PER_STUDY_CLUSTER_LABEL = 3;
 
+export const __test__ = { CENTS_PER_VISIT_EST, CENTS_PER_STUDY_CLUSTER_LABEL };
+
 // Preset ICP ids from spec §2 #9.
 const ICP_PRESETS = [
   'saas_founder_pre_pmf',

--- a/apps/api/test/domain-reports-studies-pin.test.ts
+++ b/apps/api/test/domain-reports-studies-pin.test.ts
@@ -1,0 +1,55 @@
+/**
+ * domain-reports-studies-pin.test.ts — spec-pins for domain verification,
+ * report cookie, and study pricing constants.
+ *
+ * PROBE_TIMEOUT_MS=5000, TOKEN_LENGTH=22 (domains.ts):
+ *   Lowering PROBE_TIMEOUT_MS causes spurious probe failures on slow DNS.
+ *   TOKEN_LENGTH=22 gives 22×log2(62) ≈ 131 bits of entropy for the
+ *   verification token — halving it would drop below the 64-bit floor.
+ *
+ * MAX_COOKIE_SECONDS=7200 (reports.ts):
+ *   Report share-token cookies have a 2-hour TTL per spec §2 #20 (Sprint 3
+ *   retro finding F2). Shortening it silently breaks sessions for users on
+ *   long reads; lengthening it violates the spec maximum.
+ *
+ * CENTS_PER_VISIT_EST=5, CENTS_PER_STUDY_CLUSTER_LABEL=3 (studies.ts):
+ *   These drive the cost estimate shown at study-creation time (spec §5.5).
+ *   Changing them without a billing-model review silently misquotes prices
+ *   to paying customers.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ as domainsTest } from '../src/routes/domains.js';
+import { __test__ as reportsTest } from '../src/routes/reports.js';
+import { __test__ as studiesTest } from '../src/routes/studies.js';
+
+const { PROBE_TIMEOUT_MS, TOKEN_LENGTH } = domainsTest;
+const { MAX_COOKIE_SECONDS } = reportsTest;
+const { CENTS_PER_VISIT_EST, CENTS_PER_STUDY_CLUSTER_LABEL } = studiesTest;
+
+describe('Domain verification constants spec-pin (domains.ts)', () => {
+  it('PROBE_TIMEOUT_MS is 5000 ms (5 seconds)', () => {
+    expect(PROBE_TIMEOUT_MS).toBe(5_000);
+  });
+
+  it('TOKEN_LENGTH is 22 (≈131 bits of entropy in base62)', () => {
+    expect(TOKEN_LENGTH).toBe(22);
+  });
+});
+
+describe('Report cookie constant spec-pin (reports.ts)', () => {
+  it('MAX_COOKIE_SECONDS is 7200 (2 hours per spec §2 #20)', () => {
+    expect(MAX_COOKIE_SECONDS).toBe(7_200);
+    expect(MAX_COOKIE_SECONDS).toBe(2 * 60 * 60);
+  });
+});
+
+describe('Study pricing constants spec-pin (studies.ts)', () => {
+  it('CENTS_PER_VISIT_EST is 5 (5¢ per visit per spec §5.5)', () => {
+    expect(CENTS_PER_VISIT_EST).toBe(5);
+  });
+
+  it('CENTS_PER_STUDY_CLUSTER_LABEL is 3 (3¢ once-per-study)', () => {
+    expect(CENTS_PER_STUDY_CLUSTER_LABEL).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Pins `PROBE_TIMEOUT_MS=5000` (domain DNS probe; lowering causes spurious failures on slow resolvers) and `TOKEN_LENGTH=22` (≈131 bits entropy; halving drops below security floor)
- Pins `MAX_COOKIE_SECONDS=7200` (report share-token cookie 2-hour TTL per spec §2 #20 / Sprint-3 retro finding F2; shortening breaks active long-read sessions)
- Pins `CENTS_PER_VISIT_EST=5` and `CENTS_PER_STUDY_CLUSTER_LABEL=3` (study creation cost model per spec §5.5; silently changing misquotes prices to paying customers)
- Adds `__test__` seams to `domains.ts`, `reports.ts`, `studies.ts`

## Test plan
- [x] 5/5 assertions pass locally (`bun run test` in `apps/api`)
- [x] No public API or behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)