### PR TITLE
test(api): unit-test normalizeEtldPlusOne and safeRedirect security helpers

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -197,3 +197,10 @@ export async function registerAuthRoutes(
     return reply.code(302).redirect('/sign-in');
   });
 }
+
+// Test seam — not part of the public API surface.
+export const __test__ = {
+  SESSION_7_DAYS_SECONDS,
+  MAGIC_LINK_EXPIRY_MINUTES,
+  safeRedirect,
+};

--- a/apps/api/src/routes/domains.ts
+++ b/apps/api/src/routes/domains.ts
@@ -537,3 +537,11 @@ export async function registerDomainsRoutes(
     },
   );
 }
+
+// Test seam — not part of the public API surface.
+export const __test__ = {
+  PROBE_TIMEOUT_MS,
+  TOKEN_LENGTH,
+  CreateDomainBody,
+  normalizeEtldPlusOne,
+};

--- a/apps/api/test/normalize-safe-redirect-pin.test.ts
+++ b/apps/api/test/normalize-safe-redirect-pin.test.ts
@@ -1,0 +1,95 @@
+/**
+ * normalize-safe-redirect-pin.test.ts — unit tests for two pure helper
+ * functions with security implications (no DB required).
+ *
+ * normalizeEtldPlusOne (domains.ts):
+ *   Extracts the eTLD+1 from user-supplied domain strings. Must reject
+ *   localhost, bare labels without a TLD, empty strings, and strings with
+ *   whitespace. Silently lowercases and trims (spec §2 #1).
+ *
+ * safeRedirect (auth.ts):
+ *   Validates a redirect path: must start with '/', must NOT start with '//',
+ *   must NOT contain '://'. Falls back to '/dashboard' on any violation
+ *   (spec §2 #26 open-redirect guard).
+ */
+
+import { describe, it, expect } from 'vitest';
+import { __test__ as authTest } from '../src/routes/auth.js';
+import { __test__ as domainsTest } from '../src/routes/domains.js';
+
+const { safeRedirect } = authTest;
+const { normalizeEtldPlusOne } = domainsTest;
+
+describe('normalizeEtldPlusOne (spec §2 #1 domain normalization)', () => {
+  it('returns eTLD+1 for a bare hostname', () => {
+    expect(normalizeEtldPlusOne('example.com')).toBe('example.com');
+  });
+
+  it('strips subdomain, keeps eTLD+1', () => {
+    expect(normalizeEtldPlusOne('sub.example.com')).toBe('example.com');
+  });
+
+  it('lowercases the result', () => {
+    expect(normalizeEtldPlusOne('EXAMPLE.COM')).toBe('example.com');
+  });
+
+  it('trims leading/trailing whitespace before processing', () => {
+    expect(normalizeEtldPlusOne('  example.com  ')).toBe('example.com');
+  });
+
+  it('returns null for an empty string', () => {
+    expect(normalizeEtldPlusOne('')).toBeNull();
+  });
+
+  it('returns null for whitespace-only input', () => {
+    expect(normalizeEtldPlusOne('   ')).toBeNull();
+  });
+
+  it('returns null for a string containing internal whitespace', () => {
+    expect(normalizeEtldPlusOne('exa mple.com')).toBeNull();
+  });
+
+  it('returns null for localhost (no dot = not a public-suffix domain)', () => {
+    expect(normalizeEtldPlusOne('localhost')).toBeNull();
+  });
+
+  it('returns null for a bare label without a TLD', () => {
+    expect(normalizeEtldPlusOne('notatld')).toBeNull();
+  });
+
+  it('handles a URL by extracting its eTLD+1', () => {
+    // tldts.getDomain also handles URLs
+    const result = normalizeEtldPlusOne('https://sub.example.com/path');
+    expect(result).toBe('example.com');
+  });
+});
+
+describe('safeRedirect (spec §2 #26 open-redirect guard)', () => {
+  it('returns the path unchanged when it starts with / and is not protocol-relative', () => {
+    expect(safeRedirect('/dashboard/studies')).toBe('/dashboard/studies');
+  });
+
+  it('returns /dashboard for undefined input', () => {
+    expect(safeRedirect(undefined)).toBe('/dashboard');
+  });
+
+  it('returns /dashboard for an absolute URL (contains ://)', () => {
+    expect(safeRedirect('https://evil.com')).toBe('/dashboard');
+  });
+
+  it('returns /dashboard for a protocol-relative URL (starts with //)', () => {
+    expect(safeRedirect('//evil.com')).toBe('/dashboard');
+  });
+
+  it('returns /dashboard for a path containing ://', () => {
+    expect(safeRedirect('/redirect?to=http://evil.com')).toBe('/dashboard');
+  });
+
+  it('returns /dashboard for an empty string', () => {
+    expect(safeRedirect('')).toBe('/dashboard');
+  });
+
+  it('returns / (root) when that is the redirect path', () => {
+    expect(safeRedirect('/')).toBe('/');
+  });
+});


### PR DESCRIPTION
## Summary
- 17 unit tests for two private pure functions with security implications
- `normalizeEtldPlusOne` (10 cases, spec §2 #1): eTLD+1 extraction, subdomain stripping, lowercase, whitespace trim, localhost rejection, bare-label rejection, URL input
- `safeRedirect` (7 cases, spec §2 #26 open-redirect guard): valid path pass-through, absolute URL/protocol-relative/`://`-containing → `/dashboard`, empty → `/dashboard`, `/` accepted
- Adds `normalizeEtldPlusOne` to `domains.ts` `__test__` seam and `safeRedirect` to `auth.ts` `__test__` seam

## Test plan
- [x] `bun run test --reporter=verbose test/normalize-safe-redirect-pin.test.ts` → 17/17 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)