### PR TITLE
test(log): spec-pin STRICT_ALLOWLIST (11 entries) + REMOVE_FIELDS (8 entries) + disjoint guard

### DIFF
--- a/packages/log/src/redactor.ts
+++ b/packages/log/src/redactor.ts
@@ -67,6 +67,13 @@ const REMOVE_FIELDS = new Set([
   'error_detail',
 ]);
 const API_KEY_FIELD = 'api_key';
+
+export const __test__ = {
+  STRICT_ALLOWLIST,
+  REMOVE_FIELDS,
+  STRICT_DURATION_PREFIX,
+  API_KEY_FIELD,
+};
 const EMAIL_FIELD = 'email';
 
 // Fields that look like a URL by name; if their value is a string we hash it

--- a/packages/log/test/allowlist-remove-fields-pin.test.ts
+++ b/packages/log/test/allowlist-remove-fields-pin.test.ts
@@ -1,0 +1,104 @@
+/**
+ * allowlist-remove-fields-pin.test.ts — spec-pins for STRICT_ALLOWLIST
+ * and REMOVE_FIELDS in packages/log/src/redactor.ts (spec §5.12).
+ *
+ * STRICT_ALLOWLIST (11 entries):
+ *   When the logger is built with `strict: true`, ONLY fields in this set
+ *   (or matching the `duration_` prefix) are emitted. Adding a field to this
+ *   set could silently expose sensitive data; removing one could silently drop
+ *   required observability fields (e.g. removing 'account_id' breaks log
+ *   grouping by account). Pins all 11 allowlisted fields and the total count.
+ *
+ * REMOVE_FIELDS (8 entries):
+ *   Fields whose values are ALWAYS stripped — regardless of strict mode.
+ *   Removing 'backstory' would expose LLM inputs in logs. Removing 'password'
+ *   would expose passwords. Pins all 8 entries plus count.
+ *
+ * Negative: 'backstory' must be in REMOVE_FIELDS but NOT in STRICT_ALLOWLIST
+ * (it's a removed field, not a permitted field). A copy-paste error could
+ * accidentally add it to both.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ } from '../src/redactor.js';
+
+const { STRICT_ALLOWLIST, REMOVE_FIELDS, STRICT_DURATION_PREFIX, API_KEY_FIELD } = __test__;
+
+describe('STRICT_ALLOWLIST spec-pin (packages/log — spec §5.12)', () => {
+  it('has exactly 11 entries', () => {
+    expect(STRICT_ALLOWLIST.size).toBe(11);
+  });
+
+  const requiredFields = [
+    'account_id',
+    'study_id',
+    'visit_id',
+    'provider_attempt_id',
+    'transport_attempt_id',
+    'event',
+    'error_class',
+    'msg',
+    'level',
+    'time',
+    'service',
+  ];
+
+  for (const field of requiredFields) {
+    it(`contains "${field}"`, () => {
+      expect(STRICT_ALLOWLIST.has(field)).toBe(true);
+    });
+  }
+});
+
+describe('REMOVE_FIELDS spec-pin (packages/log — spec §5.12)', () => {
+  it('has exactly 8 entries', () => {
+    expect(REMOVE_FIELDS.size).toBe(8);
+  });
+
+  const removedFields = [
+    'share_token',
+    'backstory',
+    'a11y_tree',
+    'llm_output',
+    'provider_payload',
+    'password',
+    'page_bytes',
+    'error_detail',
+  ];
+
+  for (const field of removedFields) {
+    it(`contains "${field}"`, () => {
+      expect(REMOVE_FIELDS.has(field)).toBe(true);
+    });
+  }
+});
+
+describe('STRICT_ALLOWLIST / REMOVE_FIELDS disjoint guard', () => {
+  it('"backstory" is in REMOVE_FIELDS but NOT in STRICT_ALLOWLIST', () => {
+    expect(REMOVE_FIELDS.has('backstory')).toBe(true);
+    expect(STRICT_ALLOWLIST.has('backstory')).toBe(false);
+  });
+
+  it('"password" is in REMOVE_FIELDS but NOT in STRICT_ALLOWLIST', () => {
+    expect(REMOVE_FIELDS.has('password')).toBe(true);
+    expect(STRICT_ALLOWLIST.has('password')).toBe(false);
+  });
+
+  it('no field appears in both sets (fully disjoint)', () => {
+    for (const field of REMOVE_FIELDS) {
+      expect(STRICT_ALLOWLIST.has(field)).toBe(false);
+    }
+  });
+});
+
+describe('STRICT_DURATION_PREFIX spec-pin', () => {
+  it('is "duration_"', () => {
+    expect(STRICT_DURATION_PREFIX).toBe('duration_');
+  });
+});
+
+describe('API_KEY_FIELD spec-pin', () => {
+  it('is "api_key"', () => {
+    expect(API_KEY_FIELD).toBe('api_key');
+  });
+});


### PR DESCRIPTION
## Summary
- Pins `STRICT_ALLOWLIST` (11 entries, spec §5.12): fields allowed through in strict mode; adding a field silently exposes it in logs; removing one silently drops required observability; pins all 11 fields + size
- Pins `REMOVE_FIELDS` (8 entries, spec §5.12): fields always stripped regardless of strict mode; removing `'backstory'` would expose LLM inputs; `'password'` would expose passwords; pins all 8 entries + size
- Adds **disjoint guard**: no field may appear in both sets — spot-checks `backstory` and `password` (must be in `REMOVE_FIELDS`, NOT in `STRICT_ALLOWLIST`), plus a full loop assertion `∀ f ∈ REMOVE_FIELDS: f ∉ STRICT_ALLOWLIST`
- Also pins `STRICT_DURATION_PREFIX='duration_'` and `API_KEY_FIELD='api_key'`
- Adds `__test__` seam to `redactor.ts`

## Test plan
- [x] 26/26 assertions pass locally (`bun run test` in `packages/log`)
- [x] Source change is the `__test__` seam only

🤖 Generated with [Claude Code](https://claude.com/claude-code)