### PR TITLE
test(api): unit-test buildResendClient() stub mode (spec §2 #26)

### DIFF
--- a/apps/api/test/resend-client-stub-pin.test.ts
+++ b/apps/api/test/resend-client-stub-pin.test.ts
@@ -1,0 +1,60 @@
+/**
+ * resend-client-stub-pin.test.ts — unit tests for buildResendClient()
+ * stub mode (spec §2 #26 / RESEND_TEST_MODE=stub).
+ *
+ * The stub path is used in all CI tests (RESEND_TEST_MODE=stub env var).
+ * buildResendClient() itself is never directly tested — the auth.test.ts
+ * creates its own hand-rolled stub. This file pins:
+ *  - testMode=true → sendMagicLink() resolves without throwing
+ *  - testMode=true → sendCapWarning() resolves without throwing
+ *  - callCount increments on each sendMagicLink call
+ *  - placeholder API key ('re_not_configured') forces stub mode even
+ *    if testMode=false
+ */
+
+import { describe, it, expect } from 'vitest';
+import { buildResendClient } from '../src/email/resend.js';
+
+const STUB_OPTS = { apiKey: 're_stub_key', testMode: true };
+
+describe('buildResendClient() stub mode (spec §2 #26)', () => {
+  it('sendMagicLink resolves without throwing in stub mode', async () => {
+    const client = buildResendClient(STUB_OPTS);
+    await expect(
+      client.sendMagicLink({ to: 'user@example.com', verifyUrl: 'https://x.test/verify' }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('sendCapWarning resolves without throwing in stub mode', async () => {
+    const client = buildResendClient(STUB_OPTS);
+    await expect(
+      client.sendCapWarning({
+        to: 'user@example.com',
+        account_id: '42',
+        current_cents: 5000,
+        cap_cents: 10000,
+        study_id: '7',
+      }),
+    ).resolves.toBeUndefined();
+  });
+
+  it('callCount starts at 0', () => {
+    const client = buildResendClient(STUB_OPTS);
+    expect(client.callCount).toBe(0);
+  });
+
+  it('callCount increments on each sendMagicLink call', async () => {
+    const client = buildResendClient(STUB_OPTS);
+    await client.sendMagicLink({ to: 'a@b.com', verifyUrl: 'https://x.test/v' });
+    await client.sendMagicLink({ to: 'c@d.com', verifyUrl: 'https://x.test/v2' });
+    expect(client.callCount).toBe(2);
+  });
+
+  it('placeholder API key forces stub mode (no Resend network call)', async () => {
+    const client = buildResendClient({ apiKey: 're_not_configured', testMode: false });
+    // If it tried a real call with this key it would throw; stub mode should succeed.
+    await expect(
+      client.sendMagicLink({ to: 'x@y.com', verifyUrl: 'https://test/v' }),
+    ).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary
- 5 unit tests for `buildResendClient()` stub behavior — never directly tested before
- `auth.test.ts` creates its own hand-rolled stub instead of using `buildResendClient`
- Covers: `sendMagicLink`/`sendCapWarning` resolve in stub mode, `callCount` tracking, placeholder key auto-stubs
- No source changes

## Test plan
- [x] `bun run test --reporter=verbose test/resend-client-stub-pin.test.ts` → 5/5 pass locally

🤖 Generated with [Claude Code](https://claude.com/claude-code)