### PR TITLE
test(aggregator): spec-pin HDBSCAN constructor parameters in cluster.py

### DIFF
--- a/apps/aggregator/tests/test_cluster_hdbscan_params_pin.py
+++ b/apps/aggregator/tests/test_cluster_hdbscan_params_pin.py
@@ -1,0 +1,50 @@
+"""Spec-pin for HDBSCAN parameters in aggregator/cluster.py (spec §17).
+
+The spec §17 prescribes the clustering algorithm verbatim:
+  HDBSCAN(min_cluster_size=3, min_samples=3, cluster_selection_method='eom',
+          metric='precomputed', random_state=42)
+
+Changing any of these parameters silently changes which findings are grouped
+into themes and which are classified as noise:
+  - min_cluster_size=3: raising drops small-but-real clusters from the report;
+    lowering creates singleton clusters from noise.
+  - min_samples=3: controls noise sensitivity (higher = more noise points).
+  - cluster_selection_method='eom': 'leaf' would produce fewer, larger clusters.
+  - metric='precomputed': we pre-compute the cosine distance matrix to work
+    around HDBSCAN's metric='cosine' compatibility issues (see B5/B8 comments).
+  - random_state=42: spec §17 verbatim; ensures reproducible cluster labels.
+"""
+
+from __future__ import annotations
+
+import pathlib
+
+
+SRC = (
+    pathlib.Path(__file__).parent.parent / "src" / "aggregator" / "cluster.py"
+).read_text()
+
+
+def test_min_cluster_size_is_3() -> None:
+    """Spec §17: HDBSCAN(min_cluster_size=3)."""
+    assert "min_cluster_size=3" in SRC
+
+
+def test_min_samples_is_3() -> None:
+    """Spec §17: HDBSCAN(min_samples=3)."""
+    assert "min_samples=3" in SRC
+
+
+def test_cluster_selection_method_is_eom() -> None:
+    """Spec §17: cluster_selection_method='eom' (excess-of-mass)."""
+    assert 'cluster_selection_method="eom"' in SRC
+
+
+def test_metric_is_precomputed() -> None:
+    """Uses metric='precomputed' to supply our own cosine distance matrix (B5/B8 workaround)."""
+    assert 'metric="precomputed"' in SRC
+
+
+def test_random_state_is_42() -> None:
+    """Spec §17 verbatim: random_state=42 for reproducible cluster labels."""
+    assert "random_state=42" in SRC


### PR DESCRIPTION
## Summary

- Pins the 5 HDBSCAN constructor parameters in `apps/aggregator/src/aggregator/cluster.py` (spec §17)
- `min_cluster_size=3` — minimum findings per cluster; raising drops small real clusters
- `min_samples=3` — noise sensitivity parameter
- `cluster_selection_method="eom"` — excess-of-mass extraction (vs. `"leaf"` which gives different topologies)
- `metric="precomputed"` — supplies cosine distance matrix directly (B5/B8 workaround)
- `random_state=42` — spec §17 verbatim; reproducible cluster label assignment

## Why this matters

These are the exact parameters from spec §17. Changing any one silently alters which findings appear in the theme board:
- `min_cluster_size` increase drops borderline clusters; decrease creates singleton noise clusters
- `cluster_selection_method="leaf"` produces fewer, larger clusters with different membership
- `random_state` change doesn't affect the math but docs the reproducibility intent

No behavioral tests check these parameters directly (the cluster tests pass mock data that works regardless of parameter values within a reasonable range).

## Test plan

- [x] `pytest tests/test_cluster_hdbscan_params_pin.py -v` → 5 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)