### PR TITLE
fix(infra): capture-worker service must run as root for CAP_NET_ADMIN (fixes #502)

### DIFF
--- a/infra/systemd/willbuy-capture-worker.service
+++ b/infra/systemd/willbuy-capture-worker.service
@@ -1,10 +1,19 @@
 [Unit]
-Description=willbuy capture worker — polls DB for studies in capturing state, runs Playwright, transitions to visiting
+# willbuy capture worker — polls DB for studies in `capturing` state, runs
+# Playwright inside a hardened netns container, transitions study to `visiting`.
+#
+# Must run as root: netns-bringup.sh calls iptables/nsenter which require
+# CAP_NET_ADMIN. Same pattern as willbuy-capture-broker.service.
+#
+# Depends on the capture broker (broker.sock must exist before workers connect).
+Description=willbuy capture worker (spec §5.13)
 After=network.target willbuy-api.service willbuy-capture-broker.service
 
 [Service]
 Type=simple
-User=willbuy
+User=root
+Group=willbuy
+UMask=0007
 WorkingDirectory=/srv/willbuy
 EnvironmentFile=/etc/willbuy/app.env
 ExecStart=/home/willbuy/.bun/bin/bun run apps/capture-worker/src/index.ts


### PR DESCRIPTION
## Problem

`willbuy-capture-worker.service` had `User=willbuy`. The capture worker calls `infra/capture/netns-bringup.sh` which runs `iptables`, `ip6tables`, and `nsenter -t <pid> -n` — all require `CAP_NET_ADMIN` / root. With `User=willbuy`, every capture fails with a permission error, leaving studies permanently stuck at `capturing`.

## Fix

Change to `User=root`, `Group=willbuy`, `UMask=0007` — matching `willbuy-capture-broker.service` exactly.

## Test

After deploy: create a study, watch `journalctl -u willbuy-capture-worker -f` — should show `netns-bringup.sh` succeeding and study transitioning `capturing → visiting` within 60 s.