### PR TITLE
test(shared): spec-pin VisitorOutput field cap boundaries (spec §2 #15)

### DIFF
--- a/packages/shared/test/visitor.test.ts
+++ b/packages/shared/test/visitor.test.ts
@@ -9,6 +9,74 @@ const validFixture = JSON.parse(
   readFileSync(resolve(here, 'fixtures/valid-visitor.json'), 'utf8'),
 );
 
+// ── Field cap spec-pins ────────────────────────────────────────────────────
+// The existing reject-at-cap tests verify that cap+1 is rejected but do not
+// verify that cap itself is accepted (off-by-one in the cap could silently
+// reduce the allowed size). Each pin below asserts both: cap accepts, cap+1
+// rejects. Values come from the spec §2 #15 cap table.
+
+describe('VisitorOutput field cap spec-pins (spec §2 #15)', () => {
+  it('first_impression cap=400: accepts exactly 400 chars', () => {
+    const v = { ...validFixture, first_impression: 'a'.repeat(400) };
+    expect(() => VisitorOutput.parse(v)).not.toThrow();
+  });
+
+  it('first_impression cap=400: rejects 401 chars', () => {
+    const v = { ...validFixture, first_impression: 'a'.repeat(401) };
+    expect(() => VisitorOutput.parse(v)).toThrow();
+  });
+
+  it('reasoning cap=1200: accepts exactly 1200 chars', () => {
+    const v = { ...validFixture, reasoning: 'a'.repeat(1200) };
+    expect(() => VisitorOutput.parse(v)).not.toThrow();
+  });
+
+  it('reasoning cap=1200: rejects 1201 chars', () => {
+    const v = { ...validFixture, reasoning: 'a'.repeat(1201) };
+    expect(() => VisitorOutput.parse(v)).toThrow();
+  });
+
+  it('score0to10 (will_to_buy): accepts 0 (minimum)', () => {
+    const v = { ...validFixture, will_to_buy: 0 };
+    expect(() => VisitorOutput.parse(v)).not.toThrow();
+  });
+
+  it('score0to10 (will_to_buy): accepts 10 (maximum)', () => {
+    const v = { ...validFixture, will_to_buy: 10 };
+    expect(() => VisitorOutput.parse(v)).not.toThrow();
+  });
+
+  it('score0to10 (will_to_buy): rejects 11', () => {
+    const v = { ...validFixture, will_to_buy: 11 };
+    expect(() => VisitorOutput.parse(v)).toThrow();
+  });
+
+  it('score0to10 (will_to_buy): rejects -1', () => {
+    const v = { ...validFixture, will_to_buy: -1 };
+    expect(() => VisitorOutput.parse(v)).toThrow();
+  });
+
+  it('shortStringList (questions): accepts exactly 10 items', () => {
+    const v = { ...validFixture, questions: Array(10).fill('q') };
+    expect(() => VisitorOutput.parse(v)).not.toThrow();
+  });
+
+  it('shortStringList (questions): rejects 11 items', () => {
+    const v = { ...validFixture, questions: Array(11).fill('q') };
+    expect(() => VisitorOutput.parse(v)).toThrow();
+  });
+
+  it('shortStringList item cap=200: accepts exactly 200 chars', () => {
+    const v = { ...validFixture, questions: ['a'.repeat(200)] };
+    expect(() => VisitorOutput.parse(v)).not.toThrow();
+  });
+
+  it('shortStringList item cap=200: rejects 201 chars', () => {
+    const v = { ...validFixture, questions: ['a'.repeat(201)] };
+    expect(() => VisitorOutput.parse(v)).toThrow();
+  });
+});
+
 describe('VisitorOutput (spec §2 #15)', () => {
   it('parses a known-valid fixture', () => {
     const parsed = VisitorOutput.parse(validFixture);


### PR DESCRIPTION
## Summary
- Adds 12 **at-limit/over-limit boundary assertions** to `visitor.test.ts`: the existing tests only verify `cap+1` rejects but not that `cap` itself accepts
- `first_impression cap=400`: accepts 400 chars, rejects 401
- `reasoning cap=1200`: accepts 1200 chars, rejects 1201
- `score0to10` (`will_to_buy`): accepts 0 (minimum) and 10 (maximum), rejects -1 and 11
- `shortStringList` (`questions`): accepts exactly 10 items, rejects 11; item cap=200 accepts 200 chars, rejects 201
- An off-by-one reducing `400→399` would not be caught by the prior tests but would reject valid impressions at the schema boundary
- All 8 pre-existing assertions still pass (20 total)

## Test plan
- [x] 20/20 assertions pass locally (`bun run test` in `packages/shared`)
- [x] No source changes

🤖 Generated with [Claude Code](https://claude.com/claude-code)