### PR TITLE
test(capture-worker+visitor-worker): spec-pin broker client constants + repair prompt markers

### DIFF
--- a/apps/capture-worker/src/broker-client.ts
+++ b/apps/capture-worker/src/broker-client.ts
@@ -70,6 +70,8 @@ export type BrokerClientOpts = {
 const DEFAULT_SOCKET_PATH = '/run/willbuy/broker.sock';
 const DEFAULT_TIMEOUT_MS = 30_000;
 
+export const __test__ = { HEADER_BYTES, DEFAULT_SOCKET_PATH, DEFAULT_TIMEOUT_MS };
+
 /**
  * Send a single capture artifact message to the broker and await the ack.
  *

--- a/apps/capture-worker/test/brokerClientConstants.test.ts
+++ b/apps/capture-worker/test/brokerClientConstants.test.ts
@@ -1,0 +1,40 @@
+/**
+ * brokerClientConstants.test.ts — spec-pins for HEADER_BYTES, DEFAULT_SOCKET_PATH,
+ * and DEFAULT_TIMEOUT_MS in apps/capture-worker/src/broker-client.ts.
+ *
+ * HEADER_BYTES=4: must match apps/capture-broker/src/framing.ts exactly.
+ * A mismatch causes the broker to misparse the length prefix and corrupt
+ * every message. The comment in broker-client.ts calls this out explicitly.
+ *
+ * DEFAULT_SOCKET_PATH='/run/willbuy/broker.sock': the Unix socket path
+ * hardcoded in the systemd unit (ExecStart). Changing one without the other
+ * silently breaks the capture-worker → broker IPC.
+ *
+ * DEFAULT_TIMEOUT_MS=30000: connection + read timeout for broker calls.
+ * Lowering it causes spurious timeouts under load; raising it means a stuck
+ * broker blocks the visit for longer before the worker times out.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ } from '../src/broker-client.js';
+
+const { HEADER_BYTES, DEFAULT_SOCKET_PATH, DEFAULT_TIMEOUT_MS } = __test__;
+
+describe('HEADER_BYTES spec-pin (broker-client.ts — must mirror framing.ts)', () => {
+  it('is 4 (big-endian UInt32 length prefix)', () => {
+    expect(HEADER_BYTES).toBe(4);
+  });
+});
+
+describe('DEFAULT_SOCKET_PATH spec-pin (broker-client.ts)', () => {
+  it('is "/run/willbuy/broker.sock"', () => {
+    expect(DEFAULT_SOCKET_PATH).toBe('/run/willbuy/broker.sock');
+  });
+});
+
+describe('DEFAULT_TIMEOUT_MS spec-pin (broker-client.ts)', () => {
+  it('is 30000 ms (30 seconds)', () => {
+    expect(DEFAULT_TIMEOUT_MS).toBe(30_000);
+    expect(DEFAULT_TIMEOUT_MS).toBe(30 * 1000);
+  });
+});

--- a/apps/visitor-worker/test/priorBadOutputMarkers.test.ts
+++ b/apps/visitor-worker/test/priorBadOutputMarkers.test.ts
@@ -1,0 +1,46 @@
+/**
+ * priorBadOutputMarkers.test.ts — spec-pins for PRIOR_BAD_OUTPUT_MARKER and
+ * PRIOR_BAD_OUTPUT_END_MARKER in apps/visitor-worker/src/prompt.ts.
+ *
+ * These delimiter strings wrap the prior bad LLM output in the schema-repair
+ * dynamic tail (spec §2 #14 / §5.15). The visitor-worker acceptance test in
+ * runVisit.schemaRepair.test.ts verifies that the dynamic tail CONTAINS the
+ * markers, but it imports the constants themselves — so if both the source
+ * constant and the test import the same variable, a rename is transparent
+ * to the test.
+ *
+ * Pinning the exact string values ensures:
+ *   - The BEGIN marker is the literal "PRIOR_BAD_OUTPUT_BEGIN"
+ *   - The END marker is the literal "PRIOR_BAD_OUTPUT_END"
+ *   - Renaming either silently breaks any external system that parses the
+ *     repair prompt expecting these delimiters
+ */
+
+import { describe, expect, it } from 'vitest';
+import {
+  PRIOR_BAD_OUTPUT_MARKER,
+  PRIOR_BAD_OUTPUT_END_MARKER,
+} from '../src/prompt.js';
+
+describe('PRIOR_BAD_OUTPUT_MARKER spec-pin (visitor-worker/src/prompt.ts)', () => {
+  it('is "PRIOR_BAD_OUTPUT_BEGIN"', () => {
+    expect(PRIOR_BAD_OUTPUT_MARKER).toBe('PRIOR_BAD_OUTPUT_BEGIN');
+  });
+});
+
+describe('PRIOR_BAD_OUTPUT_END_MARKER spec-pin (visitor-worker/src/prompt.ts)', () => {
+  it('is "PRIOR_BAD_OUTPUT_END"', () => {
+    expect(PRIOR_BAD_OUTPUT_END_MARKER).toBe('PRIOR_BAD_OUTPUT_END');
+  });
+});
+
+describe('marker pair consistency', () => {
+  it('BEGIN marker does not equal END marker', () => {
+    expect(PRIOR_BAD_OUTPUT_MARKER).not.toBe(PRIOR_BAD_OUTPUT_END_MARKER);
+  });
+
+  it('both markers contain "PRIOR_BAD_OUTPUT" as a common prefix', () => {
+    expect(PRIOR_BAD_OUTPUT_MARKER).toContain('PRIOR_BAD_OUTPUT');
+    expect(PRIOR_BAD_OUTPUT_END_MARKER).toContain('PRIOR_BAD_OUTPUT');
+  });
+});


### PR DESCRIPTION
## Summary
**capture-worker/broker-client.ts:**
- Pins `HEADER_BYTES=4`: must mirror `framing.ts` in `capture-broker`; a mismatch corrupts every broker message (length prefix is parsed with the wrong size)
- Pins `DEFAULT_SOCKET_PATH='/run/willbuy/broker.sock'`: matches the `systemd` `ExecStart` path; changing one without the other silently breaks capture-worker → broker IPC
- Pins `DEFAULT_TIMEOUT_MS=30000`: dual expression `30 × 1000` guards against silent unit change
- Adds `__test__` seam to `broker-client.ts`

**visitor-worker/src/prompt.ts:**
- Pins `PRIOR_BAD_OUTPUT_MARKER='PRIOR_BAD_OUTPUT_BEGIN'` and `PRIOR_BAD_OUTPUT_END_MARKER='PRIOR_BAD_OUTPUT_END'`: the schema-repair acceptance test imports these constants for `.toContain()` checks, so a rename is transparent to the test — only a literal value pin catches it
- Adds pair consistency assertion: `BEGIN ≠ END`, both share `"PRIOR_BAD_OUTPUT"` prefix

## Test plan
- [x] 3/3 assertions pass in `apps/capture-worker`
- [x] 4/4 assertions pass in `apps/visitor-worker`
- [x] No behavior changes; `broker-client.ts` seam is the only source change

🤖 Generated with [Claude Code](https://claude.com/claude-code)