### PR TITLE
fix(web+api): add View Report link to dashboard + fix study detail page (fixes #478)

### DIFF
--- a/apps/api/src/routes/auth.ts
+++ b/apps/api/src/routes/auth.ts
@@ -190,10 +190,47 @@ export async function registerAuthRoutes(
 
   // ---------------------------------------------------------------------------
   // POST /api/auth/sign-out
+  //
+  // Wrapped in an encapsulated scope so the content-type parser overrides are
+  // local to this route and do not affect other routes.
+  //
+  // Browsers submit HTML forms as application/x-www-form-urlencoded (or with no
+  // Content-Type header when the body is empty). Fastify's default parser only
+  // handles application/json, so bare form POSTs would receive a 415 before the
+  // handler runs. Since the sign-out handler never uses the request body we
+  // simply register parsers that discard whatever arrives (fixes #476).
   // ---------------------------------------------------------------------------
-  app.post('/api/auth/sign-out', async (_req: FastifyRequest, reply: FastifyReply) => {
-    const clearCookie = buildClearCookieHeader(env.NODE_ENV);
-    void reply.header('Set-Cookie', clearCookie);
-    return reply.code(302).redirect('/sign-in');
+  await app.register(async function signOutScope(scope) {
+    // Accept application/x-www-form-urlencoded — discard the body.
+    scope.addContentTypeParser(
+      'application/x-www-form-urlencoded',
+      { parseAs: 'string' },
+      function formBodyParser(
+        _req: FastifyRequest,
+        _body: string,
+        done: (err: Error | null, body?: unknown) => void,
+      ) {
+        done(null, {});
+      },
+    );
+
+    // Accept requests with no Content-Type header (empty form body).
+    scope.addContentTypeParser(
+      '*',
+      { parseAs: 'string' },
+      function wildcardBodyParser(
+        _req: FastifyRequest,
+        _body: string,
+        done: (err: Error | null, body?: unknown) => void,
+      ) {
+        done(null, {});
+      },
+    );
+
+    scope.post('/api/auth/sign-out', async (_req: FastifyRequest, reply: FastifyReply) => {
+      const clearCookie = buildClearCookieHeader(env.NODE_ENV);
+      void reply.header('Set-Cookie', clearCookie);
+      return reply.code(302).redirect('/sign-in');
+    });
   });
 }

--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -401,6 +401,7 @@ export async function registerStudiesRoutes(
         visit_progress: { ok: okCount, failed: failedCount, total },
         started_at: study.created_at.toISOString(),
         finalized_at: study.finalized_at?.toISOString() ?? null,
+        slug: study.slug ?? undefined,
         ...(study.report_public !== null ? { report_public: study.report_public } : {}),
       });
     },

--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -370,7 +370,7 @@ export async function registerStudiesRoutes(
         report_public: boolean | null;
       }>(
         `SELECT s.id, s.account_id, s.status, s.created_at, s.finalized_at,
-                r.slug, r.public AS report_public
+                r.study_id::text AS slug, r.public AS report_public
            FROM studies s
            LEFT JOIN reports r ON r.study_id = s.id
           WHERE s.id = $1`,

--- a/apps/api/test/auth.test.ts
+++ b/apps/api/test/auth.test.ts
@@ -370,6 +370,49 @@ describeIfDocker('auth magic-link (issue #79, real DB)', () => {
   });
 
   // -------------------------------------------------------------------------
+  // AC8b: POST /api/auth/sign-out with no Content-Type (browser form, empty
+  //        body) → 302 to /sign-in and cookie cleared (fixes #476).
+  // -------------------------------------------------------------------------
+  it('AC8b: POST /api/auth/sign-out with no Content-Type → 302 to /sign-in, clears cookie', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/sign-out',
+      // No headers, no payload — mimics a browser submitting an empty form
+      // without a Content-Type header.
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/sign-in');
+
+    const setCookie = res.headers['set-cookie'];
+    const cookieStr = Array.isArray(setCookie) ? setCookie[0] : setCookie ?? '';
+    expect(cookieStr).toMatch(/wb_session=/);
+    expect(cookieStr).toMatch(/Max-Age=0/i);
+  });
+
+  // -------------------------------------------------------------------------
+  // AC8c: POST /api/auth/sign-out with Content-Type: application/x-www-form-
+  //        urlencoded (standard browser HTML form submit) → 302 + cookie cleared
+  //        (fixes #476).
+  // -------------------------------------------------------------------------
+  it('AC8c: POST /api/auth/sign-out with application/x-www-form-urlencoded → 302, clears cookie', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: '/api/auth/sign-out',
+      headers: { 'content-type': 'application/x-www-form-urlencoded' },
+      payload: '',
+    });
+
+    expect(res.statusCode).toBe(302);
+    expect(res.headers.location).toBe('/sign-in');
+
+    const setCookie = res.headers['set-cookie'];
+    const cookieStr = Array.isArray(setCookie) ? setCookie[0] : setCookie ?? '';
+    expect(cookieStr).toMatch(/wb_session=/);
+    expect(cookieStr).toMatch(/Max-Age=0/i);
+  });
+
+  // -------------------------------------------------------------------------
   // AC2-regression (issue #99 N3): idempotent re-request of magic-link keeps
   // the FIRST token usable. Two POSTs for the same email within 30 min must
   // not invalidate the earlier token; the first token still verifies → 302.

