### PR TITLE
fix(web): force-dynamic rendering for /dashboard/* (nonce-mismatch hydration fix)

### DIFF
--- a/apps/web/app/dashboard/layout.tsx
+++ b/apps/web/app/dashboard/layout.tsx
@@ -16,6 +16,24 @@
 
 import type { ReactNode } from 'react';
 
+// Force dynamic rendering for the entire /dashboard/* tree.
+//
+// Without this, Next.js 14 statically pre-renders client-component pages
+// (e.g. /dashboard/studies/new — `'use client'`) and caches the HTML.
+// The cached HTML's inline-script `nonce=` attributes are baked at
+// build/cache time, but the per-request CSP `nonce-...` directive is
+// generated fresh in middleware.ts on every request. The result is a
+// nonce mismatch — the browser's CSP enforcer blocks all inline scripts,
+// React never hydrates, and forms submit as plain HTML GET (the user
+// reported on 2026-04-28: slider doesn't update, "Add second URL" link
+// doesn't work, "Start study" button does nothing).
+//
+// `force-dynamic` tells Next.js to render this segment per-request, so
+// the inline scripts are stamped with the live nonce that matches the
+// CSP header. Safe for client-component pages — they have no server
+// data fetching to revalidate.
+export const dynamic = 'force-dynamic';
+
 export default function DashboardLayout({ children }: { children: ReactNode }): JSX.Element {
   return (
     <div className="min-h-screen bg-gray-50">


### PR DESCRIPTION
User reported on /dashboard/studies/new: slider doesn't update displayed N, 'Add second URL' link doesn't work, 'Start study' button does nothing.

Real cause: Next.js was statically pre-rendering 'use client' pages and caching the HTML for a year. The cached HTML's inline-script `nonce` attributes baked in at cache time didn't match the per-request CSP `nonce-X` from `middleware.ts`. Browser CSP enforcement blocked all inline scripts → React never hydrated → form events never bound → form submitted as plain HTML GET.

Adding `export const dynamic = 'force-dynamic'` to the dashboard layout cascades dynamic rendering to all /dashboard/* routes so the inline-script nonces match the CSP header on every request.

Verified live:
- Before: `cache-control: s-maxage=31536000`, `hasReactProps: false`, `self.__next_f: undefined`
- After: `cache-control: private, no-cache, no-store`, `hasReactProps: true`, `self.__next_f: array of 6`, POST /api/studies fires on Start study click.