### PR TITLE
test(api): spec-pin KIND_CEILING values from spec §5.5

### DIFF
--- a/apps/api/test/kind-ceiling-pin.test.ts
+++ b/apps/api/test/kind-ceiling-pin.test.ts
@@ -1,0 +1,40 @@
+/**
+ * kind-ceiling-pin.test.ts — spec-pin for KIND_CEILING values (no DB required).
+ *
+ * Spec refs:
+ *   §5.5 — per-kind hard ceilings: visit=5¢, cluster_label=3¢, embedding=0¢, probe=0¢.
+ *
+ * KIND_CEILING is already exported from atomic-spend.ts; no seam needed.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { KIND_CEILING } from '../src/billing/atomic-spend.js';
+
+describe('KIND_CEILING — spec §5.5 per-kind hard ceilings', () => {
+  it('visit ceiling is 5 cents', () => {
+    expect(KIND_CEILING.visit).toBe(5);
+  });
+
+  it('cluster_label ceiling is 3 cents', () => {
+    expect(KIND_CEILING.cluster_label).toBe(3);
+  });
+
+  it('embedding ceiling is 0 cents', () => {
+    expect(KIND_CEILING.embedding).toBe(0);
+  });
+
+  it('probe ceiling is 0 cents', () => {
+    expect(KIND_CEILING.probe).toBe(0);
+  });
+
+  it('has exactly 4 kind entries', () => {
+    expect(Object.keys(KIND_CEILING)).toHaveLength(4);
+  });
+
+  it('all ceiling values are non-negative integers', () => {
+    for (const [kind, cents] of Object.entries(KIND_CEILING)) {
+      expect(Number.isInteger(cents), `${kind}: not an integer`).toBe(true);
+      expect(cents >= 0, `${kind}: negative ceiling`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- 6 standalone unit tests (no Docker) pinning `KIND_CEILING` from `atomic-spend.ts`
- Pins: `visit=5¢`, `cluster_label=3¢`, `embedding=0¢`, `probe=0¢` (spec §5.5)
- Guards entry count=4 and non-negative-integer structural invariant
- `KIND_CEILING` is already exported; no source changes needed

## Test plan
- [x] `bun run test --reporter=verbose test/kind-ceiling-pin.test.ts` → 6/6 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)