### PR TITLE
fix(infra): add nginx /stripe/ location for Stripe webhook — credits never applied without this

### DIFF
--- a/infra/nginx/willbuy.conf
+++ b/infra/nginx/willbuy.conf
@@ -37,6 +37,14 @@ server {
         proxy_set_header X-Forwarded-Proto $scheme;
     }
 
+    location /stripe/ {
+        proxy_pass http://127.0.0.1:3001;
+        proxy_set_header Host $host;
+        proxy_set_header X-Real-IP $remote_addr;
+        proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+        proxy_set_header X-Forwarded-Proto $scheme;
+    }
+
     location /health {
         proxy_pass http://127.0.0.1:3001/health;
     }


### PR DESCRIPTION
## Summary

`infra/nginx/willbuy.conf` was missing a `/stripe/` location block. The Stripe webhook handler is registered in Fastify at `POST /stripe/webhook`. Without this block, Stripe webhooks hit the `/` catch-all → Next.js (port 3000) → 404. Every payment was silently failing to credit any account.

Adds:
```nginx
location /stripe/ {
    proxy_pass http://127.0.0.1:3001;
    proxy_set_header Host $host;
    proxy_set_header X-Real-IP $remote_addr;
    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
    proxy_set_header X-Forwarded-Proto $scheme;
}
```

Note: the correct Stripe webhook URL is `https://willbuy.dev/stripe/webhook` (not `/api/stripe/webhook`).

Fixes #491.

## Deploy steps

```sh
sudo nginx -t && sudo nginx -s reload
```

## Test plan

- [ ] Manual: `curl -s -o /dev/null -w '%{http_code}' -X POST https://willbuy.dev/stripe/webhook` → 400 (missing stripe-signature from Fastify, NOT 404 from Next.js) — confirms nginx block is live
- [ ] Manual: After configuring Stripe (issue #195) — make a test purchase with card `4242 4242 4242 4242` → check `/dashboard/credits` shows increased balance
- [ ] Manual: Screenshot credits page before and after purchase as evidence