### PR TITLE
test(api): spec-pin HTTP_DURATION_BUCKETS — 12 entries, 5ms–30s, monotone

### DIFF
--- a/apps/api/src/metrics/registry.ts
+++ b/apps/api/src/metrics/registry.ts
@@ -241,6 +241,8 @@ const HTTP_DURATION_BUCKETS = [
   0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1, 2.5, 5, 10, 30,
 ] as const;
 
+export const __test__ = { HTTP_DURATION_BUCKETS };
+
 const studiesStartedTotal = makeCounter(
   'willbuy_studies_started_total',
   'Total number of studies created (POST /studies). `kind` ∈ {single,paired} per §2 #12.',

--- a/apps/api/test/metrics-histogram-buckets.test.ts
+++ b/apps/api/test/metrics-histogram-buckets.test.ts
@@ -21,7 +21,7 @@
  */
 
 import { describe, expect, it } from 'vitest';
-import { __test__ } from '../src/metrics/registry.js';
+import { __test__, PROMETHEUS_CONTENT_TYPE } from '../src/metrics/registry.js';
 
 const { HTTP_DURATION_BUCKETS } = __test__;
 
@@ -56,5 +56,19 @@ describe('HTTP_DURATION_BUCKETS spec-pin (metrics/registry.ts)', () => {
     for (const b of HTTP_DURATION_BUCKETS) {
       expect(b).toBeGreaterThan(0);
     }
+  });
+});
+
+describe('PROMETHEUS_CONTENT_TYPE spec-pin (metrics/registry.ts)', () => {
+  it('is the exact Prometheus 0.0.4 content-type string', () => {
+    expect(PROMETHEUS_CONTENT_TYPE).toBe('text/plain; version=0.0.4; charset=utf-8');
+  });
+
+  it('includes version=0.0.4 (Prometheus exposition format)', () => {
+    expect(PROMETHEUS_CONTENT_TYPE).toContain('version=0.0.4');
+  });
+
+  it('includes charset=utf-8', () => {
+    expect(PROMETHEUS_CONTENT_TYPE).toContain('charset=utf-8');
   });
 });

--- a/apps/api/test/metrics-histogram-buckets.test.ts
+++ b/apps/api/test/metrics-histogram-buckets.test.ts
@@ -1,0 +1,60 @@
+/**
+ * metrics-histogram-buckets.test.ts — spec-pins for HTTP_DURATION_BUCKETS
+ * in apps/api/src/metrics/registry.ts.
+ *
+ * HTTP_DURATION_BUCKETS defines the Prometheus histogram bucket upper bounds
+ * for willbuy_http_request_duration_seconds. The buckets are tuned for:
+ *   - Sub-100ms typical API responses
+ *   - LLM-touching routes that reach up to ~30s
+ *   - 30s = willbuy worst-case capture timeout
+ *
+ * Changing any bucket changes what percentiles are observable in Prometheus
+ * and can break dashboards or alerting rules that reference specific buckets.
+ * The 30s upper bound is spec-referenced (§4.1 capture timeout).
+ *
+ * Pins:
+ *   - Count = 12 (one +Inf is added by prom-client automatically)
+ *   - First bucket = 0.005s (5ms) — catches fast-path cache hits
+ *   - Last explicit bucket = 30s — covers worst-case capture timeout
+ *   - Contains 1s — the canonical SLO threshold for API latency
+ *   - Monotonically increasing (required by Prometheus)
+ */
+
+import { describe, expect, it } from 'vitest';
+import { __test__ } from '../src/metrics/registry.js';
+
+const { HTTP_DURATION_BUCKETS } = __test__;
+
+describe('HTTP_DURATION_BUCKETS spec-pin (metrics/registry.ts)', () => {
+  it('has exactly 12 entries', () => {
+    expect(HTTP_DURATION_BUCKETS).toHaveLength(12);
+  });
+
+  it('first bucket is 0.005s (5ms)', () => {
+    expect(HTTP_DURATION_BUCKETS[0]).toBe(0.005);
+  });
+
+  it('last explicit bucket is 30s (worst-case capture timeout)', () => {
+    expect(HTTP_DURATION_BUCKETS[HTTP_DURATION_BUCKETS.length - 1]).toBe(30);
+  });
+
+  it('contains 1s (canonical SLO threshold)', () => {
+    expect(HTTP_DURATION_BUCKETS).toContain(1);
+  });
+
+  it('contains 0.1s (100ms — typical p99 target)', () => {
+    expect(HTTP_DURATION_BUCKETS).toContain(0.1);
+  });
+
+  it('is monotonically increasing (Prometheus requires this)', () => {
+    for (let i = 1; i < HTTP_DURATION_BUCKETS.length; i++) {
+      expect(HTTP_DURATION_BUCKETS[i]!).toBeGreaterThan(HTTP_DURATION_BUCKETS[i - 1]!);
+    }
+  });
+
+  it('all values are positive (Prometheus requires positive bounds)', () => {
+    for (const b of HTTP_DURATION_BUCKETS) {
+      expect(b).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- Pins `HTTP_DURATION_BUCKETS` (12 entries: `0.005s` → `30s`) in `src/metrics/registry.ts`; changing any bucket changes which percentiles are observable in Prometheus and can break dashboards or SLO alerts
- `30s` = worst-case capture timeout per spec §4.1 — the last bucket is intentionally that long
- Pins `1s` (SLO threshold) and `0.1s` (100ms p99 target) as spot-checks
- **Monotonically increasing invariant**: Prometheus requires this; a swap would make the histogram invalid
- **All values positive**: Prometheus requires positive bucket bounds
- Pins `PROMETHEUS_CONTENT_TYPE='text/plain; version=0.0.4; charset=utf-8'`: the exact string value was only tested via regex inside a Docker-gated describe block
- Adds `__test__` seam to `src/metrics/registry.ts`

## Test plan
- [x] 10/10 assertions pass locally (`bun run test` in `apps/api`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)