### PR TITLE
test(api): spec-pin domain verification token patterns in domains.ts

### DIFF
--- a/apps/api/test/domainVerifyTokenPatternsPin.test.ts
+++ b/apps/api/test/domainVerifyTokenPatternsPin.test.ts
@@ -1,0 +1,50 @@
+/**
+ * domainVerifyTokenPatternsPin.test.ts — spec-pin for the domain
+ * verification token patterns in apps/api/src/routes/domains.ts (spec §2 #1).
+ *
+ * Three verification methods (§2 #1) each use the same token string but
+ * embed it in a method-specific pattern:
+ *
+ *   DNS TXT:   'willbuy-verify=<token>'
+ *   Well-known: GET /.well-known/willbuy-verify (body equals raw token)
+ *   Meta tag:  <meta name="willbuy-verify" content="<token>">
+ *
+ * The probe functions check that the token appears in the expected format.
+ * The methods.{dns, well_known, meta} response object shows users what to
+ * configure — they use these exact strings when setting up their verification.
+ *
+ * If 'willbuy-verify' is renamed (e.g. to 'willbuy-domain-token'), existing
+ * domain configurations become invalid — users would need to update their
+ * DNS records, well-known files, or meta tags to match the new prefix.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const src = readFileSync(resolve(here, '..', 'src', 'routes', 'domains.ts'), 'utf8');
+
+describe("domains.ts verification token patterns (spec §2 #1)", () => {
+  it("DNS TXT record probe checks 'willbuy-verify=' prefix in TXT data", () => {
+    // Line 169: const expected = `willbuy-verify=${token}`;
+    expect(src).toContain("willbuy-verify=");
+  });
+
+  it("well-known path probe fetches /.well-known/willbuy-verify", () => {
+    // Line 227: const url = `https://${domain}/.well-known/willbuy-verify`;
+    expect(src).toContain("/.well-known/willbuy-verify");
+  });
+
+  it("meta tag probe looks for name='willbuy-verify' in HTML", () => {
+    // Line 255: `<meta\\s+[^>]*name=["']willbuy-verify["']...`
+    expect(src).toContain("name=[\"']willbuy-verify[\"']");
+  });
+
+  it("methods object in POST response uses 'willbuy-verify' prefix for all three methods", () => {
+    // Lines 318-320: dns/well_known/meta show the user what to configure.
+    const count = (src.match(/willbuy-verify/g) ?? []).length;
+    expect(count).toBeGreaterThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## Summary

- Pins the three domain verification token patterns in `apps/api/src/routes/domains.ts` (spec §2 #1)
- `willbuy-verify=` — DNS TXT record prefix checked by the DNS probe
- `/.well-known/willbuy-verify` — well-known file path probed over HTTPS
- `name=["']willbuy-verify["']` — meta tag name attribute in the HTML probe regex

## Why this matters

These three strings are shown to users in the `methods.{dns, well_known, meta}` response object from `POST /api/domains`. Users configure their DNS records, web server files, or HTML meta tags based on these exact values. Renaming `'willbuy-verify'` to anything else would:
1. Break all existing domain verifications (old configurations no longer match the new probe)
2. Invalidate the verification instructions shown to new users who configured with the old string

The strings appear in 5+ places in domains.ts (probe functions, response methods object, comments).

## Test plan

- [x] `bun run test --run test/domainVerifyTokenPatternsPin.test.ts` → 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)