### PR TITLE
test(web): spec-pin CATEGORIES + ROLE_LABEL + VERDICT_COPY in report components

### DIFF
--- a/apps/web/components/report/HeadlineDelta.tsx
+++ b/apps/web/components/report/HeadlineDelta.tsx
@@ -28,6 +28,8 @@ const VERDICT_COPY: Record<ReportT['headline']['verdict'], string> = {
   inconclusive: 'Inconclusive — no clear winner.',
 };
 
+export const __test__ = { VERDICT_COPY };
+
 export function HeadlineDelta({ headline }: { headline: ReportT['headline'] }) {
   const { mean_delta, ci95_low, ci95_high, n_paired, paired_t_p, wilcoxon_p, mcnemar_p, verdict } =
     headline;

--- a/apps/web/components/report/PersonaGrid.tsx
+++ b/apps/web/components/report/PersonaGrid.tsx
@@ -16,6 +16,8 @@ const ROLE_LABEL: Record<Persona['role'], string> = {
   ic_engineer: 'IC engineer',
 };
 
+export const __test__ = { ROLE_LABEL };
+
 function PersonaCard({
   persona,
   onClick,

--- a/apps/web/components/report/ThemeBoard.tsx
+++ b/apps/web/components/report/ThemeBoard.tsx
@@ -30,6 +30,8 @@ const CATEGORIES: { key: ThemeCategory; label: string }[] = [
   { key: 'questions', label: 'Questions' },
 ];
 
+export const __test__ = { CATEGORIES };
+
 function CategoryChart({
   category,
   clusters,

--- a/apps/web/test/report-copy-constants.test.ts
+++ b/apps/web/test/report-copy-constants.test.ts
@@ -1,0 +1,102 @@
+/**
+ * report-copy-constants.test.ts — spec-pins for CATEGORIES (ThemeBoard),
+ * ROLE_LABEL (PersonaGrid), and VERDICT_COPY (HeadlineDelta).
+ *
+ * CATEGORIES (ThemeBoard.tsx):
+ *   4 theme categories rendered as chart sections in the theme board. The
+ *   keys must match CLUSTER_TO_THEME values in the Python aggregator (blockers,
+ *   objections, confusions, questions). A key mismatch causes the React
+ *   theme_board[category] lookup to return undefined, rendering an empty chart.
+ *
+ * ROLE_LABEL (PersonaGrid.tsx):
+ *   2 entries covering the RoleArchetype values that reach the report. Changing
+ *   'founder_or_eng_lead' → 'founder' would render 'undefined' for that role
+ *   in the persona grid. Must cover every role in shared/src/backstory.ts
+ *   that isn't coerced by the aggregator (the two surviving roles).
+ *
+ * VERDICT_COPY (HeadlineDelta.tsx):
+ *   3 user-facing verdict sentences for better/worse/inconclusive. A typo or
+ *   rename (e.g. 'better' → 'win') causes the verdict sentence to render
+ *   'undefined' silently. The sentence copy is what users read as the top-line
+ *   result of their study.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ as themeBoardTest } from '../components/report/ThemeBoard';
+import { __test__ as personaGridTest } from '../components/report/PersonaGrid';
+import { __test__ as headlineDeltaTest } from '../components/report/HeadlineDelta';
+
+const { CATEGORIES } = themeBoardTest;
+const { ROLE_LABEL } = personaGridTest;
+const { VERDICT_COPY } = headlineDeltaTest;
+
+describe('CATEGORIES spec-pin (ThemeBoard — must match aggregator CLUSTER_TO_THEME values)', () => {
+  it('has exactly 4 entries', () => {
+    expect(CATEGORIES).toHaveLength(4);
+  });
+
+  it('has a "blockers" entry', () => {
+    expect(CATEGORIES.some((c) => c.key === 'blockers')).toBe(true);
+  });
+
+  it('has an "objections" entry', () => {
+    expect(CATEGORIES.some((c) => c.key === 'objections')).toBe(true);
+  });
+
+  it('has a "confusions" entry', () => {
+    expect(CATEGORIES.some((c) => c.key === 'confusions')).toBe(true);
+  });
+
+  it('has a "questions" entry', () => {
+    expect(CATEGORIES.some((c) => c.key === 'questions')).toBe(true);
+  });
+
+  it('every entry has a non-empty label', () => {
+    for (const c of CATEGORIES) {
+      expect(c.label.length).toBeGreaterThan(0);
+    }
+  });
+
+  it('"blockers" → "Blockers" (display label)', () => {
+    const c = CATEGORIES.find((x) => x.key === 'blockers');
+    expect(c!.label).toBe('Blockers');
+  });
+});
+
+describe('ROLE_LABEL spec-pin (PersonaGrid — RoleArchetype display labels)', () => {
+  it('has exactly 2 entries', () => {
+    expect(Object.keys(ROLE_LABEL)).toHaveLength(2);
+  });
+
+  it('"founder_or_eng_lead" → "founder / eng lead"', () => {
+    expect(ROLE_LABEL['founder_or_eng_lead']).toBe('founder / eng lead');
+  });
+
+  it('"ic_engineer" → "IC engineer"', () => {
+    expect(ROLE_LABEL['ic_engineer']).toBe('IC engineer');
+  });
+});
+
+describe('VERDICT_COPY spec-pin (HeadlineDelta — user-facing verdict sentences)', () => {
+  it('has exactly 3 entries', () => {
+    expect(Object.keys(VERDICT_COPY)).toHaveLength(3);
+  });
+
+  it('"better" → "NEW converts better."', () => {
+    expect(VERDICT_COPY['better']).toBe('NEW converts better.');
+  });
+
+  it('"worse" → "NEW converts worse."', () => {
+    expect(VERDICT_COPY['worse']).toBe('NEW converts worse.');
+  });
+
+  it('"inconclusive" → "Inconclusive — no clear winner."', () => {
+    expect(VERDICT_COPY['inconclusive']).toBe('Inconclusive — no clear winner.');
+  });
+
+  it('all three sentences end with a period', () => {
+    for (const [, sentence] of Object.entries(VERDICT_COPY)) {
+      expect(sentence.endsWith('.')).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Pins `CATEGORIES` (ThemeBoard.tsx, 4 entries): keys must match `CLUSTER_TO_THEME` values in the Python aggregator — a key mismatch silently renders an empty chart with no test failing; adds spot-check for `'blockers' → 'Blockers'`
- Pins `ROLE_LABEL` (PersonaGrid.tsx, 2 entries): `founder_or_eng_lead → 'founder / eng lead'`, `ic_engineer → 'IC engineer'`; a key rename renders `'undefined'` for that role in the persona grid
- Pins `VERDICT_COPY` (HeadlineDelta.tsx, 3 entries): the top-line study result that users read; pins all 3 verdict strings + consistency assertion that every sentence ends with a period
- Adds `__test__` seams to `ThemeBoard.tsx`, `PersonaGrid.tsx`, `HeadlineDelta.tsx`

## Test plan
- [x] 15/15 assertions pass locally (`bun run test` in `apps/web`)
- [x] No behavior changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)