### PR TITLE
test(capture): spec-pin CAPTURE_CEILINGS (all 5 values) and BYTE_CAPS (all 3 values)

### DIFF
--- a/apps/capture-broker/test/byteCapsPin.test.ts
+++ b/apps/capture-broker/test/byteCapsPin.test.ts
@@ -1,0 +1,45 @@
+/**
+ * byteCapsPin.test.ts — spec-pin for BYTE_CAPS values (spec §5.13, §2 #6).
+ *
+ * The existing server.test.ts uses BYTE_CAPS.A11Y_TREE_BYTES as a runtime
+ * value for an integration test but never pins its numeric value. This file
+ * pins all three caps so a silent spec deviation is caught without the
+ * full Unix-socket integration suite.
+ *
+ * Spec refs:
+ *   §5.13 — broker byte caps: a11y_tree ≤ 10 MB, screenshot ≤ 5 MB.
+ *   §2 #6 — defense-in-depth: message envelope ≤ 32 MB.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { BYTE_CAPS } from '../src/byteCaps.js';
+
+describe('BYTE_CAPS spec-pin (spec §5.13, §2 #6)', () => {
+  it('MESSAGE_BYTES is 32 MB', () => {
+    expect(BYTE_CAPS.MESSAGE_BYTES).toBe(32 * 1024 * 1024);
+  });
+
+  it('A11Y_TREE_BYTES is 10 MB (spec §5.13)', () => {
+    expect(BYTE_CAPS.A11Y_TREE_BYTES).toBe(10 * 1024 * 1024);
+  });
+
+  it('SCREENSHOT_BYTES is 5 MB (spec §5.13)', () => {
+    expect(BYTE_CAPS.SCREENSHOT_BYTES).toBe(5 * 1024 * 1024);
+  });
+
+  it('has exactly 3 cap keys', () => {
+    expect(Object.keys(BYTE_CAPS)).toHaveLength(3);
+  });
+
+  it('MESSAGE_BYTES >= A11Y_TREE_BYTES >= SCREENSHOT_BYTES (structural ordering)', () => {
+    expect(BYTE_CAPS.MESSAGE_BYTES).toBeGreaterThanOrEqual(BYTE_CAPS.A11Y_TREE_BYTES);
+    expect(BYTE_CAPS.A11Y_TREE_BYTES).toBeGreaterThanOrEqual(BYTE_CAPS.SCREENSHOT_BYTES);
+  });
+
+  it('all cap values are positive integers', () => {
+    for (const [key, value] of Object.entries(BYTE_CAPS)) {
+      expect(Number.isInteger(value), `${key}: not an integer`).toBe(true);
+      expect(value > 0, `${key}: not positive`).toBe(true);
+    }
+  });
+});

--- a/apps/capture-worker/test/captureCeilingsPin.test.ts
+++ b/apps/capture-worker/test/captureCeilingsPin.test.ts
@@ -1,0 +1,49 @@
+/**
+ * captureCeilingsPin.test.ts — spec-pin for all CAPTURE_CEILINGS values
+ * (spec §2 #6). No browser or fixture server needed.
+ *
+ * The existing captureCeilings.test.ts only pins TOTAL_BYTES (25 MB).
+ * This file pins the remaining four constants so a silent spec deviation
+ * is caught without running the full integration suite.
+ *
+ * Spec refs:
+ *   §2 #5 — distinct-host budget ≤ 50.
+ *   §2 #6 — wall_clock ≤ 45s, total_bytes ≤ 25 MB, dom_nodes ≤ 250 000,
+ *            a11y_tree_bytes ≤ 10 MB.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { CAPTURE_CEILINGS } from '../src/types.js';
+
+describe('CAPTURE_CEILINGS spec-pin (spec §2 #5, §2 #6)', () => {
+  it('WALL_CLOCK_MS is 45 000 ms (45 s)', () => {
+    expect(CAPTURE_CEILINGS.WALL_CLOCK_MS).toBe(45_000);
+  });
+
+  it('TOTAL_BYTES is 25 MB', () => {
+    expect(CAPTURE_CEILINGS.TOTAL_BYTES).toBe(25 * 1024 * 1024);
+  });
+
+  it('DOM_NODES is 250 000', () => {
+    expect(CAPTURE_CEILINGS.DOM_NODES).toBe(250_000);
+  });
+
+  it('A11Y_TREE_BYTES is 10 MB', () => {
+    expect(CAPTURE_CEILINGS.A11Y_TREE_BYTES).toBe(10 * 1024 * 1024);
+  });
+
+  it('HOST_COUNT is 50 (spec §2 #5)', () => {
+    expect(CAPTURE_CEILINGS.HOST_COUNT).toBe(50);
+  });
+
+  it('has exactly 5 ceiling keys', () => {
+    expect(Object.keys(CAPTURE_CEILINGS)).toHaveLength(5);
+  });
+
+  it('all ceiling values are positive integers', () => {
+    for (const [key, value] of Object.entries(CAPTURE_CEILINGS)) {
+      expect(Number.isInteger(value), `${key}: not an integer`).toBe(true);
+      expect(value > 0, `${key}: not positive`).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- `captureCeilingsPin.test.ts` (7 cases, capture-worker): pins all 5 `CAPTURE_CEILINGS` values from spec §2 #5 and §2 #6 — `WALL_CLOCK_MS=45 000`, `TOTAL_BYTES=25 MB`, `DOM_NODES=250 000`, `A11Y_TREE_BYTES=10 MB`, `HOST_COUNT=50`; existing test only pinned `TOTAL_BYTES`
- `byteCapsPin.test.ts` (6 cases, capture-broker): pins all 3 `BYTE_CAPS` values from spec §5.13 — `MESSAGE_BYTES=32 MB`, `A11Y_TREE_BYTES=10 MB`, `SCREENSHOT_BYTES=5 MB`; existing test used the values but never pinned them as spec constants
- No source changes; both constants are already exported

## Test plan
- [x] `bun run test --reporter=verbose test/captureCeilingsPin.test.ts` → 7/7 pass (capture-worker)
- [x] `bun run test --reporter=verbose test/byteCapsPin.test.ts` → 6/6 pass (capture-broker)

🤖 Generated with [Claude Code](https://claude.com/claude-code)