### PR TITLE
test(shared): spec-pin PAID_TIERS membership

### DIFF
--- a/packages/shared/test/scoring.test.ts
+++ b/packages/shared/test/scoring.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { NEXT_ACTION_WEIGHTS, scoreVisit } from '../src/scoring.js';
+import { NEXT_ACTION_WEIGHTS, PAID_TIERS, scoreVisit } from '../src/scoring.js';
 import type { VisitorOutputT } from '../src/visitor.js';
 
 const baseVisit: VisitorOutputT = {
@@ -88,5 +88,35 @@ describe('scoreVisit (growth/ab/pricing-page-2026apr/scoring.md mirror)', () => 
       next_action: 'not_in_enum',
     } as unknown as VisitorOutputT;
     expect(scoreVisit(malformed)).toBe(0.0);
+  });
+});
+
+describe('PAID_TIERS spec-pin (packages/shared/src/scoring.ts)', () => {
+  it('has exactly 4 entries', () => {
+    expect(PAID_TIERS.size).toBe(4);
+  });
+
+  it('contains "express"', () => {
+    expect(PAID_TIERS.has('express')).toBe(true);
+  });
+
+  it('contains "starter"', () => {
+    expect(PAID_TIERS.has('starter')).toBe(true);
+  });
+
+  it('contains "scale"', () => {
+    expect(PAID_TIERS.has('scale')).toBe(true);
+  });
+
+  it('contains "enterprise"', () => {
+    expect(PAID_TIERS.has('enterprise')).toBe(true);
+  });
+
+  it('"hobby" is NOT a paid tier (free plan)', () => {
+    expect(PAID_TIERS.has('hobby')).toBe(false);
+  });
+
+  it('"none" is NOT a paid tier', () => {
+    expect(PAID_TIERS.has('none')).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary
- Extends `scoring.test.ts` with 7 `PAID_TIERS` assertions: size=4, positive for `express`/`starter`/`scale`/`enterprise`, and **negative tests** for `hobby` (must NOT be paid — triggers the free bump path `0.0` for `bookmark_compare_later`) and `none`
- `PAID_TIERS` was only checked via `expect(shared.PAID_TIERS).toBeDefined()` in `index.test.ts`; the actual members were unverified

## Test plan
- [x] 19/19 assertions pass locally (12 pre-existing + 7 new, `bun run test` in `packages/shared`)
- [x] No source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)