### PR TITLE
test(api+log): spec-pin ICP_PRESETS + DEFAULT_LOG_DIR

### DIFF
--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -55,6 +55,8 @@ const ICP_PRESETS = [
   'fintech_ops_buyer',
 ] as const;
 
+export const __test__ = { ICP_PRESETS };
+
 const IcpPresetSchema = z.object({
   preset_id: z.enum(ICP_PRESETS),
 });

--- a/apps/api/test/icp-presets-pin.test.ts
+++ b/apps/api/test/icp-presets-pin.test.ts
@@ -1,0 +1,40 @@
+/**
+ * icp-presets-pin.test.ts — spec-pin for ICP_PRESETS in studies.ts.
+ *
+ * ICP_PRESETS are the 5 preset ICP (Ideal Customer Profile) ids from spec §2 #9.
+ * These strings are used in the Zod schema for POST /studies — adding or
+ * removing a preset silently changes which studies existing API clients can
+ * create. Renaming any id (e.g. 'shopify_merchant' → 'shopify') would return
+ * 422 for clients using the old id.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ } from '../src/routes/studies.js';
+
+const { ICP_PRESETS } = __test__;
+
+describe('ICP_PRESETS spec-pin (studies.ts — spec §2 #9)', () => {
+  it('has exactly 5 presets', () => {
+    expect(ICP_PRESETS).toHaveLength(5);
+  });
+
+  it('contains "saas_founder_pre_pmf"', () => {
+    expect(ICP_PRESETS).toContain('saas_founder_pre_pmf');
+  });
+
+  it('contains "saas_founder_post_pmf"', () => {
+    expect(ICP_PRESETS).toContain('saas_founder_post_pmf');
+  });
+
+  it('contains "shopify_merchant"', () => {
+    expect(ICP_PRESETS).toContain('shopify_merchant');
+  });
+
+  it('contains "devtools_engineer"', () => {
+    expect(ICP_PRESETS).toContain('devtools_engineer');
+  });
+
+  it('contains "fintech_ops_buyer"', () => {
+    expect(ICP_PRESETS).toContain('fintech_ops_buyer');
+  });
+});

--- a/packages/log/src/index.ts
+++ b/packages/log/src/index.ts
@@ -49,6 +49,8 @@ export interface BuildLoggerOptions {
 
 const DEFAULT_LOG_DIR = '/var/log/willbuy';
 
+export const __test__ = { DEFAULT_LOG_DIR };
+
 function shouldWriteToFile(): boolean {
   if (process.env['WILLBUY_LOG_TO_FILE'] === '1') return true;
   if (process.env['WILLBUY_LOG_TO_FILE'] === '0') return false;

--- a/packages/log/test/log-dir-pin.test.ts
+++ b/packages/log/test/log-dir-pin.test.ts
@@ -1,0 +1,20 @@
+/**
+ * log-dir-pin.test.ts — spec-pin for DEFAULT_LOG_DIR in packages/log/src/index.ts.
+ *
+ * DEFAULT_LOG_DIR='/var/log/willbuy' is the production log destination.
+ * Changing it redirects log output in production without any code change
+ * visible at the call site. The infra logrotate config (infra/observability/
+ * logrotate.conf) also targets this path — a mismatch causes rotation to stop
+ * working and disk to fill.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ } from '../src/index.js';
+
+const { DEFAULT_LOG_DIR } = __test__;
+
+describe('DEFAULT_LOG_DIR spec-pin (packages/log/src/index.ts)', () => {
+  it('is "/var/log/willbuy"', () => {
+    expect(DEFAULT_LOG_DIR).toBe('/var/log/willbuy');
+  });
+});


### PR DESCRIPTION
## Summary
- Pins `ICP_PRESETS` (studies.ts, spec §2 #9): 5 preset ICP ids used in `POST /studies` Zod validation; renaming any silently breaks existing API clients, adding one without spec approval extends the surface; pins all 5 ids + length
- Pins `DEFAULT_LOG_DIR='/var/log/willbuy'` (packages/log): production log destination; changing it redirects logs in prod without a visible call-site diff, and mismatches `infra/observability/logrotate.conf` which targets the same path
- Adds `__test__` seams to `studies.ts` and `packages/log/src/index.ts`

## Test plan
- [x] 6/6 ICP preset assertions pass locally (`bun run test` in `apps/api`)
- [x] 1/1 log dir assertion passes locally (`bun run test` in `packages/log`)
- [x] No public API or behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)