### PR TITLE
test(capture-worker): spec-pin LAUNCH_FLAGS count=14 and structural invariants

### DIFF
--- a/apps/capture-worker/test/launchFlags.test.ts
+++ b/apps/capture-worker/test/launchFlags.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect } from 'vitest';
 import { LAUNCH_FLAGS } from '../src/launchFlags.js';
 
 describe('LAUNCH_FLAGS (spec §2 #2 — Chromium sandbox enabled)', () => {
+  it('has exactly 14 entries (prevents silent flag additions)', () => {
+    expect(LAUNCH_FLAGS).toHaveLength(14);
+  });
+
+  it('all flags start with "--" (no typos or bare values)', () => {
+    for (const flag of LAUNCH_FLAGS) {
+      expect(flag.startsWith('--')).toBe(true);
+    }
+  });
+
   it('does not contain the banned sandbox-disabling flag', () => {
     // The CI lint (`willbuy/no-sandbox-flag`) catches a raw literal in
     // source. This test catches a runtime composition (template-literal


### PR DESCRIPTION
## Summary
- Adds `has exactly 14 entries` assertion to catch silent flag additions/removals
- Adds `all flags start with "--"` loop assertion to catch bare values or typos
- All 6 tests pass; no source changes

## Test plan
- [x] `bun run test --reporter=verbose test/launchFlags.test.ts` → 6/6 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)