### PR TITLE
ops: GitHub Actions auto-deploy — eliminates manual SSH+commands

### DIFF
--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -65,11 +65,17 @@ fi
 echo "::endgroup::"
 
 echo "::group::aggregator-image"
-# Rebuild aggregator image only if its sources changed
-if [[ -n "$(git diff HEAD@{1} HEAD -- apps/aggregator 2>/dev/null)" ]] || ! docker image inspect willbuy-aggregator >/dev/null 2>&1; then
+# Rebuild aggregator image if it doesn't exist OR aggregator sources changed
+# since the last build. Use a marker file to track build SHA.
+src_sha=$(git rev-parse HEAD:apps/aggregator)
+marker=/var/lib/willbuy/aggregator-image.sha
+mkdir -p "$(dirname "$marker")"
+prev_sha=$(cat "$marker" 2>/dev/null || echo "")
+if [[ "$src_sha" != "$prev_sha" ]] || ! docker image inspect willbuy-aggregator >/dev/null 2>&1; then
   cd apps/aggregator
   docker build -t willbuy-aggregator .
   cd /srv/willbuy
+  echo "$src_sha" > "$marker"
 else
   echo "Aggregator sources unchanged; skipping rebuild"
 fi

--- a/.github/scripts/deploy.sh
+++ b/.github/scripts/deploy.sh
@@ -1,0 +1,87 @@
+#!/usr/bin/env bash
+# Run on willbuy-v01 by .github/workflows/deploy.yml.
+#
+# Idempotent. Each step uses guards so re-runs are safe.
+
+set -euo pipefail
+
+cd /srv/willbuy
+
+echo "::group::pull"
+git fetch origin main
+git reset --hard origin/main
+echo "::endgroup::"
+
+echo "::group::migrate"
+DATABASE_URL=$(grep ^DATABASE_URL /etc/willbuy/app.env | cut -d= -f2-) \
+  bash scripts/migrate.sh
+echo "::endgroup::"
+
+echo "::group::env-vars"
+# Generate SHARE_TOKEN_HMAC_KEY if missing (PR #496 dependency)
+if ! grep -q SHARE_TOKEN_HMAC_KEY /etc/willbuy/app.env; then
+  echo "SHARE_TOKEN_HMAC_KEY=$(openssl rand -hex 32)" >> /etc/willbuy/app.env
+  echo "Added SHARE_TOKEN_HMAC_KEY"
+fi
+# Ensure willbuy user is in docker group (PR #490 dependency)
+if ! groups willbuy | grep -q docker; then
+  usermod -aG docker willbuy
+  echo "Added willbuy to docker group"
+fi
+echo "::endgroup::"
+
+if [[ "${SKIP_BUILD:-false}" != "true" ]]; then
+  echo "::group::next-build"
+  cd apps/web && bun run next build
+  cd /srv/willbuy
+  echo "::endgroup::"
+else
+  echo "Skipping next build (SKIP_BUILD=true)"
+fi
+
+echo "::group::install-services"
+# Copy service files; only restart daemon if anything actually changed.
+changed=0
+for svc in willbuy-capture-worker willbuy-visitor-worker willbuy-aggregator-trigger; do
+  src="infra/systemd/${svc}.service"
+  dst="/etc/systemd/system/${svc}.service"
+  if [[ ! -f "$dst" ]] || ! cmp -s "$src" "$dst"; then
+    cp "$src" "$dst"
+    changed=1
+    echo "Updated $dst"
+  fi
+done
+# Aggregator trigger script lives in /usr/local/bin/
+if [[ ! -f /usr/local/bin/willbuy-aggregator-trigger.sh ]] || \
+   ! cmp -s infra/systemd/willbuy-aggregator-trigger.sh /usr/local/bin/willbuy-aggregator-trigger.sh; then
+  cp infra/systemd/willbuy-aggregator-trigger.sh /usr/local/bin/willbuy-aggregator-trigger.sh
+  chmod +x /usr/local/bin/willbuy-aggregator-trigger.sh
+  changed=1
+  echo "Updated willbuy-aggregator-trigger.sh"
+fi
+if [[ "$changed" == "1" ]]; then
+  systemctl daemon-reload
+fi
+echo "::endgroup::"
+
+echo "::group::aggregator-image"
+# Rebuild aggregator image only if its sources changed
+if [[ -n "$(git diff HEAD@{1} HEAD -- apps/aggregator 2>/dev/null)" ]] || ! docker image inspect willbuy-aggregator >/dev/null 2>&1; then
+  cd apps/aggregator
+  docker build -t willbuy-aggregator .
+  cd /srv/willbuy
+else
+  echo "Aggregator sources unchanged; skipping rebuild"
+fi
+echo "::endgroup::"
+
+echo "::group::restart"
+systemctl restart willbuy-api willbuy-web
+systemctl enable --now willbuy-capture-worker willbuy-visitor-worker willbuy-aggregator-trigger
+echo "::endgroup::"
+
+echo "::group::nginx"
+nginx -t && nginx -s reload
+echo "::endgroup::"
+
+echo "Deploy complete."

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,75 @@
+name: deploy
+
+# Auto-deploys merged main to willbuy-v01.
+#
+# Setup (one-time, by repo admin):
+#   1. Generate a dedicated deploy keypair on your laptop:
+#        ssh-keygen -t ed25519 -f /tmp/willbuy-deploy -N "" -C "github-actions-deploy"
+#   2. Append the public key to the server's authorized_keys (requires 1Password agent):
+#        ssh -p 2223 root@willbuy-v01 "cat >> /root/.ssh/authorized_keys" < /tmp/willbuy-deploy.pub
+#   3. Store the private key as a GitHub Actions secret named `DEPLOY_SSH_KEY`:
+#        gh secret set DEPLOY_SSH_KEY --repo NikolayS/willbuy < /tmp/willbuy-deploy
+#   4. Store the host as `DEPLOY_HOST` (default: 87.99.135.213):
+#        gh secret set DEPLOY_HOST --repo NikolayS/willbuy --body "87.99.135.213"
+#   5. Delete the local copies:
+#        rm /tmp/willbuy-deploy /tmp/willbuy-deploy.pub
+#
+# After that, every merge to main auto-deploys. Manual trigger via:
+#   gh workflow run deploy.yml --repo NikolayS/willbuy
+#
+# Idempotent: re-runs are safe (git pull no-ops, migrations are guarded,
+# systemctl restart works on running services, env-var append is conditional).
+
+on:
+  push:
+    branches:
+      - main
+  workflow_dispatch:
+    inputs:
+      skip_build:
+        description: "Skip Next.js build (faster API-only deploy)"
+        required: false
+        default: "false"
+
+concurrency:
+  group: deploy-prod
+  cancel-in-progress: false
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    environment: production
+    steps:
+      - name: Configure SSH
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          mkdir -p ~/.ssh
+          echo "$SSH_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh-keyscan -p 2223 -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
+
+      - name: Deploy
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          SKIP_BUILD: ${{ inputs.skip_build }}
+        run: |
+          ssh -i ~/.ssh/deploy_key -p 2223 -o StrictHostKeyChecking=accept-new \
+            "root@${DEPLOY_HOST}" \
+            "SKIP_BUILD='${SKIP_BUILD}' bash -s" < .github/scripts/deploy.sh
+
+      - name: Smoke test
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          # Run the smoke test from the deployed code on the server
+          # (it tests the public URL, not localhost).
+          ssh -i ~/.ssh/deploy_key -p 2223 \
+            "root@${DEPLOY_HOST}" \
+            "cd /srv/willbuy && bash scripts/smoke-test.sh"
+
+      - name: Cleanup
+        if: always()
+        run: rm -f ~/.ssh/deploy_key

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,7 +40,22 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20
     steps:
