### PR TITLE
ops: hourly scheduled smoke test with auto-issue creation

### DIFF
--- a/.github/workflows/scheduled-smoke.yml
+++ b/.github/workflows/scheduled-smoke.yml
@@ -1,0 +1,88 @@
+name: scheduled-smoke
+
+# Runs the public-facing smoke test against https://willbuy.dev every hour.
+# Opens a GitHub issue if it fails so prod regressions are visible without
+# waiting for a user to report them.
+#
+# The smoke test only hits public endpoints (no auth, no SSH). Safe to run
+# from a stock GitHub-hosted runner with no secrets.
+
+on:
+  schedule:
+    - cron: '17 * * * *'  # 17 minutes past every hour (avoid round-hour CI rush)
+  workflow_dispatch:
+
+concurrency:
+  group: scheduled-smoke
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Run smoke test
+        id: smoke
+        run: |
+          set +e
+          bash scripts/smoke-test.sh > /tmp/smoke.out 2>&1
+          echo "exit_code=$?" >> "$GITHUB_OUTPUT"
+          # Save for the next step (GitHub Actions trims long outputs in
+          # subsequent steps if you don't capture them)
+          {
+            echo "output<<EOF"
+            cat /tmp/smoke.out
+            echo "EOF"
+          } >> "$GITHUB_OUTPUT"
+          # Always show in step log too
+          cat /tmp/smoke.out
+
+      - name: Open issue on failure (deduped)
+        if: steps.smoke.outputs.exit_code != '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OUTPUT: ${{ steps.smoke.outputs.output }}
+        run: |
+          # Look for an existing open "prod-smoke-failing" issue. If found,
+          # comment on it with the latest run; otherwise open a new one.
+          existing=$(gh issue list --state open --label prod-smoke-failing --json number --jq '.[0].number' 2>/dev/null || echo "")
+          run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          if [[ -n "$existing" ]]; then
+            gh issue comment "$existing" --body "Still failing — run: $run_url
+
+\`\`\`
+$OUTPUT
+\`\`\`"
+          else
+            gh issue create \
+              --title "prod smoke test failing on willbuy.dev" \
+              --label prod-smoke-failing \
+              --body "Hourly scheduled smoke test failed against https://willbuy.dev.
+
+Run: $run_url
+
+\`\`\`
+$OUTPUT
+\`\`\`
+
+Likely causes:
+- Service down — check \`systemctl status willbuy-api willbuy-web\` on willbuy-v01
+- Recent deploy regressed something — check the most recent deploy.yml run
+- nginx misconfig — check \`nginx -t\` on the server
+- Cloudflare outage / DNS issue — check Cloudflare status
+
+Closes when the next hourly smoke run passes."
+          fi
+
+      - name: Close issue when smoke recovers
+        if: steps.smoke.outputs.exit_code == '0'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          existing=$(gh issue list --state open --label prod-smoke-failing --json number --jq '.[0].number' 2>/dev/null || echo "")
+          if [[ -n "$existing" ]]; then
+            run_url="https://github.com/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+            gh issue close "$existing" --comment "Smoke test recovered — run: $run_url"
+          fi


### PR DESCRIPTION
## Why

Today's session started with the user discovering prod was running pre-fix code via screenshot. A scheduled smoke test would have opened a GH issue the moment any test started failing — closing the visibility gap.

## What

`.github/workflows/scheduled-smoke.yml` runs every hour at :17 past the hour:

- Pulls the repo, runs `scripts/smoke-test.sh` against `https://willbuy.dev`
- On failure: opens (or comments on existing) GH issue labeled `prod-smoke-failing`
- On recovery: auto-closes the issue with a "recovered" comment

Stock GitHub runner, no SSH, no secrets beyond `GITHUB_TOKEN`. Only hits public endpoints.

## Self-deduping

The "Open issue on failure" step looks for an existing open `prod-smoke-failing` issue and either creates new or comments on existing. So a 6-hour outage produces 1 issue with 6 comments, not 6 issues.

## Run cadence

`17 * * * *` — every hour at :17 past. Avoids the round-hour CI rush; small enough delay to catch issues within an hour of occurrence; cheap (3-5 GH-Actions minutes/day at no cost on a public repo, fine on private too).

## Test plan

After merge:
- The next hourly run fires automatically
- Confirm with `gh run list --workflow=scheduled-smoke.yml`
- Manual fire: `gh workflow run scheduled-smoke.yml`
- It WILL fail today (smoke = 4/8) until the auto-deploy runs — first issue will land within an hour, then auto-close after deploy + smoke recovery