### PR TITLE
test(visitor-worker): spec-pin MAX_OUTPUT_TOKENS=800 and MAX_REPAIR_GENERATION=2

### DIFF
--- a/apps/visitor-worker/src/visitor.ts
+++ b/apps/visitor-worker/src/visitor.ts
@@ -219,3 +219,6 @@ export async function runVisit(opts: RunVisitOptions): Promise<VisitResult> {
     }
   }
 }
+
+// Test seam — not part of the public API surface.
+export const __test__ = { MAX_OUTPUT_TOKENS, MAX_REPAIR_GENERATION };

--- a/apps/visitor-worker/test/visitorLlmConstantsPin.test.ts
+++ b/apps/visitor-worker/test/visitorLlmConstantsPin.test.ts
@@ -1,0 +1,26 @@
+/**
+ * visitorLlmConstantsPin.test.ts — spec-pin for visitor LLM call constants.
+ *
+ * Spec refs:
+ *   §2 #15 — MAX_OUTPUT_TOKENS=800 (visitor LLM output cap).
+ *   §2 #14 — MAX_REPAIR_GENERATION=2 (schema-repair retry limit; total calls=3).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { __test__ } from '../src/visitor.js';
+
+const { MAX_OUTPUT_TOKENS, MAX_REPAIR_GENERATION } = __test__;
+
+describe('Visitor LLM call constants (spec §2 #14, §2 #15)', () => {
+  it('MAX_OUTPUT_TOKENS is 800 (spec §2 #15)', () => {
+    expect(MAX_OUTPUT_TOKENS).toBe(800);
+  });
+
+  it('MAX_REPAIR_GENERATION is 2 (spec §2 #14)', () => {
+    expect(MAX_REPAIR_GENERATION).toBe(2);
+  });
+
+  it('total calls per visit = MAX_REPAIR_GENERATION + 1 = 3 (initial + 2 repairs)', () => {
+    expect(MAX_REPAIR_GENERATION + 1).toBe(3);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `__test__` seam to `visitor.ts`
- 3 unit tests pinning:
  - `MAX_OUTPUT_TOKENS=800` (spec §2 #15 — visitor LLM output token cap)
  - `MAX_REPAIR_GENERATION=2` (spec §2 #14 — schema-repair retry limit; total calls per visit = 3)
  - Derived invariant: MAX_REPAIR_GENERATION + 1 = 3

## Test plan
- [x] `bun run test --reporter=verbose test/visitorLlmConstantsPin.test.ts` → 3/3 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)