### PR TITLE
test(capture-broker): spec-pin BYTE_CAPS — MESSAGE_BYTES 32 MiB, A11Y_TREE_BYTES 10 MiB, SCREENSHOT_BYTES 5 MiB

### DIFF
--- a/apps/capture-broker/test/byte-caps-pin.test.ts
+++ b/apps/capture-broker/test/byte-caps-pin.test.ts
@@ -1,0 +1,54 @@
+/**
+ * byte-caps-pin.test.ts — spec-pins for BYTE_CAPS in capture-broker/byteCaps.ts.
+ *
+ * Spec §5.13 + §2 #6: byte caps are enforced AFTER schema parse, BEFORE
+ * redaction and persistence. The broker rejects payloads that exceed these
+ * limits without allocating the decoded buffer (it estimates decoded length
+ * from base64 length using floor(len*3/4) - padding).
+ *
+ * MESSAGE_BYTES = 32 MiB: the maximum single Unix-socket message envelope.
+ * Raising it allows larger attack payloads through; lowering it would reject
+ * legitimate large a11y trees before the field-level cap fires.
+ *
+ * A11Y_TREE_BYTES = 10 MiB: decoded a11y-tree cap per spec §5.13.
+ * The existing server.test.ts uses A11Y_TREE_BYTES + 1024 as a test value —
+ * the literal 10 MiB was never directly asserted.
+ *
+ * SCREENSHOT_BYTES = 5 MiB: decoded screenshot cap. Raising it increases
+ * storage costs and S3 PUT latency for every successful capture.
+ *
+ * Cross-checks: A11Y cap ≤ MESSAGE cap, SCREENSHOT cap ≤ MESSAGE cap,
+ * and SCREENSHOT ≤ A11Y (screenshots are typically smaller than trees).
+ */
+
+import { describe, expect, it } from 'vitest';
+import { BYTE_CAPS } from '../src/byteCaps.js';
+
+describe('BYTE_CAPS spec-pin (byteCaps.ts — spec §5.13 + §2 #6)', () => {
+  it('MESSAGE_BYTES is 32 MiB (32 × 1024 × 1024)', () => {
+    expect(BYTE_CAPS.MESSAGE_BYTES).toBe(32 * 1024 * 1024);
+    expect(BYTE_CAPS.MESSAGE_BYTES).toBe(33_554_432);
+  });
+
+  it('A11Y_TREE_BYTES is 10 MiB (10 × 1024 × 1024)', () => {
+    expect(BYTE_CAPS.A11Y_TREE_BYTES).toBe(10 * 1024 * 1024);
+    expect(BYTE_CAPS.A11Y_TREE_BYTES).toBe(10_485_760);
+  });
+
+  it('SCREENSHOT_BYTES is 5 MiB (5 × 1024 × 1024)', () => {
+    expect(BYTE_CAPS.SCREENSHOT_BYTES).toBe(5 * 1024 * 1024);
+    expect(BYTE_CAPS.SCREENSHOT_BYTES).toBe(5_242_880);
+  });
+
+  it('A11Y_TREE_BYTES ≤ MESSAGE_BYTES (field cap must not exceed envelope cap)', () => {
+    expect(BYTE_CAPS.A11Y_TREE_BYTES).toBeLessThanOrEqual(BYTE_CAPS.MESSAGE_BYTES);
+  });
+
+  it('SCREENSHOT_BYTES ≤ MESSAGE_BYTES', () => {
+    expect(BYTE_CAPS.SCREENSHOT_BYTES).toBeLessThanOrEqual(BYTE_CAPS.MESSAGE_BYTES);
+  });
+
+  it('SCREENSHOT_BYTES ≤ A11Y_TREE_BYTES (screenshots are smaller than trees)', () => {
+    expect(BYTE_CAPS.SCREENSHOT_BYTES).toBeLessThanOrEqual(BYTE_CAPS.A11Y_TREE_BYTES);
+  });
+});


### PR DESCRIPTION
## Summary
- Pins all 3 `BYTE_CAPS` fields (spec §5.13 + §2 #6): enforced after schema parse, before redaction+persistence
  - `MESSAGE_BYTES=33554432` (32 MiB): max envelope per socket connection
  - `A11Y_TREE_BYTES=10485760` (10 MiB): decoded a11y-tree cap
  - `SCREENSHOT_BYTES=5242880` (5 MiB): decoded screenshot cap
- Each field pinned with **both** the computed form (`32 * 1024 * 1024`) and the literal integer — guards against silent unit changes
- Adds **cross-check ordering assertions**: `SCREENSHOT ≤ A11Y ≤ MESSAGE` — a field cap exceeding the envelope cap would mean that field-level enforcement fires after the envelope has already been accepted
- `server.test.ts` only used `A11Y_TREE_BYTES + 1024` relatively; the literal 10 MiB was never asserted
- No source changes — `BYTE_CAPS` is already exported

## Test plan
- [x] 6/6 assertions pass locally (`bun run test` in `apps/capture-broker`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)