### PR TITLE
fix(api): accept form POST on sign-out route (fixes #476)

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -190,10 +190,47 @@ export async function registerAuthRoutes(
 
   // ---------------------------------------------------------------------------
   // POST /api/auth/sign-out
+  //
+  // Wrapped in an encapsulated scope so the content-type parser overrides are
+  // local to this route and do not affect other routes.
+  //
+  // Browsers submit HTML forms as application/x-www-form-urlencoded (or with no
+  // Content-Type header when the body is empty). Fastify's default parser only
+  // handles application/json, so bare form POSTs would receive a 415 before the
+  // handler runs. Since the sign-out handler never uses the request body we
+  // simply register parsers that discard whatever arrives (fixes #476).
   // ---------------------------------------------------------------------------
-  app.post('/api/auth/sign-out', async (_req: FastifyRequest, reply: FastifyReply) => {
-    const clearCookie = buildClearCookieHeader(env.NODE_ENV);
-    void reply.header('Set-Cookie', clearCookie);
-    return reply.code(302).redirect('/sign-in');
+  await app.register(async function signOutScope(scope) {
+    // Accept application/x-www-form-urlencoded — discard the body.
+    scope.addContentTypeParser(
+      'application/x-www-form-urlencoded',
+      { parseAs: 'string' },
+      function formBodyParser(
+        _req: FastifyRequest,
+        _body: string,
+        done: (err: Error | null, body?: unknown) => void,
+      ) {
+        done(null, {});
+      },
+    );
+
+    // Accept requests with no Content-Type header (empty form body).
+    scope.addContentTypeParser(
+      '*',
+      { parseAs: 'string' },
+      function wildcardBodyParser(
+        _req: FastifyRequest,
+        _body: string,
+        done: (err: Error | null, body?: unknown) => void,
+      ) {
+        done(null, {});
+      },
+    );
+
+    scope.post('/api/auth/sign-out', async (_req: FastifyRequest, reply: FastifyReply) => {
+      const clearCookie = buildClearCookieHeader(env.NODE_ENV);
+      void reply.header('Set-Cookie', clearCookie);
+      return reply.code(302).redirect('/sign-in');
+    });
   });
 }

--- a/apps/api/test/auth.test.ts
+++ b/apps/api/test/auth.test.ts
@@ -370,6 +370,49 @@ describeIfDocker('auth magic-link (issue #79, real DB)', () => {
   });
 
   // -------------------------------------------------------------------------
+  // AC8b: POST /api/auth/sign-out with no Content-Type (browser form, empty
+  //        body) → 302 to /sign-in and cookie cleared (fixes #476).
+  // -------------------------------------------------------------------------
+  it('AC8b: POST /api/auth/sign-out with no Content-Type → 302 to /sign-in, clears cookie', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/sign-out',
+      // No headers, no payload — mimics a browser submitting an empty form
+      // without a Content-Type header.
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/sign-in');
+
+    const setCookie = res.headers['set-cookie'];
+    const cookieStr = Array.isArray(setCookie) ? setCookie[0] : setCookie ?? '';
+    expect(cookieStr).toMatch(/wb_session=/);
+    expect(cookieStr).toMatch(/Max-Age=0/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // AC8c: POST /api/auth/sign-out with Content-Type: application/x-www-form-
+  //        urlencoded (standard browser HTML form submit) → 302 + cookie cleared
+  //        (fixes #476).
+  // -------------------------------------------------------------------------
+  it('AC8c: POST /api/auth/sign-out with application/x-www-form-urlencoded → 302, clears cookie', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/sign-out',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: '',
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/sign-in');
+
+    const setCookie = res.headers['set-cookie'];
+    const cookieStr = Array.isArray(setCookie) ? setCookie[0] : setCookie ?? '';
+    expect(cookieStr).toMatch(/wb_session=/);
+    expect(cookieStr).toMatch(/Max-Age=0/i);
+  });
+
+  // -------------------------------------------------------------------------
   // AC2-regression (issue #99 N3): idempotent re-request of magic-link keeps
   // the FIRST token usable. Two POSTs for the same email within 30 min must
   // not invalidate the earlier token; the first token still verifies → 302.


### PR DESCRIPTION
## Root cause

`POST /api/auth/sign-out` returned HTTP 415 Unsupported Media Type when submitted from a browser HTML `<form>`. Browsers send form POSTs as `Content-Type: application/x-www-form-urlencoded`. Fastify's default parser only handles `application/json`, so it rejected the request with 415 before the route handler ever ran.

## Fix

Wrapped the sign-out route in an encapsulated Fastify scope (matching the pattern used in `stripe-webhook.ts`) and registered two content-type parsers inside that scope:

1. `application/x-www-form-urlencoded` — standard browser HTML form submit
2. `*` (wildcard) — requests with no `Content-Type` header at all (empty form body)

Both parsers simply discard the body. The sign-out handler only clears the session cookie and 302-redirects; it never reads the request body.

The scoped registration ensures these parser overrides are not visible to other routes.

## Tests

Added two new TDD tests (AC8b and AC8c) that were **red before the fix**:

- **AC8b**: `POST /api/auth/sign-out` with no Content-Type/no body → 302 + cookie cleared
- **AC8c**: `POST /api/auth/sign-out` with `Content-Type: application/x-www-form-urlencoded` → 302 + cookie cleared

Full suite: **14/14 passing** (no regressions).

## curl test evidence

Verified via `app.inject()` (equivalent to curl against a running server):

```
--- CASE 1: no Content-Type, no body (empty form) ---
HTTP 302  Location: /sign-in
Set-Cookie: wb_session=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0

--- CASE 2: Content-Type: application/x-www-form-urlencoded ---
HTTP 302  Location: /sign-in
Set-Cookie: wb_session=; HttpOnly; SameSite=Lax; Path=/; Max-Age=0
```

Both cases return 302 with the session cookie cleared (`Max-Age=0`).

Closes #476