### PR TITLE
fix(infra): add --network=host to aggregator docker run (DB connectivity)

### DIFF
--- a/infra/systemd/willbuy-aggregator-trigger.sh
+++ b/infra/systemd/willbuy-aggregator-trigger.sh
@@ -25,6 +25,7 @@ while true; do
   if [[ -n "$study_id" ]]; then
     echo "[aggregator-trigger] running aggregator for study $study_id"
     docker run --rm \
+      --network=host \
       --env DATABASE_URL="$DATABASE_URL" \
       willbuy-aggregator \
       --study-id "$study_id"


### PR DESCRIPTION
## Problem

The aggregator trigger script runs `docker run ... willbuy-aggregator --study-id <id>` without `--network=host`. On a single-server deployment, if `DATABASE_URL` uses `localhost` or a Unix socket, the container cannot reach the host's Postgres — it gets `connection refused`, the aggregator exits non-zero, and studies are permanently stuck at `aggregating`.

## Fix

Add `--network=host` so the container shares the host network stack. `localhost` inside the container then resolves to the host, matching the `DATABASE_URL` format used by the other services.

This is appropriate for the single-server MVP. Multi-host deployments would need a proper overlay network.

## Test

After deploy: create a study, watch it reach `aggregating`, confirm `docker run` in `journalctl -u willbuy-aggregator-trigger` exits 0 and study transitions to `ready`.