### PR TITLE
fix(web): credits page broken in production — wrong cookie name (fixes #483)

### DIFF
--- a/apps/web/app/dashboard/credits/page.tsx
+++ b/apps/web/app/dashboard/credits/page.tsx
@@ -49,28 +49,38 @@ export default async function CreditsPage({
 }: {
   searchParams: Promise<{ success?: string; cancelled?: string }>;
 }) {
-  const cookieStore = await cookies();
-  const sessionCookie = cookieStore.get('wb_session');
+  // In Next 14 cookies() is sync; in Next 15 it became async. Cast to
+  // accommodate both without pulling in version-specific types.
+  const cookieStore = (cookies() as unknown) as {
+    getAll: () => Array<{ name: string; value: string }>;
+  };
+  const all = cookieStore.getAll();
+  const cookieHeader = all.map((c) => `${c.name}=${c.value}`).join('; ');
+
+  // In production the cookie is __Host-wb_session; in dev it is wb_session.
+  const hasSession = all.some(
+    (c) => c.name === 'wb_session' || c.name === '__Host-wb_session',
+  );
+  if (!hasSession) {
+    redirect('/sign-in?redirect=%2Fdashboard%2Fcredits');
+  }
+
   const params = await searchParams;
   const didSucceed = params.success === '1';
   const didCancel = params.cancelled === '1';
 
   let balance_cents = 0;
-  if (sessionCookie) {
-    try {
-      const res = await fetch(`${apiBaseUrl()}/api/dashboard/summary`, {
-        headers: { cookie: `wb_session=${sessionCookie.value}` },
-        cache: 'no-store',
-      });
-      if (res.status === 401) redirect('/sign-in?redirect=%2Fdashboard%2Fcredits');
-      if (res.ok) {
-        const data = (await res.json()) as DashboardSummary;
-        balance_cents = data.balance_cents;
-      }
-    } catch {
-      redirect('/sign-in?redirect=%2Fdashboard%2Fcredits');
+  try {
+    const res = await fetch(`${apiBaseUrl()}/api/dashboard/summary`, {
+      headers: { cookie: cookieHeader },
+      cache: 'no-store',
+    });
+    if (res.status === 401) redirect('/sign-in?redirect=%2Fdashboard%2Fcredits');
+    if (res.ok) {
+      const data = (await res.json()) as DashboardSummary;
+      balance_cents = data.balance_cents;
     }
-  } else {
+  } catch {
     redirect('/sign-in?redirect=%2Fdashboard%2Fcredits');
   }
 


### PR DESCRIPTION
## Summary

`/dashboard/credits/page.tsx` was reading `cookieStore.get('wb_session')`. In production the cookie is `__Host-wb_session`. The old code returned undefined → redirected all authenticated users to sign-in. Credits page was completely broken in production.

Fix: replace `cookieStore.get()` with `cookieStore.getAll()` + `hasSession` check + full cookie header forwarding — same pattern as `dashboard/page.tsx`, `domains/page.tsx`, `studies/page.tsx`.

Fixes #483.

## Test plan

- [x] `cd apps/web && bun run test --run` — 109 tests pass
- [ ] Manual: Sign in → click "Credits" in nav → page loads showing current balance and the 3 pack tiles (Starter/Growth/Scale)
- [ ] Manual: Confirm page does NOT redirect to /sign-in when authenticated
- [ ] Manual: Screenshot the credits page with balance displayed as evidence