### PR TITLE
test(visitor-worker): spec-pin MAX_OUTPUT_TOKENS + MAX_REPAIR_GENERATION

### DIFF
--- a/apps/visitor-worker/src/visitor.ts
+++ b/apps/visitor-worker/src/visitor.ts
@@ -69,6 +69,8 @@ const MAX_OUTPUT_TOKENS = 800;
 // that's 3 chat() calls maximum per visit (repair_generation = 0, 1, 2).
 const MAX_REPAIR_GENERATION = 2;
 
+export const __test__ = { MAX_OUTPUT_TOKENS, MAX_REPAIR_GENERATION };
+
 // Spec §5.15 line 253 + §5.1 step 7 line 131 + §2 #15:
 //   logical_request_key = sha256(
 //     visit_id || provider || model || request_kind || repair_generation

--- a/apps/visitor-worker/test/visitConstants.test.ts
+++ b/apps/visitor-worker/test/visitConstants.test.ts
@@ -1,0 +1,38 @@
+/**
+ * visitConstants.test.ts — spec-pins for MAX_OUTPUT_TOKENS and
+ * MAX_REPAIR_GENERATION in visitor.ts.
+ *
+ * MAX_OUTPUT_TOKENS=800 (spec §2 #15):
+ *   Each visitor LLM call is capped at 800 output tokens. Raising it increases
+ *   cost without spec approval; lowering it risks truncating valid JSON output
+ *   (the VisitorOutput schema is ~400 tokens at minimum) and causing spurious
+ *   schema failures.
+ *
+ * MAX_REPAIR_GENERATION=2 (spec §2 #14):
+ *   Schema repairs are attempted up to 2 times (repair_generation 0→1→2),
+ *   giving 3 chat() calls maximum per visit. Setting this to 1 gives up after
+ *   one repair attempt; setting it to 0 disables schema repair entirely.
+ *   The total-calls-per-visit invariant (MAX_REPAIR_GENERATION + 1) is also
+ *   pinned to catch a drift between the constant and the prose comment.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ } from '../src/visitor.js';
+
+const { MAX_OUTPUT_TOKENS, MAX_REPAIR_GENERATION } = __test__;
+
+describe('MAX_OUTPUT_TOKENS spec-pin (visitor.ts — spec §2 #15)', () => {
+  it('is 800', () => {
+    expect(MAX_OUTPUT_TOKENS).toBe(800);
+  });
+});
+
+describe('MAX_REPAIR_GENERATION spec-pin (visitor.ts — spec §2 #14)', () => {
+  it('is 2 (allows 2 repair attempts after initial call)', () => {
+    expect(MAX_REPAIR_GENERATION).toBe(2);
+  });
+
+  it('total chat() calls per visit is MAX_REPAIR_GENERATION + 1 = 3', () => {
+    expect(MAX_REPAIR_GENERATION + 1).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Pins `MAX_OUTPUT_TOKENS=800` (spec §2 #15): raising increases LLM cost without spec approval; lowering risks truncating valid `VisitorOutput` JSON and causing spurious schema-repair failures
- Pins `MAX_REPAIR_GENERATION=2` (spec §2 #14): 2 repair attempts after initial call = 3 `chat()` calls maximum per visit; includes derived assertion `MAX_REPAIR_GENERATION + 1 === 3`
- Adds `__test__` seam to `visitor.ts`

## Test plan
- [x] 3/3 assertions pass locally (`bun run test` in `apps/visitor-worker`)
- [x] No public API or behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)