### PR TITLE
test(capture-broker): spec-pin framing + redactor + server constants

### DIFF
--- a/apps/capture-broker/test/framingRedactorConstantsPin.test.ts
+++ b/apps/capture-broker/test/framingRedactorConstantsPin.test.ts
@@ -1,0 +1,45 @@
+/**
+ * framingRedactorConstantsPin.test.ts — spec-pin for broker wire protocol
+ * and redactor constants (spec §5.9, §5.13).
+ *
+ * These values are used in existing tests but their numeric/symbolic values
+ * are never directly asserted. Changing them silently breaks the wire protocol
+ * or the redactor's labeled-context window.
+ *
+ * Spec refs:
+ *   §5.13  — Unix socket framing (u32be length prefix = 4 bytes).
+ *   §5.9   — Redactor versioning (REDACTOR_VERSION persisted on capture row).
+ *   §5.13  — Read timeout 30 s.
+ *   §5.9   — LABEL_PROXIMITY_CHARS controls labeled-secret detection window.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { HEADER_BYTES, READ_TIMEOUT_MS } from '../src/framing.js';
+import { REDACTOR_VERSION, LABEL_PROXIMITY_CHARS } from '../src/redactor.js';
+import { SOCKET_MODE } from '../src/server.js';
+
+describe('Framing constants — spec §5.13', () => {
+  it('HEADER_BYTES is 4 (u32be length prefix)', () => {
+    expect(HEADER_BYTES).toBe(4);
+  });
+
+  it('READ_TIMEOUT_MS is 30 000 ms (30 s)', () => {
+    expect(READ_TIMEOUT_MS).toBe(30_000);
+  });
+});
+
+describe('Redactor constants — spec §5.9', () => {
+  it('REDACTOR_VERSION is 1', () => {
+    expect(REDACTOR_VERSION).toBe(1);
+  });
+
+  it('LABEL_PROXIMITY_CHARS is 32', () => {
+    expect(LABEL_PROXIMITY_CHARS).toBe(32);
+  });
+});
+
+describe('Server constants — spec §5.13', () => {
+  it('SOCKET_MODE is 0o660 (rw-rw---- so worker can connect without root)', () => {
+    expect(SOCKET_MODE).toBe(0o660);
+  });
+});


### PR DESCRIPTION
## Summary
- 5 spec-pin tests for broker wire-protocol and redactor constants (spec §5.9, §5.13)
- Pins: `HEADER_BYTES=4` (u32be), `READ_TIMEOUT_MS=30 000`, `REDACTOR_VERSION=1`, `LABEL_PROXIMITY_CHARS=32`, `SOCKET_MODE=0o660`
- The existing tests use these constants as variables but never assert their actual values
- No source changes; all constants are already exported

## Test plan
- [x] `bun run test --reporter=verbose test/framingRedactorConstantsPin.test.ts` → 5/5 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)