### PR TITLE
infra: add systemd services for visitor-worker and aggregator (fixes #489)

### DIFF
--- a/infra/systemd/willbuy-aggregator-trigger.service
+++ b/infra/systemd/willbuy-aggregator-trigger.service
@@ -1,0 +1,19 @@
+[Unit]
+# willbuy aggregator trigger — polls for studies in `aggregating` status
+# every 30 s and runs the aggregator Docker container per study,
+# transitioning studies aggregating→ready.
+
+Description=willbuy aggregator trigger
+After=network.target willbuy-api.service
+
+[Service]
+Type=simple
+User=willbuy
+WorkingDirectory=/srv/willbuy
+EnvironmentFile=/etc/willbuy/app.env
+ExecStart=/usr/local/bin/willbuy-aggregator-trigger.sh
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target

--- a/infra/systemd/willbuy-aggregator-trigger.service
+++ b/infra/systemd/willbuy-aggregator-trigger.service
@@ -4,7 +4,8 @@
 # transitioning studies aggregating→ready.
 
 Description=willbuy aggregator trigger
-After=network.target willbuy-api.service
+Requires=docker.service
+After=network.target docker.service willbuy-api.service
 
 [Service]
 Type=simple

--- a/infra/systemd/willbuy-aggregator-trigger.sh
+++ b/infra/systemd/willbuy-aggregator-trigger.sh
@@ -20,7 +20,7 @@ echo "[aggregator-trigger] starting poll loop"
 while true; do
   study_id=$(psql "$DATABASE_URL" --no-align --tuples-only --command \
     "SELECT id FROM studies WHERE status='aggregating' ORDER BY created_at ASC LIMIT 1" \
-    2>/dev/null || true)
+    2>/dev/null | tr -d '[:space:]' || true)
 
   if [[ -n "$study_id" ]]; then
     echo "[aggregator-trigger] running aggregator for study $study_id"

--- a/infra/systemd/willbuy-aggregator-trigger.sh
+++ b/infra/systemd/willbuy-aggregator-trigger.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+# willbuy-aggregator-trigger.sh
+#
+# Polls for studies in `aggregating` status and runs the aggregator Docker
+# container for each one. Loaded into the environment by
+# willbuy-aggregator-trigger.service via EnvironmentFile=/etc/willbuy/app.env,
+# so DATABASE_URL is available at runtime.
+#
+# Runs as an infinite loop; systemd Restart=on-failure handles crashes.
+
+set -euo pipefail
+
+if [[ -z "${DATABASE_URL:-}" ]]; then
+  echo "[aggregator-trigger] ERROR: DATABASE_URL is not set" >&2
+  exit 1
+fi
+
+echo "[aggregator-trigger] starting poll loop"
+
+while true; do
+  study_id=$(psql "$DATABASE_URL" --no-align --tuples-only --command \
+    "SELECT id FROM studies WHERE status='aggregating' ORDER BY created_at ASC LIMIT 1" \
+    2>/dev/null || true)
+
+  if [[ -n "$study_id" ]]; then
+    echo "[aggregator-trigger] running aggregator for study $study_id"
+    docker run --rm \
+      --env DATABASE_URL="$DATABASE_URL" \
+      willbuy-aggregator \
+      --study-id "$study_id"
+  fi
+
+  sleep 30
+done

--- a/infra/systemd/willbuy-visitor-worker.service
+++ b/infra/systemd/willbuy-visitor-worker.service
@@ -1,0 +1,22 @@
+[Unit]
+# willbuy visitor worker — polls DB for studies in `visiting` status,
+# calls LLM, and transitions studies visiting→aggregating.
+#
+# Depends on the API being up (shares app.env and the same DB).
+# The entry point is scripts/run-visitor-worker-dogfood.ts; this will be
+# replaced by a proper apps/visitor-worker entrypoint once #86 ships.
+
+Description=willbuy visitor worker
+After=network.target willbuy-api.service
+
+[Service]
+Type=simple
+User=willbuy
+WorkingDirectory=/srv/willbuy
+EnvironmentFile=/etc/willbuy/app.env
+ExecStart=/home/willbuy/.bun/bin/bun run scripts/run-visitor-worker-dogfood.ts
+Restart=on-failure
+RestartSec=3
+
+[Install]
+WantedBy=multi-user.target


### PR DESCRIPTION
## Summary

No systemd services existed for the visitor worker or the aggregator. New studies were permanently stuck in `visiting` status — the visitor worker and aggregator must run as persistent processes for studies to complete.

- `willbuy-visitor-worker.service` — runs `scripts/run-visitor-worker-dogfood.ts` polling loop continuously (mirrors willbuy-api.service pattern)
- `willbuy-aggregator-trigger.service` + `willbuy-aggregator-trigger.sh` — polls `studies WHERE status='aggregating'` every 30s and runs `docker run willbuy-aggregator --study-id <id>`

Fixes #489.

## Deploy steps

```sh
sudo cp /srv/willbuy/infra/systemd/willbuy-visitor-worker.service /etc/systemd/system/
sudo cp /srv/willbuy/infra/systemd/willbuy-aggregator-trigger.service /etc/systemd/system/
sudo cp /srv/willbuy/infra/systemd/willbuy-aggregator-trigger.sh /usr/local/bin/
sudo chmod +x /usr/local/bin/willbuy-aggregator-trigger.sh
# Build aggregator Docker image first:
cd /srv/willbuy/apps/aggregator && sudo docker build -t willbuy-aggregator .
sudo systemctl daemon-reload
sudo systemctl enable --now willbuy-visitor-worker willbuy-aggregator-trigger
```

## Test plan

- [ ] Manual: `sudo systemctl status willbuy-visitor-worker willbuy-aggregator-trigger` → both show Active: active (running)
- [ ] Manual: Create a NEW study from `/dashboard/studies/new` → wait 5–15 minutes → study transitions through `capturing → visiting → aggregating → ready`
- [ ] Manual: Screenshot study status page showing "Ready" as evidence that the full pipeline completed