### PR TITLE
feat(api): drop verified-domain gate on study creation (amendment A14)

### DIFF
--- a/apps/api/src/routes/studies.ts
+++ b/apps/api/src/routes/studies.ts
@@ -184,14 +184,18 @@ export async function registerStudiesRoutes(
       }
       const body = bodyResult.data;
 
-      // §2 #1: Verify each URL's eTLD+1 is in account.verified_domains.
+      // Validate URLs parse to an eTLD+1. Domain ownership verification was
+      // dropped in amendment A14 (2026-04-28): the v0.1 verified-domain gate
+      // was an abuse-prevention guardrail per spec §2 #1, but in practice it
+      // blocked the paying owner from running studies on competitor / vendor
+      // pages they're evaluating — which is the entire point of a synthetic
+      // visitor panel. Re-introduce a check (e.g. rate limit per target eTLD,
+      // or an "acknowledge_third_party_submission" checkbox) when abuse signals
+      // appear; until then trust the paying account.
       for (const url of body.urls) {
         const etld = getEtldPlusOne(url);
         if (!etld) {
           return reply.code(422).send({ error: `invalid URL: ${url}` });
-        }
-        if (!account.verified_domains.includes(etld)) {
-          return reply.code(422).send({ error: `unverified domain: ${etld}` });
         }
       }
 
@@ -498,12 +502,11 @@ export async function registerStudiesRoutes(
       }
       const body = bodyResult.data;
 
+      // Verified-domain gate dropped in amendment A14 (2026-04-28); see
+      // sibling /studies handler for the rationale.
       for (const url of body.urls) {
         const etld = getEtldPlusOne(url);
         if (!etld) return reply.code(422).send({ error: `invalid URL: ${url}` });
-        if (!account.verified_domains.includes(etld)) {
-          return reply.code(422).send({ error: `unverified domain: ${etld}` });
-        }
       }
 
       const n = body.n_visits;

--- a/apps/api/test/studies.api.test.ts
+++ b/apps/api/test/studies.api.test.ts
@@ -184,8 +184,12 @@ describeIfDocker('studies + reports API (issue #30, real DB)', () => {
     expect(res.statusCode).toBe(422);
   });
 
-  // --- Acceptance #2: unverified domain → 422 with clear message ---
-  it('422 with message when URL domain is not in verified_domains', async () => {
+  // --- Amendment A14 (2026-04-28) — verified-domain gate dropped ---
+  // The previous behaviour ('unverified domain' → 422) was an abuse-prevention
+  // guardrail that blocked paying owners from running studies on third-party
+  // pages they wanted to evaluate. Any URL that parses to an eTLD+1 is now
+  // accepted; unparseable URLs still 422.
+  it('201 even when URL domain is not in verified_domains (A14)', async () => {
     const res = await app.inject({
       method: 'POST',
       url: '/studies',
@@ -196,10 +200,10 @@ describeIfDocker('studies + reports API (issue #30, real DB)', () => {
         n_visits: 5,
       },
     });
-    expect(res.statusCode).toBe(422);
-    const body = res.json() as { error: string };
-    expect(body.error).toMatch(/unverified domain/i);
-    expect(body.error).toContain('notverified.io');
+    expect(res.statusCode).toBe(201);
+    const body = res.json() as { study_id: number; status: string };
+    expect(body.study_id).toBeGreaterThan(0);
+    expect(body.status).toBe('capturing');
   });
 
   // --- Acceptance #1: happy path → 201 with study_id ---


### PR DESCRIPTION
User can't run studies on vendor / competitor pages they want to evaluate (`supabase.com`, etc.) because the spec §2 #1 verified-domain gate blocks them.

That gate was an abuse-prevention guardrail for v0.1, but in practice it kills the entire point of the product for the paying owner. URL parsing still validates eTLD+1, daily LLM spend cap remains as the cost gate, so junk URLs and runaway spend are still bounded.

Re-introduce a check once abuse signals appear (rate limit per target eTLD, an `acknowledge_third_party_submission` checkbox per spec §2 #31, or a manual review queue).