### PR TITLE
feat: share-token minting endpoint + UI button (closes #487)

### DIFF
--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -27,7 +27,9 @@
  *     and visit_progress {ok,failed,total} for the table render.
  */
 
+import { createHash } from 'node:crypto';
 import tldts from 'tldts';
+import { nanoid } from 'nanoid';
 import { z } from 'zod';
 import type { FastifyInstance, FastifyReply, FastifyRequest } from 'fastify';
 import type { Pool } from 'pg';
@@ -689,6 +691,86 @@ export async function registerStudiesRoutes(
       }
 
       return reply.code(200).send({ studies, next_cursor });
+    },
+  );
+
+  // ── POST /api/studies/:id/share-token (issue #487) ────────────────────────
+  //
+  // Mints a private revocable share link for the study's report.
+  // Spec refs: §2 #20 (share-token minting), user story 3 (CRO consultant
+  // mints a private share link for a client).
+  //
+  // - Owner POSTs to mint a 22-char nanoid token for their study's report.
+  // - Server stores SHA-256 hash of the token (never the raw token).
+  // - Default expiry: 90 days from now.
+  // - Returns the raw token ONCE — caller must save the link.
+  // - Link form: /r/<slug>?t=<token> where slug = study_id::text (amendment A12).
+  //
+  // Errors:
+  //   401 — no/invalid session (enforced by sessionMiddleware preHandler).
+  //   404 — study not owned by caller, or study has no report row yet.
+  //   409 — a non-revoked, non-expired share token already exists for this
+  //          report_slug; caller should revoke first (revocation deferred).
+  app.post<{ Params: { id: string } }>(
+    '/api/studies/:id/share-token',
+    { preHandler: [sessionMiddleware] },
+    async (req: FastifyRequest<{ Params: { id: string } }>, reply: FastifyReply) => {
+      const account = req.account!;
+      const studyId = req.params.id;
+
+      // Verify caller owns this study AND it already has a report row.
+      // A single JOIN enforces both constraints in one round-trip (no TOCTOU).
+      const reportResult = await pool.query<{ study_id: string }>(
+        `SELECT r.study_id::text AS study_id
+           FROM reports r
+           JOIN studies s ON s.id = r.study_id
+          WHERE s.id = $1
+            AND s.account_id = $2`,
+        [studyId, String(account.id)],
+      );
+
+      if (reportResult.rowCount === 0) {
+        return reply.code(404).send({ error: 'study not found' });
+      }
+
+      // §2 #20: report slug = study_id::text (amendment A12).
+      const reportSlug = studyId;
+
+      // 409 if an active (non-revoked, non-expired) token already exists.
+      const existingResult = await pool.query<{ id: string }>(
+        `SELECT id FROM share_tokens
+          WHERE report_slug = $1
+            AND revoked_at IS NULL
+            AND expires_at > now()`,
+        [reportSlug],
+      );
+
+      if ((existingResult.rowCount ?? 0) > 0) {
+        return reply.code(409).send({
+          error: 'a share token already exists for this report; revoke it first',
+        });
+      }
+
+      // Mint a 22-char nanoid token and store only its SHA-256 hash.
+      const rawToken = nanoid(22);
+      const tokenHash = createHash('sha256').update(rawToken).digest('hex');
+
+      // Default expiry: 90 days from now (spec §2 #20).
+      const expiresAt = new Date(Date.now() + 90 * 24 * 60 * 60 * 1000);
+
+      await pool.query(
+        `INSERT INTO share_tokens (report_slug, token_hash, expires_at, account_id)
+         VALUES ($1, $2, $3, $4)`,
+        [reportSlug, tokenHash, expiresAt.toISOString(), String(account.id)],
+      );
+
+      const shareUrl = `https://willbuy.dev/r/${reportSlug}?t=${rawToken}`;
+
+      return reply.code(201).send({
+        token: rawToken,
+        url: shareUrl,
+        expires_at: expiresAt.toISOString(),
+      });
     },
   );
 }

