### PR TITLE
fix(web): dashboard Action column links to study detail page, not /r/:id (fixes #485)

### DIFF
--- a/apps/web/app/dashboard/studies/StudiesListView.tsx
+++ b/apps/web/app/dashboard/studies/StudiesListView.tsx
@@ -225,10 +225,10 @@ export function StudiesListView({
                     <td className="whitespace-nowrap px-4 py-3 text-sm">
                       {s.status === 'ready' ? (
                         <a
-                          href={`/r/${s.id}`}
-                          className="font-medium text-indigo-600 hover:underline"
+                          href={`/dashboard/studies/${s.id}`}
+                          className="font-medium text-indigo-600 hover:underline text-xs"
                         >
-                          View report
+                          Open →
                         </a>
                       ) : (
                         <span className="text-xs text-gray-400">—</span>

--- a/apps/web/test/studies-list.test.tsx
+++ b/apps/web/test/studies-list.test.tsx
@@ -111,18 +111,24 @@ describe('/dashboard/studies view (issue #85)', () => {
   });
 
   // -------------------------------------------------------------------------
-  // 4: Per-row "View report" link only when status=ready.
+  // 4: Per-row "Open →" link → /dashboard/studies/:id only when status=ready.
   // -------------------------------------------------------------------------
-  it('renders "View report" → /r/:id only for status=ready rows', () => {
+  it('renders "Open →" → /dashboard/studies/:id only for status=ready rows', () => {
     const html = renderToStaticMarkup(
       <StudiesListView studies={FIXTURE_STUDIES} nextCursor={null} />,
     );
-    // Ready row (id=101) has a /r/101 link.
-    expect(html).toMatch(/href="\/r\/101"/);
-    // Capturing row (id=102) does NOT have /r/102.
-    expect(html).not.toMatch(/href="\/r\/102"/);
-    // Failed row (id=103) does NOT have /r/103 (failed studies have no report).
-    expect(html).not.toMatch(/href="\/r\/103"/);
+    // The "Open →" label appears in the markup.
+    expect(html).toMatch(/Open →/);
+    // It is NOT the old /r/:id route (reports are private by default).
+    expect(html).not.toMatch(/href="\/r\/101"/);
+    // Only one action link: the ready row gets "Open →", others get "—".
+    const openMatches = html.match(/Open →/g);
+    expect(openMatches).toHaveLength(1);
+    // Non-ready rows do NOT get "Open →".
+    // (URL-column links to /dashboard/studies/102 still exist, but those are
+    //  in the URL cell, not the action cell — "Open →" is the discriminator.)
+    const dashCount = (html.match(/Open →/g) ?? []).length;
+    expect(dashCount).toBe(1);
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

`StudiesListView.tsx` had the "Report" column link pointing to `/r/${s.id}` for ready studies. Reports are private by default — this URL 404s until the owner publishes. `StudyListRow` has no `report_public` field so we cannot know from the list whether the report is published.

Fix: changes link target from `/r/${s.id}` to `/dashboard/studies/${s.id}` (the study detail page where the publish button lives) and renames the label to "Open →". Test asserts the new label and no `/r/:id` href.

Fixes #485.

## Test plan

- [x] `cd apps/web && bun run test --run` — 109 tests pass
- [ ] Manual: Sign in → click "Your studies" or `/dashboard/studies` → the "Report" column shows "Open →" for a ready study
- [ ] Manual: Click "Open →" → navigates to `/dashboard/studies/:id` (the detail page), NOT to `/r/:id`
- [ ] Manual: Screenshot the studies list with "Open →" link as evidence