### PR TITLE
test(api): spec-pin study status SQL strings in aggregator-lock.ts

### DIFF
--- a/apps/api/test/aggregatorLockStatusPin.test.ts
+++ b/apps/api/test/aggregatorLockStatusPin.test.ts
@@ -1,0 +1,48 @@
+/**
+ * aggregatorLockStatusPin.test.ts — spec-pin for study status strings in
+ * apps/api/src/finalize/aggregator-lock.ts (spec §5.11).
+ *
+ * acquireFinalizeLock reads status='aggregating' to claim the single-writer lock.
+ * commitReport writes status='ready' on successful finalization.
+ * failStudy   writes status='failed' on aggregation failure.
+ *
+ * These are SQL template-literal strings, not TypeScript types. A coordinated
+ * rename compiles cleanly but breaks the state machine at runtime because the
+ * migration CHECK constraint (0002_studies.sql) only recognises the original
+ * values.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(
+  resolve(here, '..', 'src', 'finalize', 'aggregator-lock.ts'),
+  'utf8',
+);
+
+describe("aggregator-lock.ts study status SQL strings (spec §5.11)", () => {
+  it("acquireFinalizeLock reads status = 'aggregating'", () => {
+    expect(src).toContain("status = 'aggregating'");
+  });
+
+  it("commitReport writes status = 'ready'", () => {
+    expect(src).toContain("status = 'ready'");
+  });
+
+  it("failStudy writes status = 'failed'", () => {
+    expect(src).toContain("status = 'failed'");
+  });
+
+  it("all three status strings appear in correct function order", () => {
+    const aggIdx = src.indexOf("status = 'aggregating'");
+    const readyIdx = src.indexOf("status = 'ready'");
+    const failedIdx = src.indexOf("status = 'failed'");
+    // acquireFinalizeLock precedes commitReport precedes failStudy in the file.
+    expect(aggIdx).toBeGreaterThan(-1);
+    expect(readyIdx).toBeGreaterThan(aggIdx);
+    expect(failedIdx).toBeGreaterThan(readyIdx);
+  });
+});


### PR DESCRIPTION
## Summary

- Pins the three `studies.status` SQL literal strings in `apps/api/src/finalize/aggregator-lock.ts` (spec §5.11)
- `'aggregating'` — read in `acquireFinalizeLock` as the single-writer lock condition
- `'ready'` — written by `commitReport` on successful finalization
- `'failed'` — written by `failStudy` on aggregation failure
- Includes a structural test asserting the three strings appear in file order (lock → commit → fail)

## Why this matters

All three are SQL template-literal strings, not TypeScript union type members. A coordinated rename (e.g., `'aggregating'` → `'aggregating_now'`) compiles cleanly but silently breaks `acquireFinalizeLock`: the lock query returns zero rows for every study because `status = 'aggregating_now'` never matches the DB's `CHECK('aggregating')` constraint, and no report is ever written.

## Test plan

- [x] `bun run test --run test/aggregatorLockStatusPin.test.ts` → 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)