### PR TITLE
test(web): spec-pin PROGRESS_CLASSES length + boundary entries

### DIFF
--- a/apps/web/test/study-status.test.tsx
+++ b/apps/web/test/study-status.test.tsx
@@ -25,6 +25,28 @@ import {
   PROGRESS_CLASSES,
 } from '../app/dashboard/studies/[id]/page';
 
+describe('PROGRESS_CLASSES spec-pin (issue #111 — 13 Tailwind width buckets)', () => {
+  it('has exactly 13 entries (0% + 12 twelfths + 100%)', () => {
+    expect(PROGRESS_CLASSES).toHaveLength(13);
+  });
+
+  it('first entry is "w-0"', () => {
+    expect(PROGRESS_CLASSES[0]).toBe('w-0');
+  });
+
+  it('last entry is "w-full"', () => {
+    expect(PROGRESS_CLASSES[PROGRESS_CLASSES.length - 1]).toBe('w-full');
+  });
+
+  it('contains "w-1/2" (50% progress bucket)', () => {
+    expect(PROGRESS_CLASSES).toContain('w-1/2');
+  });
+
+  it('contains "w-1/12" (first non-zero bucket)', () => {
+    expect(PROGRESS_CLASSES).toContain('w-1/12');
+  });
+});
+
 describe('progressClass helper (issue #111)', () => {
   it('maps 0% to w-0', () => {
     expect(progressClass(0)).toBe('w-0');


### PR DESCRIPTION
## Summary
- Extends `study-status.test.tsx` with 5 `PROGRESS_CLASSES` spec-pin assertions: `length=13` (0% + 12 twelfths), `first='w-0'`, `last='w-full'`, spot-check `'w-1/2'` (50%) and `'w-1/12'` (first non-zero bucket)
- The existing test only checked `PROGRESS_CLASSES.toContain(progressClass(pct))` — adding a 14th bucket or misordering the array would not fail the prior test
- All 14 pre-existing assertions still pass (19 total)
- No source changes

## Test plan
- [x] 19/19 assertions pass locally (`bun run test` in `apps/web`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)