### PR TITLE
ops: smoke-test — add 3 endpoint-existence tests (share-token, publish, reports)

### DIFF
--- a/scripts/smoke-test.sh
+++ b/scripts/smoke-test.sh
@@ -183,6 +183,64 @@ http_get_with_body() {
 }
 
 # ──────────────────────────────────────────────
+# Test 9 — Share-token mint endpoint registered (issue #487 / PR #496)
+# POST /api/studies/1/share-token (no session) → 401 (not 404)
+# Confirms the route is wired and protected.
+# ──────────────────────────────────────────────
+{
+  status=$(http_get \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "{}" \
+    "${BASE_URL}/api/studies/1/share-token")
+  if [[ "$status" == "401" ]]; then
+    pass "9. Share-token route (POST /api/studies/1/share-token → 401, route exists)"
+  elif [[ "$status" == "404" ]]; then
+    fail "9. Share-token route" "got 404 — route not registered (PR #496 not deployed)"
+  else
+    fail "9. Share-token route" "expected 401, got $status"
+  fi
+}
+
+# ──────────────────────────────────────────────
+# Test 10 — Publish endpoint registered (PR #479)
+# POST /api/studies/1/publish (no session) → 401 (not 404)
+# ──────────────────────────────────────────────
+{
+  status=$(http_get \
+    -X POST \
+    -H "Content-Type: application/json" \
+    -d "{}" \
+    "${BASE_URL}/api/studies/1/publish")
+  if [[ "$status" == "401" ]]; then
+    pass "10. Publish route (POST /api/studies/1/publish → 401, route exists)"
+  elif [[ "$status" == "404" ]]; then
+    fail "10. Publish route" "got 404 — route not registered"
+  else
+    fail "10. Publish route" "expected 401, got $status"
+  fi
+}
+
+# ──────────────────────────────────────────────
+# Test 11 — Reports endpoint returns 200 for public report
+# GET /reports/1 → 200 (study #1 is published) with report_json
+# ──────────────────────────────────────────────
+{
+  tmp=$(mktemp)
+  status=$(curl -s --max-time 10 -w "%{http_code}" -o "$tmp" "${BASE_URL}/reports/1" 2>/dev/null) || status="000"
+  body=$(cat "$tmp"); rm -f "$tmp"
+  if [[ "$status" == "200" ]] && echo "$body" | grep -q '"report_json"'; then
+    pass "11. Reports API (GET /reports/1 → 200 + report_json)"
+  elif [[ "$status" == "200" ]]; then
+    fail "11. Reports API" "got 200 but response missing report_json field"
+  elif [[ "$status" == "404" ]]; then
+    fail "11. Reports API" "got 404 — study #1 may not be published, or route missing"
+  else
+    fail "11. Reports API" "expected 200, got $status"
+  fi
+}
+
+# ──────────────────────────────────────────────
 # Summary
 # ──────────────────────────────────────────────
 echo ""


### PR DESCRIPTION
## Why

Auto-deploy now runs the smoke test as a gate. Strengthening it catches more silent regressions before they ship.

## What

Adds tests 9-11 to `scripts/smoke-test.sh`:

- **Test 9** — `POST /api/studies/1/share-token` → 401 confirms PR #496 (share-token minting) is wired
- **Test 10** — `POST /api/studies/1/publish` → 401 confirms publish route is wired
- **Test 11** — `GET /reports/1` → 200 with `report_json` confirms the public report path works end-to-end

Each test distinguishes "route returns 401 (correct)" from "route returns 404 (missing — fail loudly)".

## Live verification (against current prod)

| Test | Result |
|------|--------|
| 9. Share-token  | FAIL — 404 (PR #496 not yet deployed) ← expected, deploy fixes |
| 10. Publish     | PASS — 401 (already deployed in older code) |
| 11. Reports API | PASS — 200 with report_json (study #1 already public) |

After auto-deploy runs, expect **11/11 pass**.