### PR TITLE
test(visitor-worker, api): spec-pin 7 structured-log event names (spec §5.11, §5.12)

### DIFF
--- a/apps/api/test/api-key-event-names-pin.test.ts
+++ b/apps/api/test/api-key-event-names-pin.test.ts
@@ -1,0 +1,31 @@
+/**
+ * api-key-event-names-pin.test.ts — spec-pin for structured-log event names
+ * emitted by apps/api/src/routes/api-keys.ts (spec §2 #21, §2 #22, §5.10).
+ *
+ * These event strings appear in pino JSON log lines as `event:` fields.
+ * Security audit rules and SIEM integrations filter on them. Renaming would
+ * silently break audit-trail queries with no test catching the mismatch.
+ *
+ *   'api_key.created'  — emitted after POST /api/api-keys succeeds; the
+ *                        raw key is also logged masked (§2 #22) for
+ *                        creation evidence
+ *   'api_key.revoked'  — emitted after DELETE /api/api-keys/:id succeeds
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(here, '..', 'src', 'routes', 'api-keys.ts'), 'utf8');
+
+describe('api-keys structured-log event names spec-pin (spec §2 #21, §5.10)', () => {
+  it("'api_key.created' event name is present in api-keys.ts", () => {
+    expect(src).toContain("'api_key.created'");
+  });
+
+  it("'api_key.revoked' event name is present in api-keys.ts", () => {
+    expect(src).toContain("'api_key.revoked'");
+  });
+});

--- a/apps/visitor-worker/test/eventNamesPin.test.ts
+++ b/apps/visitor-worker/test/eventNamesPin.test.ts
@@ -1,0 +1,45 @@
+/**
+ * eventNamesPin.test.ts — spec-pin for structured-log event names emitted by
+ * apps/visitor-worker/src/poller.ts (spec §5.11, §5.12).
+ *
+ * These event strings appear as `event:` fields in pino JSON log lines.
+ * Alerting rules filter on these values. Renaming any would silently break
+ * on-call alerts with no test catching the mismatch.
+ *
+ * Covered events:
+ *   'visit.no_snapshot'          — a11y_object_key is NULL; capture not linked
+ *   'visit.storage_read_failed'  — object storage read error
+ *   'visit.backstory_parse_failed' — backstory_payload JSON parse error
+ *   'visit.backstory_invalid'    — backstory_payload fails Backstory schema
+ *   'visitor_poll.error'         — unhandled error in the polling loop
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(here, '..', 'src', 'poller.ts'), 'utf8');
+
+describe('visitor-worker structured-log event names spec-pin (spec §5.11, §5.12)', () => {
+  it("'visit.no_snapshot' event name is present", () => {
+    expect(src).toContain("'visit.no_snapshot'");
+  });
+
+  it("'visit.storage_read_failed' event name is present", () => {
+    expect(src).toContain("'visit.storage_read_failed'");
+  });
+
+  it("'visit.backstory_parse_failed' event name is present", () => {
+    expect(src).toContain("'visit.backstory_parse_failed'");
+  });
+
+  it("'visit.backstory_invalid' event name is present", () => {
+    expect(src).toContain("'visit.backstory_invalid'");
+  });
+
+  it("'visitor_poll.error' event name is present", () => {
+    expect(src).toContain("'visitor_poll.error'");
+  });
+});


### PR DESCRIPTION
## Summary

Pins 7 structured-log `event:` names across visitor-worker and API:

**visitor-worker `poller.ts`** (5 events): `visit.no_snapshot`, `visit.storage_read_failed`, `visit.backstory_parse_failed`, `visit.backstory_invalid`, `visitor_poll.error`

**API `api-keys.ts`** (2 events): `api_key.created`, `api_key.revoked`

Companion to PR #451 (capture-worker event names). None were independently asserted — a rename would silently break alerting/SIEM queries.

## Test plan
- [ ] 5 tests pass in `@willbuy/visitor-worker` workspace
- [ ] 2 tests pass in `@willbuy/api` workspace (no Docker for either)
- [ ] `bun run --filter '@willbuy/visitor-worker' test -- eventNamesPin`
- [ ] `bun run --filter '@willbuy/api' test -- api-key-event-names-pin`

🤖 Generated with [Claude Code](https://claude.com/claude-code)