### PR TITLE
fix(aggregator): add founder_or_eng_lead to VALID_ROLES (fixes #497)

### DIFF
--- a/apps/aggregator/src/aggregator/main.py
+++ b/apps/aggregator/src/aggregator/main.py
@@ -63,6 +63,7 @@ VALID_ROLES: frozenset[str] = frozenset({
     "dba",
     "devops_sre",
     "founder",
+    "founder_or_eng_lead",
     "product_manager",
 })
 

--- a/apps/aggregator/tests/test_main_e2e.py
+++ b/apps/aggregator/tests/test_main_e2e.py
@@ -232,6 +232,7 @@ def _seed_with_unknown_role(conn: sqlite3.Connection, study_id: str) -> None:
 def test_unknown_role_archetype_coerced_to_ic_engineer(tmp_path: Path) -> None:
     """Backstory with role_archetype='unknown_role' must produce 'ic_engineer' in report."""
     # Unit-level sanity check on the coercion helper itself.
+    assert _coerce_role("founder_or_eng_lead") == "founder_or_eng_lead"
     assert _coerce_role("unknown_role") == "ic_engineer"
     assert _coerce_role(None) == "ic_engineer"
     assert _coerce_role("ic_engineer") == "ic_engineer"


### PR DESCRIPTION
## Summary

- `founder_or_eng_lead` was missing from `VALID_ROLES` in `apps/aggregator/src/aggregator/main.py`, causing `_coerce_role("founder_or_eng_lead")` to fall through to the `"ic_engineer"` default, mislabeling every founder/lead persona in the report JSON.
- The canonical `RoleArchetype` enum in `packages/shared/src/backstory.ts` is `z.enum(['founder_or_eng_lead', 'ic_engineer'])`, so backstories in the DB only ever carry those two values — making this the only role that was ever silently coerced.

## Fix

Single-line addition to the `VALID_ROLES` frozenset (spec §2 / amendment A1). No other files changed.

## Test output

```
platform darwin -- Python 3.13.11, pytest-9.0.3
collected 2 items

tests/test_main_e2e.py::test_unknown_role_archetype_coerced_to_ic_engineer PASSED
tests/test_main_e2e.py::test_study_run_e2e PASSED

2 passed in 0.78s
```

New assertions added to `test_unknown_role_archetype_coerced_to_ic_engineer`:
- `_coerce_role("founder_or_eng_lead") == "founder_or_eng_lead"` — was broken (returned `"ic_engineer"`), now passes
- `_coerce_role("unknown_role") == "ic_engineer"` — fallback unchanged

Closes #497