--- a/apps/web/app/dashboard/DashboardView.tsx
+++ b/apps/web/app/dashboard/DashboardView.tsx
@@ -187,6 +187,9 @@ export function DashboardView({ summary }: { summary: DashboardSummary }): React
                   <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">
                     Created
                   </th>
+                  <th scope="col" className="px-4 py-3 text-left text-xs font-medium uppercase tracking-wide text-gray-500">
+                    Action
+                  </th>
                 </tr>
               </thead>
               <tbody className="divide-y divide-gray-100">
@@ -221,6 +224,15 @@ export function DashboardView({ summary }: { summary: DashboardSummary }): React
                     </td>
                     <td className="whitespace-nowrap px-4 py-3 text-xs text-gray-500">
                       {formatCreatedAt(s.created_at)}
+                    </td>
+                    <td className="whitespace-nowrap px-4 py-3 text-sm">
+                      {s.status === 'ready' ? (
+                        <a href={`/r/${s.id}`} className="font-medium text-indigo-600 hover:underline text-xs">
+                          View report →
+                        </a>
+                      ) : (
+                        <span className="text-xs text-gray-400">—</span>
+                      )}
                     </td>
                   </tr>
                 ))}

--- a/apps/web/app/dashboard/DashboardView.tsx
+++ b/apps/web/app/dashboard/DashboardView.tsx
@@ -227,8 +227,8 @@ export function DashboardView({ summary }: { summary: DashboardSummary }): React
                     </td>
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
                       {s.status === 'ready' ? (
-                        <a href={`/r/${s.id}`} className="font-medium text-indigo-600 hover:underline text-xs">
-                          View report →
+                        <a href={`/dashboard/studies/${s.id}`} className="font-medium text-indigo-600 hover:underline text-xs">
+                          Open →
                         </a>
                       ) : (
                         <span className="text-xs text-gray-400">—</span>

--- a/apps/web/components/dashboard/PublishButton.tsx
+++ b/apps/web/components/dashboard/PublishButton.tsx
@@ -34,7 +34,7 @@ export function PublishButton({ studyId, reportSlug, initialPublished = false }:
     setLoading(true);
     setError(null);
     try {
-      const res = await fetch(`/api/studies/${studyId}/publish`, { method: 'POST' });
+      const res = await fetch(`/api/studies/${studyId}/publish`, { method: 'POST', credentials: 'include' });
       if (res.ok) {
         setPublished(true);
       } else {

--- a/apps/web/lib/api-client.ts
+++ b/apps/web/lib/api-client.ts
@@ -113,7 +113,7 @@ async function apiFetch<T>(
 
   let res: Response;
   try {
-    res = await fetch(`${getApiBase()}${path}`, { ...opts, headers });
+    res = await fetch(`${getApiBase()}${path}`, { credentials: 'include', ...opts, headers });
   } catch (err) {
     return { ok: false, status: 0, error: String(err) };
   }


### PR DESCRIPTION
## Summary

- **r.slug SQL fix**: `GET /api/studies/:id` was selecting `r.slug` from the `reports` table, but that column doesn't exist — caused 500 on every study detail load when a report existed. Fixed to `r.study_id::text AS slug`.
- **credentials: 'include'**: Added to `apiFetch` so session cookie is sent for all API calls.
- **PublishButton credentials**: Raw `fetch()` in PublishButton was missing `credentials: 'include'` → 401 silently.
- **slug field in response**: `r.slug` was queried but never emitted; now included as `slug: study.slug ?? undefined`.
- **Dashboard Action column**: Changed "View report →" link from `/r/:id` (404 before publish) to `/dashboard/studies/:id`. Same fix applied to DashboardView.
- **Sign-out 415**: Wraps sign-out route in encapsulated Fastify scope with discard parsers for `application/x-www-form-urlencoded` and `*`.

Fixes #476, #478, #480, #485.

## Test plan

- [x] `cd apps/web && bun run test --run` — 109 tests pass
- [x] `cd apps/api && bun run test --run` — 147 tests pass
- [ ] Manual: Sign in → `/dashboard` → study #1 shows "Open →" → click → `/dashboard/studies/1` loads with "Ready" status
- [ ] Manual: Click "Make report public" → button changes to "Report is now public — share this link"
- [ ] Manual: Click "View report" link → `/r/1` loads with full report visualization
- [ ] Manual: Click "Sign out" in nav → 302 to `/sign-in` (no 415 error)
- [ ] Manual: Screenshot each step above as evidence