### PR TITLE
test(api): spec-pin MagicLinkBody schema + auth constants (spec §2 #26, §5.10)

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -197,3 +197,11 @@ export async function registerAuthRoutes(
     return reply.code(302).redirect('/sign-in');
   });
 }
+
+// Test seam — not part of the public API surface.
+export const __test__ = {
+  SESSION_7_DAYS_SECONDS,
+  MAGIC_LINK_EXPIRY_MINUTES,
+  MagicLinkBody,
+  safeRedirect,
+};

--- a/apps/api/test/magic-link-schema-pin.test.ts
+++ b/apps/api/test/magic-link-schema-pin.test.ts
@@ -1,0 +1,62 @@
+/**
+ * magic-link-schema-pin.test.ts — spec-pin for MagicLinkBody schema
+ * boundaries (spec §2 #26, §4.1). No DB required.
+ *
+ * The existing auth.test.ts tests the full magic-link flow (Docker-gated).
+ * This file pins the Zod schema contract standalone.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { __test__ } from '../src/routes/auth.js';
+
+const { MagicLinkBody, SESSION_7_DAYS_SECONDS, MAGIC_LINK_EXPIRY_MINUTES } = __test__;
+
+describe('MagicLinkBody — email field validation (spec §2 #26)', () => {
+  it('accepts a valid email', () => {
+    expect(MagicLinkBody.safeParse({ email: 'user@example.com' }).success).toBe(true);
+  });
+
+  it('rejects a string without @ (not an email)', () => {
+    expect(MagicLinkBody.safeParse({ email: 'notanemail' }).success).toBe(false);
+  });
+
+  it('rejects an empty email string', () => {
+    expect(MagicLinkBody.safeParse({ email: '' }).success).toBe(false);
+  });
+
+  it('rejects missing email field', () => {
+    expect(MagicLinkBody.safeParse({}).success).toBe(false);
+  });
+});
+
+describe('MagicLinkBody — redirect field (optional, max=200)', () => {
+  it('accepts a valid relative path as redirect', () => {
+    const r = MagicLinkBody.safeParse({ email: 'a@b.com', redirect: '/dashboard' });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts missing redirect (optional)', () => {
+    const r = MagicLinkBody.safeParse({ email: 'a@b.com' });
+    expect(r.success).toBe(true);
+  });
+
+  it('accepts redirect of exactly 200 chars', () => {
+    const r = MagicLinkBody.safeParse({ email: 'a@b.com', redirect: '/'.repeat(200) });
+    expect(r.success).toBe(true);
+  });
+
+  it('rejects redirect of 201 chars', () => {
+    const r = MagicLinkBody.safeParse({ email: 'a@b.com', redirect: '/'.repeat(201) });
+    expect(r.success).toBe(false);
+  });
+});
+
+describe('Auth constants (spec §5.10, §2 #21)', () => {
+  it('SESSION_7_DAYS_SECONDS is 604800', () => {
+    expect(SESSION_7_DAYS_SECONDS).toBe(604_800);
+  });
+
+  it('MAGIC_LINK_EXPIRY_MINUTES is 30', () => {
+    expect(MAGIC_LINK_EXPIRY_MINUTES).toBe(30);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `__test__` seam to `auth.ts` (MagicLinkBody, SESSION_7_DAYS_SECONDS, MAGIC_LINK_EXPIRY_MINUTES, safeRedirect)
- 10 standalone unit tests (no DB) for email validation, redirect max=200 boundary, and auth constants
- `auth.test.ts` only tests the full flow inside `describeIfDocker`

## Test plan
- [x] `bun run test --reporter=verbose test/magic-link-schema-pin.test.ts` → 10/10 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)