--- a/apps/api/test/share-tokens.test.ts
+++ b/apps/api/test/share-tokens.test.ts
@@ -1,0 +1,267 @@
+/**
+ * share-tokens.test.ts — TDD acceptance tests for issue #487.
+ *
+ * Spec refs: §2 #20 (share-token minting), §5.12 (share-token cookie redirect).
+ *
+ * Real-DB integration: spins up a Postgres 16 container via Docker, applies
+ * all migrations, seeds data, runs Fastify in-process via app.inject().
+ *
+ * POST /api/studies/:id/share-token
+ *   - 201: valid session + owned study with report → returns { token, url, expires_at }
+ *   - 401: no session
+ *   - 404: study exists but no report row yet
+ *   - 404: study not owned by caller
+ *   - 409: non-revoked, non-expired share token already exists for this report_slug
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from 'vitest';
+import { spawnSync } from 'node:child_process';
+import { createHash } from 'node:crypto';
+import { readdirSync, readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import type { FastifyInstance } from 'fastify';
+import { Client } from 'pg';
+
+import { startPostgres, stopPostgres } from '../../../tests/helpers/start-postgres.js';
+import { buildServer } from '../src/server.js';
+import { encodeSession } from '../src/auth/session.js';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const repoRoot = resolve(here, '../../..');
+const migrationsDir = resolve(repoRoot, 'infra/migrations');
+
+// --- Docker availability guard ---
+
+const dockerCheck = spawnSync('docker', ['version', '--format', '{{.Server.Version}}'], {
+  encoding: 'utf8',
+});
+const dockerAvailable = dockerCheck.status === 0;
+const describeIfDocker = dockerAvailable ? describe : describe.skip;
+
+function uid(): string {
+  return `${Date.now()}-${Math.floor(Math.random() * 1e6)}`;
+}
+
+async function applyMigrations(url: string): Promise<void> {
+  const files = readdirSync(migrationsDir)
+    .filter((f) => /^\d{4}_.*\.sql$/.test(f))
+    .sort();
+  const client = new Client({ connectionString: url });
+  await client.connect();
+  try {
+    for (const file of files) {
+      const sql = readFileSync(resolve(migrationsDir, file), 'utf8');
+      await client.query(sql);
+    }
+  } finally {
+    await client.end();
+  }
+}
+
+function sha256hex(s: string): string {
+  return createHash('sha256').update(s).digest('hex');
+}
+
+// Build a session cookie using the same HMAC signing as the session middleware.
+// Expires 1 hour from now — sufficient for test assertions.
+function buildSessionCookie(accountId: bigint | string, hmacKey: string, email = 'test@example.com'): string {
+  const expiresAt = new Date(Date.now() + 60 * 60 * 1000).toISOString();
+  const value = encodeSession({ account_id: String(accountId), owner_email: email, expires_at: expiresAt }, hmacKey);
+  return `wb_session=${value}`;
+}
+
+// --- Test suite ---
+
+describeIfDocker('POST /api/studies/:id/share-token (issue #487)', () => {
+  let container = '';
+  let dbUrl = '';
+  let app: FastifyInstance;
+  let accountId: bigint;
+  let otherAccountId: bigint;
+
+  // A study that has a report row (minted successfully).
+  let studyWithReport: string;
+  // A study with no report row yet.
+  let studyNoReport: string;
+  // A study owned by otherAccount (for 404 cross-account test).
+  let otherStudyWithReport: string;
+
+  const HMAC_KEY = 'test-session-hmac-key-share-tokens-487';
+
+  beforeAll(async () => {
+    const pg = await startPostgres({ containerPrefix: 'willbuy-sharetoken-test-' });
+    container = pg.container;
+    dbUrl = pg.url;
+
+    await applyMigrations(dbUrl);
+
+    const client = new Client({ connectionString: dbUrl });
+    await client.connect();
+    try {
+      // Account 1.
+      const acc1 = await client.query<{ id: bigint }>(
+        `INSERT INTO accounts (owner_email) VALUES ('share-test@example.com') RETURNING id`,
+      );
+      accountId = acc1.rows[0]!.id;
+
+      // Account 2 (cross-account ownership test).
+      const acc2 = await client.query<{ id: bigint }>(
+        `INSERT INTO accounts (owner_email) VALUES ('share-other@example.com') RETURNING id`,
+      );
+      otherAccountId = acc2.rows[0]!.id;
+
+      // Study with report (account 1).
+      const s1 = await client.query<{ id: string }>(
+        `INSERT INTO studies (account_id, kind, status, urls)
+         VALUES ($1, 'single', 'ready', ARRAY['https://example.com'])
+         RETURNING id`,
+        [String(accountId)],
+      );
+      studyWithReport = s1.rows[0]!.id;
+      // share_token_hash is NOT NULL in the reports table (legacy column, see 0009_reports.sql).
+      // Use a dummy hash value — the new minting endpoint stores tokens in share_tokens, not here.
+      await client.query(
+        `INSERT INTO reports (study_id, conv_score, paired_delta_json, share_token_hash, ready_at)
+         VALUES ($1, 0.75, '{}', $2, now())`,
+        [studyWithReport, sha256hex(`seed-dummy-${uid()}`)],
+      );
+
+      // Study without report (account 1).
+      const s2 = await client.query<{ id: string }>(
+        `INSERT INTO studies (account_id, kind, status, urls)
+         VALUES ($1, 'single', 'ready', ARRAY['https://example.com'])
+         RETURNING id`,
+        [String(accountId)],
+      );
+      studyNoReport = s2.rows[0]!.id;
+
+      // Study with report (account 2 — for cross-account 404).
+      const s3 = await client.query<{ id: string }>(
+        `INSERT INTO studies (account_id, kind, status, urls)
+         VALUES ($1, 'single', 'ready', ARRAY['https://other.com'])
+         RETURNING id`,
+        [String(otherAccountId)],
+      );
+      otherStudyWithReport = s3.rows[0]!.id;
+      await client.query(
+        `INSERT INTO reports (study_id, conv_score, paired_delta_json, share_token_hash, ready_at)
+         VALUES ($1, 0.50, '{}', $2, now())`,
+        [otherStudyWithReport, sha256hex(`seed-dummy-other-${uid()}`)],
+      );
+    } finally {
+      await client.end();
+    }
+
+    app = await buildServer({
+      env: {
+        PORT: 0,
+        LOG_LEVEL: 'silent',
+        URL_HASH_SALT: 'x'.repeat(32),
+        DATABASE_URL: dbUrl,
+        DAILY_CAP_CENTS: 10_000,
+        STRIPE_SECRET_KEY: 'sk_test_not_used_in_share_token_test',
+        STRIPE_WEBHOOK_SECRET: 'whsec_not_used',
+        STRIPE_PRICE_ID_STARTER: 'price_not_used',
+        STRIPE_PRICE_ID_GROWTH: 'price_not_used',
+        STRIPE_PRICE_ID_SCALE: 'price_not_used',
+        SESSION_HMAC_KEY: HMAC_KEY,
+        SHARE_TOKEN_HMAC_KEY: 'dev-only-share-token-hmac-key-not-for-production-use',
+      },
+    });
+  }, 60_000);
+
+  afterAll(async () => {
+    await app?.close();
+    if (container) stopPostgres(container);
+  });
+
+  // --- 401: no session ---
+
+  it('401 when no session cookie is present', async () => {
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/studies/${studyWithReport}/share-token`,
+    });
+    expect(res.statusCode).toBe(401);
+  });
+
+  // --- 404: study not owned by caller ---
+
+  it('404 when study belongs to a different account', async () => {
+    // Account 1 tries to mint a token for account 2's study.
+    const cookie = buildSessionCookie(accountId, HMAC_KEY);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/studies/${otherStudyWithReport}/share-token`,
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  // --- 404: study has no report row yet ---
+
+  it('404 when study exists but has no report row yet', async () => {
+    const cookie = buildSessionCookie(accountId, HMAC_KEY);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/studies/${studyNoReport}/share-token`,
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(404);
+  });
+
+  // --- 201: happy path ---
+
+  it('201 with token, url, and expires_at on first mint', async () => {
+    const cookie = buildSessionCookie(accountId, HMAC_KEY);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/studies/${studyWithReport}/share-token`,
+      headers: { cookie },
+    });
+
+    expect(res.statusCode).toBe(201);
+
+    const body = res.json<{ token: string; url: string; expires_at: string }>();
+    expect(typeof body.token).toBe('string');
+    expect(body.token).toHaveLength(22);
+    expect(body.url).toBe(`https://willbuy.dev/r/${studyWithReport}?t=${body.token}`);
+
+    // expires_at should be ~90 days from now (within a 5-minute window).
+    const expiresAt = new Date(body.expires_at);
+    const now = Date.now();
+    const ninetyDaysMs = 90 * 24 * 60 * 60 * 1000;
+    expect(expiresAt.getTime()).toBeGreaterThan(now + ninetyDaysMs - 5 * 60 * 1000);
+    expect(expiresAt.getTime()).toBeLessThan(now + ninetyDaysMs + 5 * 60 * 1000);
+
+    // Token must NOT be in DB (only the hash is stored).
+    const client = new Client({ connectionString: dbUrl });
+    await client.connect();
+    try {
+      const row = await client.query<{ token_hash: string }>(
+        `SELECT token_hash FROM share_tokens WHERE report_slug = $1`,
+        [studyWithReport],
+      );
+      expect(row.rows).toHaveLength(1);
+      // Verify the stored hash matches SHA-256 of the returned raw token.
+      expect(row.rows[0]!.token_hash).toBe(sha256hex(body.token));
+    } finally {
+      await client.end();
+    }
+  });
+
+  // --- 409: duplicate token for same report ---
+
+  it('409 when a non-revoked, non-expired token already exists for this report', async () => {
+    // The 201 test above already minted a token for studyWithReport.
+    // A second call should return 409.
+    const cookie = buildSessionCookie(accountId, HMAC_KEY);
+    const res = await app.inject({
+      method: 'POST',
+      url: `/api/studies/${studyWithReport}/share-token`,
+      headers: { cookie },
+    });
+    expect(res.statusCode).toBe(409);
+  });
+});

--- a/apps/web/app/dashboard/studies/[id]/page.tsx
+++ b/apps/web/app/dashboard/studies/[id]/page.tsx
@@ -22,6 +22,7 @@ import React from 'react';
 import { useState, useEffect } from 'react';
 import { getStudy, type GetStudyResponse, type StudyStatus } from '../../../../lib/api-client';
 import { PublishButton } from '../../../../components/dashboard/PublishButton';
+import { ShareLinkButton } from '../../../../components/dashboard/ShareLinkButton';
 
 // Poll interval in milliseconds (spec: 5 s).
 const POLL_INTERVAL_MS = 5_000;
@@ -222,6 +223,7 @@ function StudyStatusInner({ id }: { id: string }) {
             View report
           </a>
           <PublishButton studyId={s.id} reportSlug={s.slug ?? String(s.id)} initialPublished={s.report_public ?? false} />
+          <ShareLinkButton studyId={s.id} />
         </div>
       )}
 

--- a/apps/web/components/dashboard/ShareLinkButton.tsx
+++ b/apps/web/components/dashboard/ShareLinkButton.tsx
@@ -1,0 +1,115 @@
+'use client';
+
+// ShareLinkButton — mints a private revocable share link for a ready study's report.
+// Issue #487, spec §2 #20 (user story 3: CRO consultant mints a share link for a client).
+//
+// Calls POST /api/studies/:id/share-token (session-cookie auth).
+// On 201: shows the full URL in a <code> block + Copy button (clipboard API).
+// On 409: shows "A share link already exists — revoke it first" in muted text.
+// On other error: shows a brief error message (data-testid="share-link-error").
+
+import React, { useState } from 'react';
+
+interface ShareLinkButtonProps {
+  studyId: string | number;
+}
+
+type State =
+  | { kind: 'idle' }
+  | { kind: 'loading' }
+  | { kind: 'done'; url: string }
+  | { kind: 'conflict' }
+  | { kind: 'error'; message: string };
+
+export function ShareLinkButton({ studyId }: ShareLinkButtonProps) {
+  const [state, setState] = useState<State>({ kind: 'idle' });
+  const [copied, setCopied] = useState(false);
+
+  async function handleClick() {
+    setState({ kind: 'loading' });
+    try {
+      const res = await fetch(`/api/studies/${studyId}/share-token`, {
+        method: 'POST',
+        credentials: 'include',
+      });
+
+      if (res.status === 201) {
+        const body = (await res.json()) as { token: string; url: string; expires_at: string };
+        setState({ kind: 'done', url: body.url });
+        return;
+      }
+
+      if (res.status === 409) {
+        setState({ kind: 'conflict' });
+        return;
+      }
+
+      // Other error — show brief message.
+      const isJson = res.headers.get('content-type')?.includes('application/json');
+      const msg = isJson
+        ? ((await res.json()) as { error?: string }).error ?? 'failed to create share link'
+        : 'failed to create share link — please try again';
+      setState({ kind: 'error', message: msg });
+    } catch {
+      setState({ kind: 'error', message: 'network error — please try again' });
+    }
+  }
+
+  async function handleCopy(url: string) {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Silently ignore clipboard failures (e.g. insecure context).
+    }
+  }
+
+  if (state.kind === 'done') {
+    return (
+      <div className="mt-3">
+        <p className="text-xs text-gray-500 mb-1">
+          Share this link — it expires in 90 days. Anyone with the link can view the report.
+        </p>
+        <div className="flex items-center gap-2 flex-wrap">
+          <code className="block flex-1 rounded bg-gray-100 px-2 py-1 text-xs text-gray-800 break-all">
+            {state.url}
+          </code>
+          <button
+            onClick={() => { void handleCopy(state.url); }}
+            className="rounded-md border border-gray-300 px-3 py-1 text-xs font-medium text-gray-700 hover:bg-gray-50"
+          >
+            {copied ? 'Copied!' : 'Copy'}
+          </button>
+        </div>
+      </div>
+    );
+  }
+
+  if (state.kind === 'conflict') {
+    return (
+      <div className="mt-3">
+        <p className="text-xs text-gray-500">
+          A share link already exists — revoke it first (coming soon)
+        </p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="mt-3">
+      <button
+        onClick={() => { void handleClick(); }}
+        disabled={state.kind === 'loading'}
+        className="rounded-md border border-gray-300 px-4 py-2 text-sm font-medium text-gray-700 hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed"
+      >
+        {state.kind === 'loading' ? 'Generating link…' : 'Get private share link'}
+      </button>
+      {state.kind === 'error' && (
+        <p className="mt-1 text-xs text-red-600" data-testid="share-link-error">
+          {state.message}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/web/test/ShareLinkButton.test.tsx
+++ b/apps/web/test/ShareLinkButton.test.tsx
@@ -1,0 +1,124 @@
+// @vitest-environment jsdom
+//
+// ShareLinkButton.test.tsx — TDD acceptance tests for issue #487.
+//
+// Spec refs: §2 #20 (share-token minting), user story 3.
+//
+// Tests:
+//   1. Renders "Get private share link" button.
+//   2. On click, fires POST /api/studies/:id/share-token.
+//   3. On 201 response: hides the button and shows the URL in a <code> block
+//      plus a "Copy" button.
+//   4. On 409 response: shows "A share link already exists" message.
+//   5. On other error (500): shows a generic error message.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react';
+import { ShareLinkButton } from '../components/dashboard/ShareLinkButton';
+
+// Minimal clipboard API stub so navigator.clipboard.writeText doesn't throw.
+const clipboardWriteText = vi.fn().mockResolvedValue(undefined);
+
+beforeEach(() => {
+  Object.defineProperty(navigator, 'clipboard', {
+    value: { writeText: clipboardWriteText },
+    writable: true,
+    configurable: true,
+  });
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
+describe('ShareLinkButton (issue #487)', () => {
+  it('1. renders "Get private share link" button', () => {
+    render(<ShareLinkButton studyId={42} />);
+    expect(screen.getByRole('button', { name: /get private share link/i })).toBeTruthy();
+  });
+
+  it('2. fires POST /api/studies/:id/share-token on click', async () => {
+    const fetchMock = vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: 'abc12345678901234567890',
+          url: 'https://willbuy.dev/r/42?t=abc12345678901234567890',
+          expires_at: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
+        { status: 201, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    render(<ShareLinkButton studyId={42} />);
+    fireEvent.click(screen.getByRole('button', { name: /get private share link/i }));
+
+    expect(fetchMock).toHaveBeenCalledWith(
+      '/api/studies/42/share-token',
+      expect.objectContaining({ method: 'POST', credentials: 'include' }),
+    );
+  });
+
+  it('3. shows URL in <code> block + Copy button on 201', async () => {
+    const shareUrl = 'https://willbuy.dev/r/42?t=abc12345678901234567890';
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          token: 'abc12345678901234567890',
+          url: shareUrl,
+          expires_at: new Date(Date.now() + 90 * 24 * 60 * 60 * 1000).toISOString(),
+        }),
+        { status: 201, headers: { 'content-type': 'application/json' } },
+      ),
+    );
+
+    render(<ShareLinkButton studyId={42} />);
+    fireEvent.click(screen.getByRole('button', { name: /get private share link/i }));
+
+    // Button should be replaced with a URL code block.
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: /get private share link/i })).toBeNull();
+    });
+
+    // The URL should appear inside a <code> element.
+    const codeEl = document.querySelector('code');
+    expect(codeEl).toBeTruthy();
+    expect(codeEl!.textContent).toBe(shareUrl);
+
+    // A "Copy" button should be present.
+    expect(screen.getByRole('button', { name: /copy/i })).toBeTruthy();
+  });
+
+  it('4. shows "share link already exists" message on 409', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'conflict' }), {
+        status: 409,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    render(<ShareLinkButton studyId={42} />);
+    fireEvent.click(screen.getByRole('button', { name: /get private share link/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText(/a share link already exists/i)).toBeTruthy();
+    });
+  });
+
+  it('5. shows generic error message on 500', async () => {
+    vi.spyOn(globalThis, 'fetch').mockResolvedValue(
+      new Response(JSON.stringify({ error: 'internal server error' }), {
+        status: 500,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+
+    render(<ShareLinkButton studyId={42} />);
+    fireEvent.click(screen.getByRole('button', { name: /get private share link/i }));
+
+    await waitFor(() => {
+      // Some error message should be visible.
+      expect(screen.getByTestId('share-link-error')).toBeTruthy();
+    });
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `POST /api/studies/:id/share-token` (session-cookie auth) that mints a 22-char nanoid share token for a study's report, stores only the SHA-256 hash in `share_tokens`, and returns the raw token **once** with the full link URL and expiry.
- Adds `ShareLinkButton` client component rendered below `PublishButton` on ready studies — shows the URL in a `<code>` block with a clipboard Copy button on success, graceful messages on 409 (active token already exists) and other errors.
- Spec ref: **§2 #20**, user story 3 (CRO consultant mints a private revocable share link for a client).

### API contract

`POST /api/studies/:id/share-token`

| Status | Condition |
|--------|-----------|
| 201 | `{ token, url, expires_at }` — raw token returned once; URL is `https://willbuy.dev/r/<slug>?t=<token>` |
| 401 | No/invalid session |
| 404 | Study not owned by caller or has no report row yet |
| 409 | Non-revoked, non-expired token already exists for this report slug |

Token stored as SHA-256 hex in `share_tokens` (existing table from migration `0014_share_tokens.sql`). Default expiry 90 days. Link form `/r/<slug>?t=<token>` where slug = `study_id::text` (amendment A12).

### Test commands to verify

```bash
# API — 5 integration tests (real Docker Postgres)
cd apps/api && bun run test share

# Web — 5 unit tests (jsdom + @testing-library/react)
cd apps/web && bun run test ShareLink
```

### Out of scope (deferred)

- Token revocation UI (issue noted in component comment)
- API-key-authenticated variant of the mint endpoint

🤖 Generated with [Claude Code](https://claude.com/claude-code)