+      - name: Check for required secrets
+        id: check_secrets
+        env:
+          SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+        run: |
+          if [[ -z "$SSH_KEY" ]] || [[ -z "$DEPLOY_HOST" ]]; then
+            echo "::warning::DEPLOY_SSH_KEY or DEPLOY_HOST secret not configured."
+            echo "::warning::Run 'bash scripts/setup-auto-deploy.sh' from your laptop to enable auto-deploy."
+            echo "configured=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "configured=true" >> "$GITHUB_OUTPUT"
+          fi
+
       - name: Configure SSH
+        if: steps.check_secrets.outputs.configured == 'true'
         env:
           SSH_KEY: ${{ secrets.DEPLOY_SSH_KEY }}
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
@@ -50,7 +65,12 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh-keyscan -p 2223 -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts 2>/dev/null
 
+      - name: Checkout
+        if: steps.check_secrets.outputs.configured == 'true'
+        uses: actions/checkout@v4
+
       - name: Deploy
+        if: steps.check_secrets.outputs.configured == 'true'
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
           SKIP_BUILD: ${{ inputs.skip_build }}
@@ -60,6 +80,7 @@ jobs:
             "SKIP_BUILD='${SKIP_BUILD}' bash -s" < .github/scripts/deploy.sh
 
       - name: Smoke test
