### PR TITLE
test(log): spec-pin MAX_FIELD_BYTES=8192 (8 KiB per spec §5.12)

### DIFF
--- a/packages/log/test/oversize.test.ts
+++ b/packages/log/test/oversize.test.ts
@@ -20,6 +20,13 @@ import { buildLogger } from '../src/index.js';
 import { LogPayloadOversizeError, MAX_FIELD_BYTES } from '../src/errors.js';
 import { redact } from '../src/redactor.js';
 
+describe('MAX_FIELD_BYTES spec-pin (packages/log/src/errors.ts — spec §5.12)', () => {
+  it('is 8192 (8 KiB per spec §5.12)', () => {
+    expect(MAX_FIELD_BYTES).toBe(8_192);
+    expect(MAX_FIELD_BYTES).toBe(8 * 1024);
+  });
+});
+
 describe('TDD #4 — oversize string fields throw LogPayloadOversizeError', () => {
   it('redact() throws on a single string field > MAX_FIELD_BYTES', () => {
     const big = 'x'.repeat(MAX_FIELD_BYTES + 1);


### PR DESCRIPTION
## Summary
- Extends `oversize.test.ts` with a `MAX_FIELD_BYTES` spec-pin: the existing tests only use `MAX_FIELD_BYTES + N` (relative comparisons); the literal value `8192` was never asserted
- Dual expression: `expect(MAX_FIELD_BYTES).toBe(8_192)` and `expect(MAX_FIELD_BYTES).toBe(8 * 1024)` — catches both accidental value changes and silent unit changes (e.g. `1024 * 1024`)
- All 6 pre-existing assertions still pass (7 total)

## Test plan
- [x] 7/7 assertions pass locally (`bun run test` in `packages/log`)
- [x] No source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)