### PR TITLE
test(visitor-worker): spec-pin study status SQL strings visiting→aggregating

### DIFF
--- a/apps/visitor-worker/test/studyStatusTransitionsPin.test.ts
+++ b/apps/visitor-worker/test/studyStatusTransitionsPin.test.ts
@@ -1,0 +1,44 @@
+/**
+ * studyStatusTransitionsPin.test.ts — spec-pin for study status SQL strings
+ * in apps/visitor-worker/src/poller.ts (spec §5.11).
+ *
+ * The visitor-worker drives the second state-machine transition:
+ *   study.status = 'visiting'  →  study.status = 'aggregating'
+ *
+ * pollOnce SELECTs visits whose study is in 'visiting' state; when all visits
+ * are processed, maybeAdvanceStudy UPDATEs the study to 'aggregating' to hand
+ * off to the aggregator subprocess.
+ *
+ * Both strings are SQL template-literal values, not TypeScript types.
+ * Renaming either (e.g. 'visiting' → 'running') compiles cleanly but breaks
+ * the poll query or the state transition at runtime.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(here, '..', 'src', 'poller.ts'), 'utf8');
+
+describe("visitor-worker poller study status SQL strings (spec §5.11)", () => {
+  it("reads visits for studies with status = 'visiting'", () => {
+    expect(src).toContain("s.status = 'visiting'");
+  });
+
+  it("advances study to status = 'aggregating' when all visits are processed", () => {
+    expect(src).toContain("SET status = 'aggregating'");
+  });
+
+  it("the transition guard checks AND status = 'visiting' to be idempotent", () => {
+    expect(src).toContain("AND status = 'visiting'");
+  });
+
+  it("'aggregating' write appears after 'visiting' read in the file", () => {
+    const readIdx = src.indexOf("s.status = 'visiting'");
+    const writeIdx = src.indexOf("SET status = 'aggregating'");
+    expect(readIdx).toBeGreaterThan(-1);
+    expect(writeIdx).toBeGreaterThan(readIdx);
+  });
+});


### PR DESCRIPTION
## Summary

- Pins the study status SQL literal strings in `apps/visitor-worker/src/poller.ts` (spec §5.11)
- `'visiting'` — filter condition in `pollOnce` SELECT: `WHERE s.status = 'visiting'`
- `'aggregating'` — state transition write in `maybeAdvanceStudy`: `SET status = 'aggregating' WHERE ... AND status = 'visiting'`
- Structural test asserting the write appears after the read in the file

## Why this matters

These are the SQL template-literal strings driving the second leg of the study state machine (`visiting → aggregating`). They are not TypeScript types — renaming either compiles cleanly but breaks the poll at runtime: the visitor-worker would never pick up visits (wrong filter), or never hand off to the aggregator (wrong write value).

Companion to PR #456 (capture-worker `capturing→visiting` pin) and PR #455 (API `aggregator-lock` `aggregating→ready|failed` pin). Together, all five study status SQL strings are now pinned across the full state machine.

## Test plan

- [x] `bun run test --run test/studyStatusTransitionsPin.test.ts` → 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)