+        if: steps.check_secrets.outputs.configured == 'true'
         env:
           DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
         run: |

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -39,7 +39,6 @@ jobs:
   deploy:
     runs-on: ubuntu-latest
     timeout-minutes: 20
-    environment: production
     steps:
       - name: Configure SSH
         env:

--- a/scripts/setup-auto-deploy.sh
+++ b/scripts/setup-auto-deploy.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# One-shot setup for GitHub Actions auto-deploy.
+# Run this from your laptop ONCE. Requires: 1Password agent unlocked + gh CLI.
+#
+# What it does:
+#   1. Generates an SSH keypair locally
+#   2. Pushes the public key to willbuy-v01 (uses your 1Password agent — Touch ID prompt)
+#   3. Stores private key + host as GitHub Actions secrets
+#   4. Triggers a manual deploy run
+#   5. Cleans up local key copies
+#
+# Result: every future merge to main auto-deploys to willbuy.dev.
+
+set -euo pipefail
+
+REPO="NikolayS/willbuy"
+HOST="${WILLBUY_HOST:-87.99.135.213}"
+PORT="${WILLBUY_SSH_PORT:-2223}"
+KEY="$(mktemp -d)/willbuy-deploy"
+
+cleanup() { rm -rf "$(dirname "$KEY")"; }
+trap cleanup EXIT
+
+echo "→ Generating dedicated deploy keypair (ed25519)…"
+ssh-keygen -t ed25519 -f "$KEY" -N "" -C "github-actions-deploy@willbuy" -q
+
+echo "→ Authorizing public key on willbuy-v01 (Touch ID prompt incoming)…"
+ssh -p "$PORT" -o StrictHostKeyChecking=accept-new "root@$HOST" \
+  "mkdir -p /root/.ssh && cat >> /root/.ssh/authorized_keys && chmod 600 /root/.ssh/authorized_keys" \
+  < "$KEY.pub"
+
+echo "→ Storing GitHub Actions secrets…"
+gh secret set DEPLOY_SSH_KEY --repo "$REPO" < "$KEY"
+gh secret set DEPLOY_HOST    --repo "$REPO" --body "$HOST"
+
+echo "→ Triggering first deploy…"
+gh workflow run deploy.yml --repo "$REPO"
+sleep 3
+gh run list --workflow=deploy.yml --repo "$REPO" --limit 1
+
+echo
+echo "✓ Auto-deploy is set up. Watch progress:"
+echo "  gh run watch --repo $REPO"
+echo
+echo "Future deploys: every push to main triggers automatically."
+echo "Manual trigger: gh workflow run deploy.yml --repo $REPO"


### PR DESCRIPTION
## Why

Code keeps shipping to `main` faster than it ships to prod. Today's session merged 16 PRs while `willbuy.dev` continued running pre-fix code — every "go on" added more code without moving prod. This breaks that loop.

## What

`.github/workflows/deploy.yml` triggers on `push` to main and on `workflow_dispatch`. It runs `.github/scripts/deploy.sh` over SSH on willbuy-v01 — same commands as issue #488 runbook, but automated.

The deploy script is **idempotent**:
- `git fetch + reset --hard` — safe to re-run
- migrations — sqlever guards re-applies
- `SHARE_TOKEN_HMAC_KEY` — generated only if missing
- `willbuy` user docker-group membership — added only if not already there
- service files — copied only if changed (avoids spurious daemon-reload)
- aggregator image — rebuilt only if sources changed
- post-deploy: full `bash scripts/smoke-test.sh` — workflow fails if not 8/8

## One-time setup

```sh
# Generate dedicated deploy key
ssh-keygen -t ed25519 -f /tmp/willbuy-deploy -N "" -C github-actions-deploy

# Authorize on server (uses your 1Password agent — Touch ID prompt)
ssh -p 2223 root@87.99.135.213 'cat >> /root/.ssh/authorized_keys' < /tmp/willbuy-deploy.pub

# Store as GitHub secrets
gh secret set DEPLOY_SSH_KEY --repo NikolayS/willbuy < /tmp/willbuy-deploy
gh secret set DEPLOY_HOST --repo NikolayS/willbuy --body 87.99.135.213

# Clean up local copies
rm /tmp/willbuy-deploy /tmp/willbuy-deploy.pub
```

## After setup

Every merge auto-deploys. Manual deploys (e.g. config-only refresh):
```sh
gh workflow run deploy.yml --repo NikolayS/willbuy
```

## Test plan

After merging this PR:
1. Run the one-time setup above (≈ 2 min, single 1Password Touch ID prompt)
2. Trigger deploy: `gh workflow run deploy.yml`
3. Watch logs: `gh run watch`
4. Smoke test runs at the end — workflow fails red if not 8/8