### PR TITLE
test(api): spec-pin 'pack_id' Stripe metadata key coordination

### DIFF
--- a/apps/api/test/stripePackIdMetadataKeyPin.test.ts
+++ b/apps/api/test/stripePackIdMetadataKeyPin.test.ts
@@ -1,0 +1,50 @@
+/**
+ * stripePackIdMetadataKeyPin.test.ts — spec-pin for the 'pack_id' metadata
+ * key used to pass pack identity through Stripe Checkout (spec §4.1 / §5.6).
+ *
+ * The metadata key 'pack_id' is set in checkout.ts when creating the
+ * Checkout Session:
+ *   metadata: { pack_id: packId }
+ *
+ * And read back in stripe-webhook.ts when the payment completes:
+ *   session.metadata?.['pack_id']
+ *
+ * If renamed in either file (e.g., to 'packId' or 'pack'), the webhook
+ * can't look up the pack and logs a warning — the credit_ledger INSERT is
+ * skipped and the account is silently not credited despite a successful payment.
+ *
+ * The two files use different syntax:
+ *   checkout.ts:       { pack_id: packId }  — object shorthand notation
+ *   stripe-webhook.ts: ['pack_id']           — string indexer
+ *
+ * Both must use the same key string 'pack_id'.
+ */
+
+import { describe, expect, it } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve, dirname } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const checkoutSrc = readFileSync(resolve(here, '..', 'src', 'routes', 'checkout.ts'), 'utf8');
+const webhookSrc = readFileSync(resolve(here, '..', 'src', 'routes', 'stripe-webhook.ts'), 'utf8');
+
+describe("Stripe 'pack_id' metadata key coordination (spec §4.1)", () => {
+  it("checkout.ts sets metadata.pack_id on the Checkout Session", () => {
+    expect(checkoutSrc).toContain("pack_id: packId");
+  });
+
+  it("stripe-webhook.ts reads metadata['pack_id'] from the completed session", () => {
+    expect(webhookSrc).toContain("['pack_id']");
+  });
+
+  it("the metadata key in checkout.ts is the string 'pack_id' (not 'packId' or 'pack')", () => {
+    // The Zod schema uses pack_id as the field name — confirm it appears in metadata context.
+    expect(checkoutSrc).toContain("metadata: { pack_id:");
+  });
+
+  it("webhook reads with optional chaining on metadata before ['pack_id']", () => {
+    // Defensive access: session.metadata?.['pack_id'] — metadata can be null.
+    expect(webhookSrc).toContain("metadata?.['pack_id']");
+  });
+});


### PR DESCRIPTION
## Summary

- Pins the `'pack_id'` Stripe Checkout Session metadata key used in two API routes (spec §4.1 / §5.6)
- `checkout.ts`: `metadata: { pack_id: packId }` — sets key when creating session
- `stripe-webhook.ts`: `session.metadata?.['pack_id']` — reads key on payment completion
- Verifies the webhook uses optional chaining (`?.`) before the index access

## Why this matters

`'pack_id'` is the coordination key that links the Stripe Checkout Session back to the willbuy pack tier. It's set in `checkout.ts` and read in `stripe-webhook.ts` — two files that are never compared at compile time. Renaming the key in one file without the other means the webhook can't look up the pack; it logs a warning and skips the `credit_ledger` INSERT. Result: Stripe charges the customer but the account balance is never updated.

This is a **cross-file contract** — TypeScript's type system does not verify that the same key string is used in both places.

## Test plan

- [x] `bun run test --run test/stripePackIdMetadataKeyPin.test.ts` → 4 passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)